### PR TITLE
feat: add rate limiting to AI roadmap generation endpoint

### DIFF
--- a/server/src/middleware/rate-limit.middleware.ts
+++ b/server/src/middleware/rate-limit.middleware.ts
@@ -1,0 +1,21 @@
+import rateLimit from "express-rate-limit";
+
+// Rate limiting for AI roadmap generation to prevent abuse and API quota drains
+export const aiRoadmapLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour window
+  max: 5, // Limit each IP or User to 5 requests per window
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => {
+    // Prefer user ID if authenticated, fallback to IP
+    const defaultIp = req.ip || "unknown_ip";
+    const user = (req as any).user;
+    if (user && user.id) {
+      return `user_${user.id}`;
+    }
+    return defaultIp;
+  },
+  message: { 
+    message: "Too many AI roadmap generation requests. Please try again later."
+  },
+});

--- a/server/src/module/roadmap/roadmap.routes.ts
+++ b/server/src/module/roadmap/roadmap.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
+import { aiRoadmapLimiter } from "../../middleware/rate-limit.middleware.js";
 import {
   downloadPdf,
   enroll,
@@ -16,7 +17,7 @@ import {
 export const roadmapRouter = Router();
 
 // ── AI generation (registered BEFORE /:slug to avoid conflicts) ──────────
-roadmapRouter.post("/ai/generate", authMiddleware, postAiGenerate);
+roadmapRouter.post("/ai/generate", authMiddleware, aiRoadmapLimiter, postAiGenerate);
 
 // ── Authenticated "me" routes (also BEFORE /:slug) ────────────────────────
 roadmapRouter.get("/me/enrollments", authMiddleware, getMyEnrollments);


### PR DESCRIPTION
Fixes #92

This PR introduces a dedicated rate limiter for the `/api/roadmaps/ai/generate` endpoint to prevent abuse, avoid expensive AI quota drains, and ensure fair use for all users.

**Key Changes:**
- Created a new `rate-limit.middleware.ts` using `express-rate-limit` for dedicated route-level limits.
- Configured a limit of 5 requests per hour per authenticated user (or IP address as a fallback).
- Applied the `aiRoadmapLimiter` middleware directly to the `POST /ai/generate` route in `roadmap.routes.ts`.
- Requests exceeding the limit will now be blocked with a `429 Too Many Requests` status and a clear "Too many AI roadmap generation requests" error message.