### PR TITLE
Fix accessibility issue in AtsScorePage transitions

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -717,7 +717,12 @@ export default function AtsScorePage() {
         </div>
 
         {/* ─── Right column: Results ─── */}
-        <div className="lg:col-span-3">
+        <div
+          className="lg:col-span-3"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
           <AnimatePresence mode="wait">
             {/* Empty state */}
             {!result && !loading && (
@@ -896,7 +901,6 @@ export default function AtsScorePage() {
                 transition={{ duration: 0.4 }}
                 className="space-y-6"
                 role="region"
-                aria-live="polite"
                 aria-label={`ATS analysis complete. Overall score ${result.overallScore} out of 100.`}
               >
                 {/* Score Header */}


### PR DESCRIPTION
# PR Summary
## Description
Fixed an issue where screen readers weren't announcing anything while the resume was being scanned or when the results finally appeared.

The aria-live attribute was sitting only on the results div. Since the loading and empty states were siblings (and the results div isn't even in the DOM until it's finished), screen readers ignored the transitions.

## Changes
Wrapped the whole section: Moved the `aria-live="polite"` to a parent wrapper that stays on the page. Now it captures everything happening inside the `AnimatePresence` block.

Added better attributes: Included `role="status"` and `aria-atomic="true"` on that wrapper so the screen reader knows to read the full update whenever the state changes from "scanning" to "results."

## Impact
Users with screen readers will now actually hear "Scanning your resume" and get the results announced automatically once the analysis is done.

Labels: `bug`, `accessibility`

Difficulty: `Medium`

---

> closes #133 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader compatibility for the results section, enabling state change announcements for users relying on assistive technologies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->