### PR TITLE
Add PDF preview for ATS uploads

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -198,6 +198,7 @@ function ScoreCircle({
 export default function AtsScorePage() {
   const queryClient = useQueryClient();
   const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState("");
   const [resumeUrl, setResumeUrl] = useState("");
   const [jobTitle, setJobTitle] = useState("");
   const [jobDescription, setJobDescription] = useState("");
@@ -275,6 +276,16 @@ export default function AtsScorePage() {
     }
     return () => timers.forEach(clearTimeout);
   }, [loading]);
+
+  useEffect(() => {
+    if (!file) {
+      setPreviewUrl("");
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selected = e.target.files?.[0];
@@ -431,13 +442,24 @@ export default function AtsScorePage() {
                         )}
                       </div>
                       {file ? (
-                        <div className="text-center">
+                        <div className="text-center space-y-3">
                           <p className="text-sm font-bold text-stone-900 dark:text-stone-50 max-w-60 truncate mx-auto">
                             {file.name}
                           </p>
                           <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mt-1">
                             {(file.size / 1024).toFixed(1)} kb · pdf
                           </p>
+                          {previewUrl && (
+                            <div className="w-full max-w-xs mx-auto border border-stone-200 dark:border-white/10 rounded-md overflow-hidden bg-white dark:bg-stone-950">
+                              <div className="aspect-[3/4] w-full">
+                                <iframe
+                                  src={`${previewUrl}#toolbar=0&navpanes=0&scrollbar=0`}
+                                  title="Resume preview"
+                                  className="w-full h-full"
+                                />
+                              </div>
+                            </div>
+                          )}
                         </div>
                       ) : (
                         <div className="text-center">


### PR DESCRIPTION
## Summary
- Add a first-page PDF preview in the ATS upload card so users can confirm the correct resume before analysis.

## Changes
- Generate an object URL for the selected PDF
- Render a compact preview thumbnail in the upload card
- Revoke the object URL on cleanup to prevent leaks

## How to test
1) cd client && npm run dev
2) Go to ATS Score page
3) Upload a PDF and confirm the preview appears 
4) Remove the file and verify the preview disappears

## Screenshots 
- Before: 
- 
<img width="1891" height="953" alt="image" src="https://github.com/user-attachments/assets/e643ca84-1e30-4879-bb3a-fa93684641ed" />




- After: 
<img width="1904" height="885" alt="image copy" src="https://github.com/user-attachments/assets/094a8a25-66ba-4c2a-8a2e-4e8f51bac04a" />

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF preview functionality. Users can now preview selected PDF files in an embedded viewer before uploading, with file details (filename and size) displayed alongside the preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->