### PR TITLE
Fix: Add dynamic alt text to badge name (#23)

### DIFF
--- a/client/src/module/admin/AdminBadgesPage.tsx
+++ b/client/src/module/admin/AdminBadgesPage.tsx
@@ -322,7 +322,7 @@ export default function AdminBadgesPage() {
                         {badge.iconUrl ? (
                           <img
                             src={badge.iconUrl}
-                            alt=""
+                            alt={badge.name}
                             className="w-8 h-8 rounded-lg object-cover"
                           />
                         ) : (
@@ -342,9 +342,8 @@ export default function AdminBadgesPage() {
                     </td>
                     <td className="px-4 py-3">
                       <span
-                        className={`text-xs font-medium px-2 py-1 rounded-md ${
-                          CATEGORY_COLORS[badge.category]
-                        }`}
+                        className={`text-xs font-medium px-2 py-1 rounded-md ${CATEGORY_COLORS[badge.category]
+                          }`}
                       >
                         {badge.category}
                       </span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "InternHack",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Fixed the empty alt tag on the admin badge image by passing in the dynamic badge.name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility for badge images with descriptive alt text

* **Style**
  * Code formatting improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->