### PR TITLE
fix: add client-side file size and type validation for ATS resume upload #54

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -216,6 +216,7 @@ export default function AtsScorePage() {
 
   const atsUsage = usageData?.usage.find((u) => u.action === "ATS_SCORE");
   const limitReached = atsUsage ? atsUsage.used >= atsUsage.limit : false;
+  const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
 
   const [currentStep, setCurrentStep] = useState(-1);
   const [analysisComplete, setAnalysisComplete] = useState(false);
@@ -287,9 +288,25 @@ export default function AtsScorePage() {
     return () => URL.revokeObjectURL(url);
   }, [file]);
 
+  const validateFile = (file: File): string | null => {
+    if (file.size > MAX_SIZE) {
+      return `File is ${(file.size / 1024 / 1024).toFixed(1)} MB. Max 10 MB.`;
+    }
+    if (file.type !== "application/pdf") {
+      return "Only PDF files are allowed.";
+    }
+    return null;
+  };
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selected = e.target.files?.[0];
     if (selected) {
+      const error = validateFile(selected);
+      if (error) {
+        toast.error(error);
+        e.target.value = "";
+        return;
+      }
       setFile(selected);
       setResumeUrl("");
       setResult(null);
@@ -304,10 +321,9 @@ export default function AtsScorePage() {
     setIsDragging(false);
     const dropped = e.dataTransfer.files[0];
     if (!dropped) return;
-    if (dropped.type !== "application/pdf") {
-      const msg = "Only PDF files are supported. Please drop a .pdf resume.";
-      setError(msg);
-      toast.error(msg);
+    const error = validateFile(dropped);
+    if (error) {
+      toast.error(error);
       return;
     }
     setFile(dropped);


### PR DESCRIPTION
## Summary
This PR adds client-side file validation for the resume upload feature on the ATS Score page. While the UI stated a "Max 10 MB" limit, there was no logic to enforce this or restrict file types before attempting an upload. This change improves UX by providing instant feedback and prevents unnecessary bandwidth usage for invalid uploads.

## Changes
- **Added `validateFile` utility:** A shared helper function that checks if a file exceeds 10MB and verifies the MIME type is `application/pdf`.
- **Integrated validation in `handleFileChange`:** Prevents state updates and triggers an error toast if the selected file via the file picker is invalid.
- **Integrated validation in `handleDrop`:** Validates files dropped into the drag-and-drop zone immediately.
- **Input Reset:** Added logic to clear the file input value on error, allowing users to re-select a corrected version of the same file.

## How to test
1. Navigate to the **Resume/ATS Score** page in the student dashboard.
2. **Test Size Limit:** Attempt to upload or drag-and-drop a PDF file larger than 10MB. 
   - *Expected:* An error toast appears stating the actual size and the limit. No upload starts.
3. **Test File Type:** Attempt to upload a `.png`, `.jpg`, or `.docx` file.
   - *Expected:* An error toast appears saying "Only PDF files are allowed."
4. **Test Valid Upload:** Upload a PDF file under 10MB.
   - *Expected:* The file is accepted and the process continues as normal.

## Screenshots (if UI changes)

| Before (No validation) | After (Instant validation) |
| :--- | :--- |
|<img width="540" height="202" alt="image" src="https://github.com/user-attachments/assets/b8fc5feb-327f-41e8-b9c8-3d616c1a5836" /> | <img width="278" height="83" alt="image" src="https://github.com/user-attachments/assets/9395cd4a-e40f-4ea9-ace8-951484bea3a1" />|
|<img width="532" height="200" alt="image" src="https://github.com/user-attachments/assets/1a391b57-3d1c-4b4f-b2a0-f646f29ded19" />|<img width="281" height="82" alt="image" src="https://github.com/user-attachments/assets/2b42dae7-a6ad-4390-9b7b-53938ee8a80c" />|

**Closes #54**

#GSSoC2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced resume file validation with a 10 MB size limit
  * Improved error notifications for invalid file uploads
  * Refined drag-and-drop functionality with consistent validation across file selection methods

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/119)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->