### PR TITLE
fix: prevent stale resumeUrl from scoring wrong resume in ATS scorer

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -227,7 +227,7 @@ export default function AtsScorePage() {
   const analyzeMutation = useMutation({
     mutationFn: async (): Promise<{ score: AtsScore; emailQueued: boolean }> => {
       let url = resumeUrl;
-      if (file && !resumeUrl) {
+      if (file) {
         const formData = new FormData();
         formData.append("file", file);
         const uploadRes = await api.post("/upload/profile-resume", formData, {


### PR DESCRIPTION
## Summary
  - Fixes #136
  - The `analyzeMutation` was skipping the file upload when `resumeUrl` was already set (`if (file && !resumeUrl)`), causing a
  previously uploaded resume URL to be used if state hadn't settled before `mutate()` fired
  - Changed condition to `if (file)` — whenever a `File` object is present, always upload it fresh and never fall back to a lingering
  URL

  ## Root cause
  React state updates are async. After analyzing Resume A, `resumeUrl` holds the S3 URL. Picking Resume B calls `setResumeUrl("")`,
  but if the mutation fires before that state settles (race condition / double-submit), the stale closure value passes the
  `!resumeUrl` check as truthy and Resume A gets scored again.

  ## Test plan
  - [ ] Upload Resume A → analyze → note the score
  - [ ] Without clicking "New Resume", pick Resume B → click Analyze → confirm Resume B is scored
  - [ ] Upload a resume → analyze → click "Re-analyze" → confirm it still works (re-uploads same file, correct result)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume upload reliability by ensuring files are consistently uploaded during the ATS scoring analysis process, providing more reliable scoring results.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/148)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->