### PR TITLE
fix: use AI_ROADMAP_GENERATION log type instead of COVER_LETTER in roadmap section 

### DIFF
--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -7,14 +7,14 @@ datasource db {
 }
 
 model user {
-  id                    Int                       @id @default(autoincrement())
+  id                    Int                         @id @default(autoincrement())
   name                  String
-  email                 String                    @unique
+  email                 String                      @unique
   password              String
-  role                  UserRole                  @default(STUDENT)
-  isActive              Boolean                   @default(true)
-  isProfilePublic       Boolean                   @default(false)
-  isVerified            Boolean                   @default(false)
+  role                  UserRole                    @default(STUDENT)
+  isActive              Boolean                     @default(true)
+  isProfilePublic       Boolean                     @default(false)
+  isVerified            Boolean                     @default(false)
   verificationOtp       String?
   otpExpiresAt          DateTime?
   resetPasswordOtp      String?
@@ -22,66 +22,66 @@ model user {
   contactNo             String?
   profilePic            String?
   coverImage            String?
-  resumes               String[]                  @default([])
+  resumes               String[]                    @default([])
   company               String?
   designation           String?
-  createdAt             DateTime                  @default(now())
-  updatedAt             DateTime                  @updatedAt
-  subscriptionPlan      SubscriptionPlan          @default(FREE)
-  subscriptionStatus    SubscriptionStatus        @default(EXPIRED)
+  createdAt             DateTime                    @default(now())
+  updatedAt             DateTime                    @updatedAt
+  subscriptionPlan      SubscriptionPlan            @default(FREE)
+  subscriptionStatus    SubscriptionStatus          @default(EXPIRED)
   subscriptionStartDate DateTime?
   subscriptionEndDate   DateTime?
   bio                   String?
   college               String?
   graduationYear        Int?
-  skills                String[]                  @default([])
+  skills                String[]                    @default([])
   linkedinUrl           String?
   githubUrl             String?
   portfolioUrl          String?
   location              String?
   jobStatus             String?
-  projects              Json                      @default("[]")
-  achievements          Json                      @default("[]")
+  projects              Json                        @default("[]")
+  achievements          Json                        @default("[]")
   leetcodeUrl           String?
-  tokenVersion          Int                       @default(0)
-  adminActivityLogs     adminActivityLog[]        @relation("AdminActivityLogs")
-  adminProfile          adminProfile?             @relation("AdminProfile")
-  applications          application[]             @relation("StudentApplications")
-  atsScores             atsScore[]                @relation("StudentAtsScores")
-  blogPosts             blogPost[]                @relation("BlogAuthor")
-  createdCompanies      company[]                 @relation("UserCreatedCompanies")
-  addedContacts         companyContact[]          @relation("UserAddedContacts")
-  reviewedContributions companyContribution[]     @relation("AdminReviewedContributions")
-  contributions         companyContribution[]     @relation("UserContributions")
-  companyReviews        companyReview[]           @relation("UserReviews")
-  dsaBookmarks          dsaBookmark[]             @relation("StudentDsaBookmarks")
-  emailCampaigns        emailCampaign[]           @relation("UserEmailCampaigns")
-  employeeProfile       employee?                 @relation("EmployeeUser")
-  postedJobs            job[]                     @relation("RecruiterJobs")
-  payments              payment[]                 @relation("UserPayments")
-  createdSkillTests     skillTest[]               @relation("SkillTestCreator")
-  skillTestAttempts     skillTestAttempt[]        @relation("StudentSkillTestAttempts")
-  aptitudeProgress      studentAptitudeProgress[] @relation("StudentAptitudeProgress")
-  studentBadges         studentBadge[]            @relation("StudentBadges")
-  dsaProgress           studentDsaProgress[]      @relation("StudentDsaProgress")
-  dsaSubmissions        dsaSubmission[]           @relation("StudentDsaSubmissions")
-  sqlProgress           studentSqlProgress[]      @relation("StudentSqlProgress")
-  savedCandidates       savedCandidate[]          @relation("RecruiterSavedCandidates")
-  savedByRecruiters     savedCandidate[]          @relation("StudentSavedByRecruiters")
-  usageLogs             usageLog[]                @relation("UserUsageLogs")
-  customRoles           userCustomRole[]          @relation("UserCustomRoles")
-  verifiedSkills        verifiedSkill[]           @relation("StudentVerifiedSkills")
-  jobPreference         userJobPreference?        @relation("UserJobPreferences")
-  jobMatches            jobMatch[]                @relation("UserJobMatches")
-  agentConversations    jobAgentConversation[]    @relation("UserAgentConversations")
-  milestoneEmails       milestoneEmail[]          @relation("StudentMilestoneEmails")
-  externalApplications  externalJobApplication[] @relation("StudentExternalApplications")
-  repoRequests          repoRequest[]            @relation("UserRepoRequests")
-  interviewExperiences  interviewExperience[]    @relation("UserInterviewExperiences")
+  tokenVersion          Int                         @default(0)
+  adminActivityLogs     adminActivityLog[]          @relation("AdminActivityLogs")
+  adminProfile          adminProfile?               @relation("AdminProfile")
+  applications          application[]               @relation("StudentApplications")
+  atsScores             atsScore[]                  @relation("StudentAtsScores")
+  blogPosts             blogPost[]                  @relation("BlogAuthor")
+  createdCompanies      company[]                   @relation("UserCreatedCompanies")
+  addedContacts         companyContact[]            @relation("UserAddedContacts")
+  reviewedContributions companyContribution[]       @relation("AdminReviewedContributions")
+  contributions         companyContribution[]       @relation("UserContributions")
+  companyReviews        companyReview[]             @relation("UserReviews")
+  dsaBookmarks          dsaBookmark[]               @relation("StudentDsaBookmarks")
+  emailCampaigns        emailCampaign[]             @relation("UserEmailCampaigns")
+  employeeProfile       employee?                   @relation("EmployeeUser")
+  postedJobs            job[]                       @relation("RecruiterJobs")
+  payments              payment[]                   @relation("UserPayments")
+  createdSkillTests     skillTest[]                 @relation("SkillTestCreator")
+  skillTestAttempts     skillTestAttempt[]          @relation("StudentSkillTestAttempts")
+  aptitudeProgress      studentAptitudeProgress[]   @relation("StudentAptitudeProgress")
+  studentBadges         studentBadge[]              @relation("StudentBadges")
+  dsaProgress           studentDsaProgress[]        @relation("StudentDsaProgress")
+  dsaSubmissions        dsaSubmission[]             @relation("StudentDsaSubmissions")
+  sqlProgress           studentSqlProgress[]        @relation("StudentSqlProgress")
+  savedCandidates       savedCandidate[]            @relation("RecruiterSavedCandidates")
+  savedByRecruiters     savedCandidate[]            @relation("StudentSavedByRecruiters")
+  usageLogs             usageLog[]                  @relation("UserUsageLogs")
+  customRoles           userCustomRole[]            @relation("UserCustomRoles")
+  verifiedSkills        verifiedSkill[]             @relation("StudentVerifiedSkills")
+  jobPreference         userJobPreference?          @relation("UserJobPreferences")
+  jobMatches            jobMatch[]                  @relation("UserJobMatches")
+  agentConversations    jobAgentConversation[]      @relation("UserAgentConversations")
+  milestoneEmails       milestoneEmail[]            @relation("StudentMilestoneEmails")
+  externalApplications  externalJobApplication[]    @relation("StudentExternalApplications")
+  repoRequests          repoRequest[]               @relation("UserRepoRequests")
+  interviewExperiences  interviewExperience[]       @relation("UserInterviewExperiences")
   interviewUpvotes      interviewExperienceUpvote[] @relation("UserInterviewUpvotes")
-  roadmapEnrollments    roadmapEnrollment[]      @relation("UserRoadmapEnrollments")
-  scheduledEmails       scheduledEmail[]         @relation("UserScheduledEmails")
-  privateRoadmaps       roadmap[]                @relation("UserPrivateRoadmaps")
+  roadmapEnrollments    roadmapEnrollment[]         @relation("UserRoadmapEnrollments")
+  scheduledEmails       scheduledEmail[]            @relation("UserScheduledEmails")
+  privateRoadmaps       roadmap[]                   @relation("UserPrivateRoadmaps")
 
   @@index([role])
   @@index([role, isActive])
@@ -295,45 +295,45 @@ model fundingSignal {
 }
 
 model fundingSignalLog {
-  id              Int      @id @default(autoincrement())
-  source          String
-  status          String
-  signalsFound    Int      @default(0)
-  signalsCreated  Int      @default(0)
-  signalsUpdated  Int      @default(0)
-  error           String?
-  duration        Int
-  createdAt       DateTime @default(now())
+  id             Int      @id @default(autoincrement())
+  source         String
+  status         String
+  signalsFound   Int      @default(0)
+  signalsCreated Int      @default(0)
+  signalsUpdated Int      @default(0)
+  error          String?
+  duration       Int
+  createdAt      DateTime @default(now())
 }
 
 model company {
-  id              Int              @id @default(autoincrement())
-  name            String
-  slug            String           @unique
-  logo            String?
-  description     String
-  mission         String?
-  industry        String
-  size            CompanySize
-  city            String
-  state           String?
-  address         String?
-  officeLocations Json             @default("[]")
-  website         String?
-  socialLinks     Json             @default("{}")
-  technologies    String[]         @default([])
-  hiringStatus    Boolean          @default(false)
-  foundedYear     Int?
-  photos          String[]         @default([])
-  avgRating       Float            @default(0)
-  reviewCount     Int              @default(0)
-  isApproved      Boolean          @default(false)
-  createdById     Int
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
-  createdBy       user             @relation("UserCreatedCompanies", fields: [createdById], references: [id])
-  contacts        companyContact[]
-  reviews         companyReview[]
+  id                   Int                   @id @default(autoincrement())
+  name                 String
+  slug                 String                @unique
+  logo                 String?
+  description          String
+  mission              String?
+  industry             String
+  size                 CompanySize
+  city                 String
+  state                String?
+  address              String?
+  officeLocations      Json                  @default("[]")
+  website              String?
+  socialLinks          Json                  @default("{}")
+  technologies         String[]              @default([])
+  hiringStatus         Boolean               @default(false)
+  foundedYear          Int?
+  photos               String[]              @default([])
+  avgRating            Float                 @default(0)
+  reviewCount          Int                   @default(0)
+  isApproved           Boolean               @default(false)
+  createdById          Int
+  createdAt            DateTime              @default(now())
+  updatedAt            DateTime              @updatedAt
+  createdBy            user                  @relation("UserCreatedCompanies", fields: [createdById], references: [id])
+  contacts             companyContact[]
+  reviews              companyReview[]
   interviewExperiences interviewExperience[]
 
   @@index([city])
@@ -456,23 +456,23 @@ model opensourceRepo {
 }
 
 model repoRequest {
-  id          Int                @id @default(autoincrement())
+  id          Int               @id @default(autoincrement())
   name        String
   owner       String
   description String
   language    String
   url         String
-  domain      RepoDomain         @default(WEB)
-  difficulty  RepoDifficulty     @default(BEGINNER)
-  techStack   String[]           @default([])
-  tags        String[]           @default([])
+  domain      RepoDomain        @default(WEB)
+  difficulty  RepoDifficulty    @default(BEGINNER)
+  techStack   String[]          @default([])
+  tags        String[]          @default([])
   reason      String
-  status      RepoRequestStatus  @default(PENDING)
+  status      RepoRequestStatus @default(PENDING)
   adminNote   String?
   userId      Int
-  user        user               @relation("UserRepoRequests", fields: [userId], references: [id], onDelete: Cascade)
-  createdAt   DateTime           @default(now())
-  updatedAt   DateTime           @updatedAt
+  user        user              @relation("UserRepoRequests", fields: [userId], references: [id], onDelete: Cascade)
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @updatedAt
 
   @@index([status])
   @@index([userId])
@@ -946,20 +946,20 @@ model aiRequestLog {
 }
 
 model adminJob {
-  id           Int                       @id @default(autoincrement())
+  id           Int                      @id @default(autoincrement())
   company      String?
   role         String?
   description  String?
   salary       String?
   location     String?
   applyLink    String?
-  tags         String[]                  @default([])
+  tags         String[]                 @default([])
   expiresAt    DateTime
-  isActive     Boolean                   @default(true)
-  createdAt    DateTime                  @default(now())
-  updatedAt    DateTime                  @updatedAt
-  slug         String?                   @unique
-  applications externalJobApplication[]  @relation("AdminJobApplications")
+  isActive     Boolean                  @default(true)
+  createdAt    DateTime                 @default(now())
+  updatedAt    DateTime                 @updatedAt
+  slug         String?                  @unique
+  applications externalJobApplication[] @relation("AdminJobApplications")
 
   @@index([isActive, expiresAt])
 }
@@ -1129,6 +1129,7 @@ enum AIServiceType {
   RESUME_GEN
   LATEX_CHAT
   EMAIL_CHAT
+  AI_ROADMAP_GENERATION
 }
 
 enum ScrapedJobStatus {
@@ -1276,9 +1277,9 @@ model interviewExperience {
   createdAt       DateTime            @default(now())
   updatedAt       DateTime            @updatedAt
 
-  company         company?            @relation(fields: [companyId], references: [id], onDelete: SetNull)
-  user            user                @relation("UserInterviewExperiences", fields: [userId], references: [id], onDelete: Cascade)
-  upvoteRecords   interviewExperienceUpvote[]
+  company       company?                    @relation(fields: [companyId], references: [id], onDelete: SetNull)
+  user          user                        @relation("UserInterviewExperiences", fields: [userId], references: [id], onDelete: Cascade)
+  upvoteRecords interviewExperienceUpvote[]
 
   @@index([companyId, status])
   @@index([status])
@@ -1293,8 +1294,8 @@ model interviewExperienceUpvote {
   userId       Int
   createdAt    DateTime @default(now())
 
-  experience   interviewExperience @relation(fields: [experienceId], references: [id], onDelete: Cascade)
-  user         user                @relation("UserInterviewUpvotes", fields: [userId], references: [id], onDelete: Cascade)
+  experience interviewExperience @relation(fields: [experienceId], references: [id], onDelete: Cascade)
+  user       user                @relation("UserInterviewUpvotes", fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([experienceId, userId])
   @@index([experienceId])

--- a/server/src/module/admin/admin.validation.ts
+++ b/server/src/module/admin/admin.validation.ts
@@ -341,7 +341,7 @@ export const broadcastEmailSchema = z.object({
 // ==================== AI PROVIDER MANAGEMENT ====================
 
 export const switchAIProviderSchema = z.object({
-  service: z.enum(["ATS_SCORE", "COVER_LETTER", "RESUME_GEN", "LATEX_CHAT"]),
+  service: z.enum(["ATS_SCORE", "COVER_LETTER", "RESUME_GEN", "LATEX_CHAT","AI_ROADMAP_GENERATION"]),
   provider: z.enum(["GEMINI", "GROQ", "OPENROUTER", "CODESTRAL", "CLAUDE"]),
   modelName: z.string().min(1, "Model name is required"),
 });

--- a/server/src/module/roadmap/roadmap.ai.service.ts
+++ b/server/src/module/roadmap/roadmap.ai.service.ts
@@ -63,9 +63,9 @@ export async function generateAiRoadmap(
   let parsed: unknown;
   try {
     parsed = parseJsonResponse(response.text);
-    logAIRequest("COVER_LETTER", response, true, undefined, userId);
+    logAIRequest("AI_ROADMAP_GENERATION", response, true, undefined, userId);
   } catch (err) {
-    logAIRequest("COVER_LETTER", response, false, (err as Error).message, userId);
+    logAIRequest("AI_ROADMAP_GENERATION", response, false, (err as Error).message, userId);
     throw new Error("AI returned a response we could not parse. Please try again.");
   }
 


### PR DESCRIPTION
## fix: use `AI_ROADMAP_GENERATION` log type instead of `COVER_LETTER` in roadmap AI service

### Problem
`logAIRequest` in `roadmap.ai.service.ts` uses the `COVER_LETTER` type for roadmap generation requests. This is misleading and pollutes analytics — roadmap generation logs appear as cover letter operations, making debugging, auditing, and usage tracking unreliable.

### Solution
- **Added `AI_ROADMAP_GENERATION`** to the `AIServiceType` Prisma enum to provide a dedicated, descriptive log type for roadmap AI calls.
- **Updated `roadmap.ai.service.ts`** — replaced both `logAIRequest("COVER_LETTER", ...)` calls (success + error paths) with `logAIRequest("AI_ROADMAP_GENERATION", ...)`.
- **Updated `admin.validation.ts`** — added `"AI_ROADMAP_GENERATION"` to the `switchAIProviderSchema` Zod enum so admins can configure the AI provider for this service.



###Migration Note
⚠️ This change adds a new value to the `AIServiceType` database enum. After merging:
1. Run `npx prisma migrate dev` from `server/src/database/` to apply the schema change.
2. Seed or insert an `aiServiceConfig` row for `AI_ROADMAP_GENERATION` to enable proper provider registry lookups.

### Testing
- Verified Prisma schema validates cleanly
- TypeScript compiles without errors
- No runtime behavior changes beyond correct log categorization



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for a new AI service type to expand platform capabilities.
  * Improved event logging for AI-powered roadmap generation to enhance system tracking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/143)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->