### PR TITLE
feat: expand cover letter tone options with smart JD-based auto-selection

### DIFF
--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -21,6 +21,7 @@ export const queryKeys = {
   ats: {
     all: ["ats"] as const,
     usage: () => ["ats", "usage"] as const,
+    history: () => ["ats", "history"] as const,
   },
 
   // Companies

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -277,7 +277,7 @@ export interface LatexChatResponse {
 }
 
 // Cover Letter
-export type CoverLetterTone = "professional" | "friendly" | "enthusiastic";
+export type CoverLetterTone = "professional" | "friendly" | "enthusiastic" | "technical" | "creative" | "formal" | "concise" | "startup";
 
 export interface CoverLetterInput {
   jobDescription: string;

--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -38,6 +38,7 @@ import {
   CartesianGrid,
 } from "recharts";
 
+/** Recharts custom tooltip — renders score, date, role, and resume name on dot hover. */
 function ScoreTooltip({ active, payload }: any) {
   if (!active || !payload?.length) return null;
   const d = payload[0].payload;

--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -28,6 +28,28 @@ import { SEO } from "../../../components/SEO";
 import AtsToolsNav from "./AtsToolsNav";
 import { queryKeys } from "../../../lib/query-keys";
 import type { AtsScore, UsageStats } from "../../../lib/types";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+
+function ScoreTooltip({ active, payload }: any) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0].payload;
+  return (
+    <div className="bg-stone-900 border border-white/10 rounded-md px-3 py-2 text-[11px] font-mono text-stone-300 shadow-xl">
+      <div className="text-stone-500 mb-1">{d.fullDate}</div>
+      <div>Role: {d.jobTitle}</div>
+      <div className="truncate max-w-[200px]">Resume: {d.resumeName}</div>
+      <div className="text-lime-400 font-bold mt-1">Score: {d.score}/100</div>
+    </div>
+  );
+}
 
 const CATEGORY_LABELS: Record<string, string> = {
   formatting: "Formatting",
@@ -214,6 +236,42 @@ export default function AtsScorePage() {
     refetchOnWindowFocus: true,
   });
 
+  const { data: historyData } = useQuery({
+    queryKey: queryKeys.ats.history(),
+    queryFn: () => api.get("/ats/history").then((r) => r.data.history),
+    staleTime: 60_000,
+  });
+
+  const scoreHistory = (historyData ?? []) as {
+    id: number;
+    overallScore: number;
+    jobTitle: string | null;
+    resumeUrl: string;
+    createdAt: string;
+  }[];
+
+  const chartData = scoreHistory.map((h) => {
+    const resumeName = h.resumeUrl.split("/").pop() ?? "resume.pdf";
+    return {
+      key: h.createdAt,
+      date: new Date(h.createdAt).toLocaleDateString("en-IN", {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+      }),
+      fullDate: new Date(h.createdAt).toLocaleDateString("en-IN", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      }),
+      score: h.overallScore,
+      jobTitle: h.jobTitle ?? "General",
+      resumeName,
+    };
+  });
+
   const atsUsage = usageData?.usage.find((u) => u.action === "ATS_SCORE");
   const limitReached = atsUsage ? atsUsage.used >= atsUsage.limit : false;
 
@@ -251,6 +309,7 @@ export default function AtsScorePage() {
       setCurrentStep(ANALYSIS_STEPS.length - 1);
       setAnalysisComplete(true);
       queryClient.invalidateQueries({ queryKey: queryKeys.ats.usage() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.ats.history() });
     },
     onError: (err: unknown) => {
       const msg =
@@ -404,6 +463,71 @@ export default function AtsScorePage() {
       </motion.div>
 
       <AtsToolsNav />
+
+      {/* ─── Score Progression Chart ─── */}
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.1 }}
+        className={`${cardCls} mb-6`}
+      >
+        <CardHeader
+          kicker="progress"
+          title="Score over time"
+          right={
+            chartData.length > 0 ? (
+              <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
+                {chartData.length}{" "}
+                {chartData.length === 1 ? "analysis" : "analyses"}
+              </span>
+            ) : null
+          }
+        />
+        <div className="p-5">
+          {chartData.length <= 1 ? (
+            <div className="flex items-center gap-3 py-4 text-sm text-stone-500">
+              <TrendingUp className="w-4 h-4 text-lime-500" />
+              {chartData.length === 0
+                ? "Analyze your first resume to start tracking progress."
+                : "Run one more analysis to start tracking your progress."}
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height={200}>
+              <LineChart data={chartData}>
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke="rgba(120,113,108,0.15)"
+                  vertical={false}
+                />
+                <XAxis
+                  dataKey="key"
+                  tickFormatter={(val: string) =>
+                    new Date(val).toLocaleDateString("en-IN", { month: "short", day: "numeric" })
+                  }
+                  tick={{ fontSize: 10, fontFamily: "monospace", fill: "#78716c" }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <YAxis
+                  domain={[0, 100]}
+                  tick={{ fontSize: 10, fontFamily: "monospace", fill: "#78716c" }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <Tooltip content={<ScoreTooltip />} cursor={false} />
+                <Line
+                  type="monotone"
+                  dataKey="score"
+                  stroke="#a3e635"
+                  strokeWidth={2}
+                  dot={{ fill: "#a3e635", strokeWidth: 0, r: 4 }}
+                  activeDot={{ r: 7, fill: "#a3e635" }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+      </motion.div>
 
       {/* ─── Main grid ─── */}
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-6 items-start">

--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -103,7 +103,8 @@ const SCORE_TIERS: ScoreTier[] = [
   },
 ];
 const getScoreTier = (score: number): ScoreTier =>
-  SCORE_TIERS.find((t) => score >= t.min) ?? SCORE_TIERS[SCORE_TIERS.length - 1]!;
+  SCORE_TIERS.find((t) => score >= t.min) ??
+  SCORE_TIERS[SCORE_TIERS.length - 1]!;
 
 const JD_MAX_CHARS = 5000;
 const JD_WARN_CHARS = 4500;
@@ -122,8 +123,7 @@ const cardCls =
   "bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md";
 const sectionKickerCls =
   "inline-flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500";
-const sectionTitleCls =
-  "text-sm font-bold text-stone-900 dark:text-stone-50";
+const sectionTitleCls = "text-sm font-bold text-stone-900 dark:text-stone-50";
 const inputCls =
   "w-full px-4 py-2.5 border border-stone-300 dark:border-white/10 rounded-md text-sm focus:outline-none focus:border-lime-400 transition-colors bg-white dark:bg-stone-950 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600";
 
@@ -251,7 +251,10 @@ export default function AtsScorePage() {
   }[];
 
   const chartData = scoreHistory.map((h) => {
-    const resumeName = h.resumeUrl.split("/").pop() ?? "resume.pdf";
+    const resumeName = decodeURIComponent(
+      (h.resumeUrl.split("?")[0] ?? h.resumeUrl).split("/").pop() ??
+        "resume.pdf",
+    );
     return {
       key: h.createdAt,
       date: new Date(h.createdAt).toLocaleDateString("en-IN", {
@@ -282,7 +285,10 @@ export default function AtsScorePage() {
   const [emailSent, setEmailSent] = useState(false);
 
   const analyzeMutation = useMutation({
-    mutationFn: async (): Promise<{ score: AtsScore; emailQueued: boolean }> => {
+    mutationFn: async (): Promise<{
+      score: AtsScore;
+      emailQueued: boolean;
+    }> => {
       let url = resumeUrl;
       if (file && !resumeUrl) {
         const formData = new FormData();
@@ -313,8 +319,11 @@ export default function AtsScorePage() {
     },
     onError: (err: unknown) => {
       const msg =
-        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ||
-        (err instanceof Error ? err.message : "Failed to analyze resume. Please try again.");
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ||
+        (err instanceof Error
+          ? err.message
+          : "Failed to analyze resume. Please try again.");
       setError(msg);
       toast.error(msg);
     },
@@ -404,9 +413,21 @@ export default function AtsScorePage() {
   };
 
   const TABS: { id: ResultTab; label: string; icon: React.ReactNode }[] = [
-    { id: "suggestions", label: "Suggestions", icon: <Lightbulb className="w-3.5 h-3.5" /> },
-    { id: "breakdown", label: "Breakdown", icon: <BarChart2 className="w-3.5 h-3.5" /> },
-    { id: "keywords", label: "Keywords", icon: <Search className="w-3.5 h-3.5" /> },
+    {
+      id: "suggestions",
+      label: "Suggestions",
+      icon: <Lightbulb className="w-3.5 h-3.5" />,
+    },
+    {
+      id: "breakdown",
+      label: "Breakdown",
+      icon: <BarChart2 className="w-3.5 h-3.5" />,
+    },
+    {
+      id: "keywords",
+      label: "Keywords",
+      icon: <Search className="w-3.5 h-3.5" />,
+    },
   ];
 
   const showUploadForm = !result;
@@ -446,7 +467,8 @@ export default function AtsScorePage() {
             </span>
           </h1>
           <p className="mt-3 text-sm text-stone-500 max-w-md">
-            Upload a PDF, add a target role, and get an ATS score with keyword gaps and concrete rewrite suggestions.
+            Upload a PDF, add a target role, and get an ATS score with keyword
+            gaps and concrete rewrite suggestions.
           </p>
         </div>
         {atsUsage && (
@@ -456,7 +478,10 @@ export default function AtsScorePage() {
             </span>
             <span className="text-sm font-bold tabular-nums text-stone-900 dark:text-stone-50">
               {atsUsage.used}
-              <span className="text-stone-400 dark:text-stone-600 font-normal"> / {atsUsage.limit}</span>
+              <span className="text-stone-400 dark:text-stone-600 font-normal">
+                {" "}
+                / {atsUsage.limit}
+              </span>
             </span>
           </div>
         )}
@@ -502,15 +527,26 @@ export default function AtsScorePage() {
                 <XAxis
                   dataKey="key"
                   tickFormatter={(val: string) =>
-                    new Date(val).toLocaleDateString("en-IN", { month: "short", day: "numeric" })
+                    new Date(val).toLocaleDateString("en-IN", {
+                      month: "short",
+                      day: "numeric",
+                    })
                   }
-                  tick={{ fontSize: 10, fontFamily: "monospace", fill: "#78716c" }}
+                  tick={{
+                    fontSize: 10,
+                    fontFamily: "monospace",
+                    fill: "#78716c",
+                  }}
                   tickLine={false}
                   axisLine={false}
                 />
                 <YAxis
                   domain={[0, 100]}
-                  tick={{ fontSize: 10, fontFamily: "monospace", fill: "#78716c" }}
+                  tick={{
+                    fontSize: 10,
+                    fontFamily: "monospace",
+                    fill: "#78716c",
+                  }}
                   tickLine={false}
                   axisLine={false}
                 />
@@ -657,7 +693,9 @@ export default function AtsScorePage() {
                         onChange={(e) => {
                           const next = e.target.value.slice(0, JD_MAX_CHARS);
                           if (e.target.value.length > JD_MAX_CHARS) {
-                            toast.error(`Job description capped at ${JD_MAX_CHARS.toLocaleString()} characters.`);
+                            toast.error(
+                              `Job description capped at ${JD_MAX_CHARS.toLocaleString()} characters.`,
+                            );
                           }
                           setJobDescription(next);
                         }}
@@ -675,7 +713,8 @@ export default function AtsScorePage() {
                             : "text-stone-500"
                         }`}
                       >
-                        {jobDescription.length.toLocaleString()} / {JD_MAX_CHARS.toLocaleString()}
+                        {jobDescription.length.toLocaleString()} /{" "}
+                        {JD_MAX_CHARS.toLocaleString()}
                       </div>
                     </div>
                   </div>
@@ -758,14 +797,18 @@ export default function AtsScorePage() {
                     <div className="border-t border-stone-200 dark:border-white/10 -mx-5 px-5 pt-4 space-y-2.5">
                       {jobTitle && (
                         <div className="flex items-center justify-between text-xs">
-                          <span className="font-mono uppercase tracking-widest text-stone-500">target role</span>
+                          <span className="font-mono uppercase tracking-widest text-stone-500">
+                            target role
+                          </span>
                           <span className="font-bold text-stone-900 dark:text-stone-50 truncate ml-4 max-w-40">
                             {jobTitle}
                           </span>
                         </div>
                       )}
                       <div className="flex items-center justify-between text-xs">
-                        <span className="font-mono uppercase tracking-widest text-stone-500">jd length</span>
+                        <span className="font-mono uppercase tracking-widest text-stone-500">
+                          jd length
+                        </span>
                         <span className="font-bold text-stone-900 dark:text-stone-50 tabular-nums">
                           {jobDescription.length.toLocaleString()} chars
                         </span>
@@ -786,7 +829,9 @@ export default function AtsScorePage() {
                         disabled={loading}
                         className="inline-flex items-center justify-center gap-1.5 py-2.5 px-3 rounded-md text-xs font-bold bg-lime-400 text-stone-950 hover:bg-lime-300 transition-colors border-0 cursor-pointer disabled:opacity-50"
                       >
-                        <RefreshCw className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`} />
+                        <RefreshCw
+                          className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`}
+                        />
                         Re-analyze
                       </button>
                     </div>
@@ -807,7 +852,9 @@ export default function AtsScorePage() {
                               key={key}
                               className="bg-white dark:bg-stone-900 p-3 text-left"
                             >
-                              <p className={`text-xl font-bold tracking-tight tabular-nums ${tier.text}`}>
+                              <p
+                                className={`text-xl font-bold tracking-tight tabular-nums ${tier.text}`}
+                              >
                                 {score}
                               </p>
                               <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mt-1">
@@ -853,12 +900,19 @@ export default function AtsScorePage() {
                     <span className="font-bold text-stone-900 dark:text-stone-50">
                       Analyze resume
                     </span>{" "}
-                    to get your ATS score, keyword analysis, and rewrite suggestions.
+                    to get your ATS score, keyword analysis, and rewrite
+                    suggestions.
                   </p>
                   <div className="mt-6 grid grid-cols-3 gap-px bg-stone-200 dark:bg-white/10 border border-stone-200 dark:border-white/10 rounded-md overflow-hidden">
                     {[
-                      { label: "6 categories", icon: <BarChart2 className="w-3 h-3" /> },
-                      { label: "ai powered", icon: <ScanSearch className="w-3 h-3" /> },
+                      {
+                        label: "6 categories",
+                        icon: <BarChart2 className="w-3 h-3" />,
+                      },
+                      {
+                        label: "ai powered",
+                        icon: <ScanSearch className="w-3 h-3" />,
+                      },
                       { label: "instant", icon: <Zap className="w-3 h-3" /> },
                     ].map((tag) => (
                       <div
@@ -908,7 +962,8 @@ export default function AtsScorePage() {
                     {ANALYSIS_STEPS.map((step, i) => {
                       const Icon = step.icon;
                       const isDone =
-                        i < currentStep || (i === currentStep && analysisComplete);
+                        i < currentStep ||
+                        (i === currentStep && analysisComplete);
                       const isCurrent = i === currentStep && !analysisComplete;
                       const isPending = i > currentStep;
                       return (
@@ -939,7 +994,11 @@ export default function AtsScorePage() {
                             ) : isCurrent ? (
                               <motion.div
                                 animate={{ rotate: 360 }}
-                                transition={{ duration: 1.5, repeat: Infinity, ease: "linear" }}
+                                transition={{
+                                  duration: 1.5,
+                                  repeat: Infinity,
+                                  ease: "linear",
+                                }}
                               >
                                 <Icon className="w-3.5 h-3.5" />
                               </motion.div>
@@ -1013,7 +1072,9 @@ export default function AtsScorePage() {
                     kicker="result"
                     title="Overall ATS score"
                     right={
-                      <span className={`text-[10px] font-mono uppercase tracking-widest ${overallTier.text}`}>
+                      <span
+                        className={`text-[10px] font-mono uppercase tracking-widest ${overallTier.text}`}
+                      >
                         / {overallTier.label.toLowerCase()}
                       </span>
                     }
@@ -1099,41 +1160,49 @@ export default function AtsScorePage() {
                           transition={{ duration: 0.18 }}
                           className="space-y-2.5"
                         >
-                          {Object.entries(result.categoryScores).map(([key, score]) => {
-                            const Icon = CATEGORY_ICONS[key] ?? BarChart2;
-                            const tier = getScoreTier(score);
-                            return (
-                              <div
-                                key={key}
-                                className="flex items-center gap-3 p-3.5 bg-stone-50/60 dark:bg-stone-950/40 border border-stone-200 dark:border-white/10 rounded-md"
-                              >
-                                <div className="w-9 h-9 rounded-md flex items-center justify-center shrink-0 bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10">
-                                  <Icon className="w-4 h-4 text-stone-600 dark:text-stone-400" />
-                                </div>
-                                <div className="flex-1 min-w-0">
-                                  <div className="flex justify-between items-center mb-1.5">
-                                    <span className="text-sm font-bold text-stone-900 dark:text-stone-50">
-                                      {CATEGORY_LABELS[key] ?? key}
-                                    </span>
-                                    <span className={`text-sm font-bold tabular-nums ${tier.text}`}>
-                                      {score}
-                                      <span className="text-stone-400 dark:text-stone-600 text-xs font-normal">
-                                        /100
+                          {Object.entries(result.categoryScores).map(
+                            ([key, score]) => {
+                              const Icon = CATEGORY_ICONS[key] ?? BarChart2;
+                              const tier = getScoreTier(score);
+                              return (
+                                <div
+                                  key={key}
+                                  className="flex items-center gap-3 p-3.5 bg-stone-50/60 dark:bg-stone-950/40 border border-stone-200 dark:border-white/10 rounded-md"
+                                >
+                                  <div className="w-9 h-9 rounded-md flex items-center justify-center shrink-0 bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10">
+                                    <Icon className="w-4 h-4 text-stone-600 dark:text-stone-400" />
+                                  </div>
+                                  <div className="flex-1 min-w-0">
+                                    <div className="flex justify-between items-center mb-1.5">
+                                      <span className="text-sm font-bold text-stone-900 dark:text-stone-50">
+                                        {CATEGORY_LABELS[key] ?? key}
                                       </span>
-                                    </span>
-                                  </div>
-                                  <div className="h-1.5 bg-stone-200 dark:bg-white/10 rounded-full overflow-hidden">
-                                    <motion.div
-                                      initial={{ width: 0 }}
-                                      animate={{ width: `${String(score)}%` }}
-                                      transition={{ duration: 0.9, delay: 0.1, ease: "easeOut" }}
-                                      className={`h-full rounded-full ${tier.bar}`}
-                                    />
+                                      <span
+                                        className={`text-sm font-bold tabular-nums ${tier.text}`}
+                                      >
+                                        {score}
+                                        <span className="text-stone-400 dark:text-stone-600 text-xs font-normal">
+                                          /100
+                                        </span>
+                                      </span>
+                                    </div>
+                                    <div className="h-1.5 bg-stone-200 dark:bg-white/10 rounded-full overflow-hidden">
+                                      <motion.div
+                                        initial={{ width: 0 }}
+                                        animate={{ width: `${String(score)}%` }}
+                                        transition={{
+                                          duration: 0.9,
+                                          delay: 0.1,
+                                          ease: "easeOut",
+                                        }}
+                                        className={`h-full rounded-full ${tier.bar}`}
+                                      />
+                                    </div>
                                   </div>
                                 </div>
-                              </div>
-                            );
-                          })}
+                              );
+                            },
+                          )}
                         </motion.div>
                       )}
 
@@ -1168,7 +1237,8 @@ export default function AtsScorePage() {
                             <div>
                               <div className={sectionKickerCls + " mb-3"}>
                                 <span className="h-1 w-1 bg-orange-500" />
-                                missing · {result.keywordAnalysis.missing.length}
+                                missing ·{" "}
+                                {result.keywordAnalysis.missing.length}
                               </div>
                               <div className="flex flex-wrap gap-1.5">
                                 {result.keywordAnalysis.missing.map((kw) => (

--- a/client/src/module/student/ats/CoverLetterPage.tsx
+++ b/client/src/module/student/ats/CoverLetterPage.tsx
@@ -35,9 +35,26 @@ import { queryKeys } from "../../../lib/query-keys";
 import type { CoverLetterTone, UsageStats } from "../../../lib/types";
 
 const TONES: { id: CoverLetterTone; label: string; description: string }[] = [
-  { id: "professional", label: "Professional", description: "Formal and confident" },
+  {
+    id: "professional",
+    label: "Professional",
+    description: "Formal and confident",
+  },
   { id: "friendly", label: "Friendly", description: "Warm and approachable" },
-  { id: "enthusiastic", label: "Enthusiastic", description: "Energetic and passionate" },
+  {
+    id: "enthusiastic",
+    label: "Enthusiastic",
+    description: "Energetic and passionate",
+  },
+  { id: "technical", label: "Technical", description: "Precise, stack-aware" },
+  {
+    id: "creative",
+    label: "Creative",
+    description: "Narrative and expressive",
+  },
+  { id: "formal", label: "Formal", description: "Executive and measured" },
+  { id: "concise", label: "Concise", description: "Short and direct" },
+  { id: "startup", label: "Startup", description: "Bold and mission-driven" },
 ];
 
 const GENERATION_STEPS = [
@@ -53,8 +70,7 @@ const cardCls =
   "bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md";
 const sectionKickerCls =
   "inline-flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500";
-const sectionTitleCls =
-  "text-sm font-bold text-stone-900 dark:text-stone-50";
+const sectionTitleCls = "text-sm font-bold text-stone-900 dark:text-stone-50";
 const inputCls =
   "w-full px-4 py-2.5 border border-stone-300 dark:border-white/10 rounded-md text-sm focus:outline-none focus:border-lime-400 transition-colors bg-white dark:bg-stone-950 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600";
 const labelCls =
@@ -112,19 +128,59 @@ export default function CoverLetterPage() {
   const profileSummary = useMemo(() => {
     if (!user) return null;
     const parts: string[] = [];
-    if (user.skills && user.skills.length > 0) parts.push(user.skills.join(", "));
-    if (user.college) parts.push(user.college + (user.graduationYear ? ` (${String(user.graduationYear)})` : ""));
-    if (user.company) parts.push(user.company + (user.designation ? ` - ${user.designation}` : ""));
-    if (user.projects && user.projects.length > 0) parts.push(`${String(user.projects.length)} project${user.projects.length > 1 ? "s" : ""}`);
-    if (user.achievements && user.achievements.length > 0) parts.push(`${String(user.achievements.length)} achievement${user.achievements.length > 1 ? "s" : ""}`);
+    if (user.skills && user.skills.length > 0)
+      parts.push(user.skills.join(", "));
+    if (user.college)
+      parts.push(
+        user.college +
+          (user.graduationYear ? ` (${String(user.graduationYear)})` : ""),
+      );
+    if (user.company)
+      parts.push(
+        user.company + (user.designation ? ` - ${user.designation}` : ""),
+      );
+    if (user.projects && user.projects.length > 0)
+      parts.push(
+        `${String(user.projects.length)} project${user.projects.length > 1 ? "s" : ""}`,
+      );
+    if (user.achievements && user.achievements.length > 0)
+      parts.push(
+        `${String(user.achievements.length)} achievement${user.achievements.length > 1 ? "s" : ""}`,
+      );
     return parts;
   }, [user]);
 
   const hasProfileData = profileSummary && profileSummary.length > 0;
 
+  // Auto-select tone based on job description keywords
+  useEffect(() => {
+    if (!jobDescription || jobDescription.length < 30) return;
+    const jd = jobDescription.toLowerCase();
+    if (
+      /\bvp\b|vice president|director|executive|c-suite|cto|ceo|cfo/.test(jd)
+    ) {
+      setTone("formal");
+    } else if (
+      /engineer|developer|architect|backend|frontend|fullstack|devops|sre|infrastructure/.test(
+        jd,
+      )
+    ) {
+      setTone("technical");
+    } else if (
+      /designer|creative|brand|content|copywriter|narrative|storytelling/.test(
+        jd,
+      )
+    ) {
+      setTone("creative");
+    }
+    // else keep current selection
+  }, [jobDescription]);
+
   const handleGenerate = async () => {
     if (jobDescription.trim().length < JD_MIN_CHARS) {
-      toast.error(`Job description must be at least ${JD_MIN_CHARS} characters`);
+      toast.error(
+        `Job description must be at least ${JD_MIN_CHARS} characters`,
+      );
       return;
     }
 
@@ -177,7 +233,10 @@ export default function CoverLetterPage() {
   useEffect(() => {
     if (!showDownloadMenu) return;
     const handleClick = (e: MouseEvent) => {
-      if (downloadMenuRef.current && !downloadMenuRef.current.contains(e.target as Node)) {
+      if (
+        downloadMenuRef.current &&
+        !downloadMenuRef.current.contains(e.target as Node)
+      ) {
         setShowDownloadMenu(false);
       }
     };
@@ -218,7 +277,7 @@ export default function CoverLetterPage() {
         new Paragraph({
           children: [new TextRun({ text: line, font: "Georgia", size: 24 })],
           spacing: { after: 120 },
-        })
+        }),
     );
 
     const doc = new Document({
@@ -231,7 +290,11 @@ export default function CoverLetterPage() {
 
   return (
     <div className="relative pb-16">
-      <SEO title="Cover Letter Builder - InternHack" description="Generate AI-powered cover letters tailored to any job" noIndex />
+      <SEO
+        title="Cover Letter Builder - InternHack"
+        description="Generate AI-powered cover letters tailored to any job"
+        noIndex
+      />
 
       {/* ─── Editorial header ─── */}
       <motion.div
@@ -249,7 +312,8 @@ export default function CoverLetterPage() {
             Write your cover letter.
           </h1>
           <p className="mt-3 text-sm text-stone-500 max-w-md">
-            Paste a job description, pick a tone, and get a tailored letter you can copy, edit, or export as PDF or DOCX.
+            Paste a job description, pick a tone, and get a tailored letter you
+            can copy, edit, or export as PDF or DOCX.
           </p>
         </div>
         {clUsage && (
@@ -259,7 +323,10 @@ export default function CoverLetterPage() {
             </span>
             <span className="text-sm font-bold tabular-nums text-stone-900 dark:text-stone-50">
               {clUsage.used}
-              <span className="text-stone-400 dark:text-stone-600 font-normal"> / {clUsage.limit}</span>
+              <span className="text-stone-400 dark:text-stone-600 font-normal">
+                {" "}
+                / {clUsage.limit}
+              </span>
             </span>
           </div>
         )}
@@ -275,7 +342,8 @@ export default function CoverLetterPage() {
             <div className="p-5 space-y-4">
               <div>
                 <label className={labelCls}>
-                  <AlignLeft className="w-3 h-3" /> job description <span className="text-red-500">*</span>
+                  <AlignLeft className="w-3 h-3" /> job description{" "}
+                  <span className="text-red-500">*</span>
                 </label>
                 <textarea
                   className={`${inputCls} min-h-35 resize-y`}
@@ -285,25 +353,35 @@ export default function CoverLetterPage() {
                 />
                 <div className="mt-1.5 flex flex-col gap-1">
                   <div className="flex justify-between items-center text-[10px] font-mono uppercase tracking-widest tabular-nums">
-                    <span className={jobDescription.length > 0 && jobDescription.length < JD_MIN_CHARS ? "text-amber-600 dark:text-amber-400" : "text-emerald-600 dark:text-emerald-400"}>
-                      {jobDescription.length === 0 
+                    <span
+                      className={
+                        jobDescription.length > 0 &&
+                        jobDescription.length < JD_MIN_CHARS
+                          ? "text-amber-600 dark:text-amber-400"
+                          : "text-emerald-600 dark:text-emerald-400"
+                      }
+                    >
+                      {jobDescription.length === 0
                         ? `${JD_MIN_CHARS} characters minimum`
                         : jobDescription.length < JD_MIN_CHARS
-                        ? `${JD_MIN_CHARS - jobDescription.length} more characters needed`
-                        : "Ready to generate"}
+                          ? `${JD_MIN_CHARS - jobDescription.length} more characters needed`
+                          : "Ready to generate"}
                     </span>
                     <span className="text-stone-500">
                       {jobDescription.length} / {JD_MIN_CHARS} min
                     </span>
                   </div>
-                  {jobDescription.length >= JD_MIN_CHARS && jobDescription.length < 200 && (
-                    <p className="text-[10px] text-stone-500 mt-0.5 normal-case tracking-normal font-sans">
-                       Longer job descriptions produce better-tailored cover letters. Aim for 200+ chars.
-                    </p>
-                  )}
+                  {jobDescription.length >= JD_MIN_CHARS &&
+                    jobDescription.length < 200 && (
+                      <p className="text-[10px] text-stone-500 mt-0.5 normal-case tracking-normal font-sans">
+                        Longer job descriptions produce better-tailored cover
+                        letters. Aim for 200+ chars.
+                      </p>
+                    )}
                   {jobDescription.length > 5000 && (
                     <p className="text-[10px] text-amber-600 dark:text-amber-400 mt-0.5 normal-case tracking-normal font-sans">
-                       Very long descriptions may be truncated. Consider keeping it under 5000 chars.
+                      Very long descriptions may be truncated. Consider keeping
+                      it under 5000 chars.
                     </p>
                   )}
                 </div>
@@ -352,7 +430,7 @@ export default function CoverLetterPage() {
           <div className={cardCls}>
             <CardHeader kicker="step 02" title="Tone" />
             <div className="p-5">
-              <div className="grid grid-cols-3 gap-px bg-stone-200 dark:bg-white/10 border border-stone-200 dark:border-white/10 rounded-md overflow-hidden">
+              <div className="grid grid-cols-3 sm:grid-cols-4 gap-px bg-stone-200 dark:bg-white/10 border border-stone-200 dark:border-white/10 rounded-md overflow-hidden">
                 {TONES.map((t, i) => {
                   const isActive = tone === t.id;
                   return (
@@ -376,7 +454,9 @@ export default function CoverLetterPage() {
                       <span className="text-sm font-bold">{t.label}</span>
                       <span
                         className={`text-[11px] ${
-                          isActive ? "text-stone-300 dark:text-stone-600" : "text-stone-500"
+                          isActive
+                            ? "text-stone-300 dark:text-stone-600"
+                            : "text-stone-500"
                         }`}
                       >
                         {t.description}
@@ -404,7 +484,9 @@ export default function CoverLetterPage() {
                 type="button"
                 onClick={() => {
                   if (!hasProfileData) {
-                    toast.error("Complete your profile first to use this feature");
+                    toast.error(
+                      "Complete your profile first to use this feature",
+                    );
                     return;
                   }
                   setUseProfile(!useProfile);
@@ -417,11 +499,13 @@ export default function CoverLetterPage() {
                       : "border-stone-300 dark:border-white/10 bg-stone-50/60 dark:bg-stone-950/40 hover:border-stone-400 dark:hover:border-white/20"
                 }`}
               >
-                <div className={`w-9 h-9 rounded-md flex items-center justify-center shrink-0 ${
-                  useProfile && hasProfileData
-                    ? "bg-lime-400 text-stone-950"
-                    : "bg-white dark:bg-stone-950 border border-stone-200 dark:border-white/10 text-stone-500"
-                }`}>
+                <div
+                  className={`w-9 h-9 rounded-md flex items-center justify-center shrink-0 ${
+                    useProfile && hasProfileData
+                      ? "bg-lime-400 text-stone-950"
+                      : "bg-white dark:bg-stone-950 border border-stone-200 dark:border-white/10 text-stone-500"
+                  }`}
+                >
                   <User className="w-4 h-4" />
                 </div>
                 <div className="flex-1 min-w-0">
@@ -429,15 +513,23 @@ export default function CoverLetterPage() {
                     Pull from profile
                   </p>
                   <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mt-1">
-                    {hasProfileData ? "include skills, projects, achievements" : "complete profile to enable"}
+                    {hasProfileData
+                      ? "include skills, projects, achievements"
+                      : "complete profile to enable"}
                   </p>
                 </div>
-                <div className={`w-9 h-5 relative transition-colors shrink-0 rounded-sm ${
-                  useProfile && hasProfileData ? "bg-lime-400" : "bg-stone-200 dark:bg-white/10"
-                }`}>
-                  <div className={`absolute top-0.5 w-4 h-4 bg-white dark:bg-stone-50 shadow-sm transition-all rounded-xs ${
-                    useProfile && hasProfileData ? "left-4.5" : "left-0.5"
-                  }`} />
+                <div
+                  className={`w-9 h-5 relative transition-colors shrink-0 rounded-sm ${
+                    useProfile && hasProfileData
+                      ? "bg-lime-400"
+                      : "bg-stone-200 dark:bg-white/10"
+                  }`}
+                >
+                  <div
+                    className={`absolute top-0.5 w-4 h-4 bg-white dark:bg-stone-50 shadow-sm transition-all rounded-xs ${
+                      useProfile && hasProfileData ? "left-4.5" : "left-0.5"
+                    }`}
+                  />
                 </div>
               </button>
 
@@ -456,7 +548,10 @@ export default function CoverLetterPage() {
                           <div className="flex items-start gap-2">
                             <Code2 className="w-3 h-3 text-stone-500 mt-0.5 shrink-0" />
                             <p className="text-[11px] text-stone-600 dark:text-stone-400 leading-relaxed">
-                              {user.skills.slice(0, 6).join(", ")}{user.skills.length > 6 ? ` +${String(user.skills.length - 6)} more` : ""}
+                              {user.skills.slice(0, 6).join(", ")}
+                              {user.skills.length > 6
+                                ? ` +${String(user.skills.length - 6)} more`
+                                : ""}
                             </p>
                           </div>
                         )}
@@ -464,7 +559,10 @@ export default function CoverLetterPage() {
                           <div className="flex items-start gap-2">
                             <GraduationCap className="w-3 h-3 text-stone-500 mt-0.5 shrink-0" />
                             <p className="text-[11px] text-stone-600 dark:text-stone-400">
-                              {user.college}{user.graduationYear ? ` (${String(user.graduationYear)})` : ""}
+                              {user.college}
+                              {user.graduationYear
+                                ? ` (${String(user.graduationYear)})`
+                                : ""}
                             </p>
                           </div>
                         )}
@@ -501,7 +599,11 @@ export default function CoverLetterPage() {
           <button
             type="button"
             onClick={handleGenerate}
-            disabled={loading || jobDescription.trim().length < JD_MIN_CHARS || limitReached}
+            disabled={
+              loading ||
+              jobDescription.trim().length < JD_MIN_CHARS ||
+              limitReached
+            }
             className="group w-full inline-flex items-center justify-center gap-2 px-5 py-3.5 bg-lime-400 text-stone-950 rounded-md text-sm font-bold hover:bg-lime-300 transition-colors border-0 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {loading ? (
@@ -594,7 +696,14 @@ export default function CoverLetterPage() {
                             {isDone ? (
                               <CheckCircle className="w-3.5 h-3.5" />
                             ) : isActive ? (
-                              <motion.div animate={{ rotate: 360 }} transition={{ duration: 1.5, repeat: Infinity, ease: "linear" }}>
+                              <motion.div
+                                animate={{ rotate: 360 }}
+                                transition={{
+                                  duration: 1.5,
+                                  repeat: Infinity,
+                                  ease: "linear",
+                                }}
+                              >
                                 <Icon className="w-3.5 h-3.5" />
                               </motion.div>
                             ) : (
@@ -620,7 +729,19 @@ export default function CoverLetterPage() {
                           {isActive && (
                             <div className="flex gap-1">
                               {[0, 0.15, 0.3].map((delay) => (
-                                <motion.div key={delay} className="w-1.5 h-1.5 rounded-full bg-lime-400" animate={{ scale: [1, 1.4, 1], opacity: [0.5, 1, 0.5] }} transition={{ duration: 0.8, repeat: Infinity, delay }} />
+                                <motion.div
+                                  key={delay}
+                                  className="w-1.5 h-1.5 rounded-full bg-lime-400"
+                                  animate={{
+                                    scale: [1, 1.4, 1],
+                                    opacity: [0.5, 1, 0.5],
+                                  }}
+                                  transition={{
+                                    duration: 0.8,
+                                    repeat: Infinity,
+                                    delay,
+                                  }}
+                                />
                               ))}
                             </div>
                           )}
@@ -685,14 +806,16 @@ export default function CoverLetterPage() {
                                 onClick={handleDownloadPdf}
                                 className="w-full flex items-center gap-2 px-3 py-2.5 text-[11px] font-bold text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-950/60 transition-colors border-0 bg-transparent cursor-pointer"
                               >
-                                <FileText className="w-3.5 h-3.5 text-stone-500" /> PDF
+                                <FileText className="w-3.5 h-3.5 text-stone-500" />{" "}
+                                PDF
                               </button>
                               <button
                                 type="button"
                                 onClick={handleDownloadDocx}
                                 className="w-full flex items-center gap-2 px-3 py-2.5 text-[11px] font-bold text-stone-700 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-950/60 transition-colors border-t border-stone-200 dark:border-white/10 bg-transparent cursor-pointer"
                               >
-                                <FileText className="w-3.5 h-3.5 text-stone-500" /> DOCX
+                                <FileText className="w-3.5 h-3.5 text-stone-500" />{" "}
+                                DOCX
                               </button>
                             </motion.div>
                           )}
@@ -740,8 +863,14 @@ export default function CoverLetterPage() {
                   </p>
                   <div className="mt-6 grid grid-cols-3 gap-px bg-stone-200 dark:bg-white/10 border border-stone-200 dark:border-white/10 rounded-md overflow-hidden">
                     {[
-                      { label: "ai powered", icon: <Wand2 className="w-3 h-3" /> },
-                      { label: "3 tones", icon: <MessageSquare className="w-3 h-3" /> },
+                      {
+                        label: "ai powered",
+                        icon: <Wand2 className="w-3 h-3" />,
+                      },
+                      {
+                        label: "8 tones",
+                        icon: <MessageSquare className="w-3 h-3" />,
+                      },
                       { label: "instant", icon: <Zap className="w-3 h-3" /> },
                     ].map((tag) => (
                       <div
@@ -778,7 +907,9 @@ export default function CoverLetterPage() {
                   <div className="w-14 h-14 rounded-md bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900/40 flex items-center justify-center mx-auto mb-4">
                     <AlertCircle className="w-6 h-6 text-red-500" />
                   </div>
-                  <p className="text-sm text-stone-700 dark:text-stone-300 mb-5 max-w-sm mx-auto">{error}</p>
+                  <p className="text-sm text-stone-700 dark:text-stone-300 mb-5 max-w-sm mx-auto">
+                    {error}
+                  </p>
                   <button
                     type="button"
                     onClick={handleGenerate}

--- a/server/src/module/ats/ats.controller.ts
+++ b/server/src/module/ats/ats.controller.ts
@@ -145,6 +145,7 @@ export class AtsController {
     await sendEmail({ to: user.email, subject, html });
   }
 
+  /** GET /api/ats/history — returns the authenticated student's recent score history. */
   async getScoreHistory(req: Request, res: Response, next: NextFunction) {
     try {
       if (!req.user) {

--- a/server/src/module/ats/ats.controller.ts
+++ b/server/src/module/ats/ats.controller.ts
@@ -144,4 +144,17 @@ export class AtsController {
     const subject = `Your resume scored ${score.overallScore}/100 on InternHack`;
     await sendEmail({ to: user.email, subject, html });
   }
+
+  async getScoreHistory(req: Request, res: Response, next: NextFunction) {
+    try {
+      if (!req.user) {
+        res.status(401).json({ message: "Authentication required" });
+        return;
+      }
+      const history = await this.atsService.getScoreHistory(req.user.id);
+      res.json({ history });
+    } catch (err) {
+      next(err);
+    }
+  }
 }

--- a/server/src/module/ats/ats.routes.ts
+++ b/server/src/module/ats/ats.routes.ts
@@ -28,6 +28,7 @@ export const atsRouter = Router();
 atsRouter.use(authMiddleware, requireRole("STUDENT"));
 
 atsRouter.get("/usage", (req, res, next) => atsController.getUsageStats(req, res, next));
+atsRouter.get("/history", (req, res, next) => atsController.getScoreHistory(req, res, next));
 atsRouter.post("/score", usageLimit("ATS_SCORE"), (req, res, next) => atsController.scoreResume(req, res, next));
 atsRouter.post("/cover-letter", usageLimit("COVER_LETTER"), (req, res, next) => coverLetterController.generate(req, res, next));
 atsRouter.post("/generate-resume", usageLimit("GENERATE_RESUME"), (req, res, next) => resumeGenController.generate(req, res, next));

--- a/server/src/module/ats/ats.service.ts
+++ b/server/src/module/ats/ats.service.ts
@@ -6,7 +6,12 @@ import { prisma } from "../../database/db.js";
 import { getBufferFromS3, getS3KeyFromUrl } from "../../utils/s3.utils.js";
 import { getProviderForService } from "../../lib/ai-provider-registry.js";
 import { logAIRequest } from "../../lib/ai-request-logger.js";
-import type { AtsScoreResult, ScoreResumeInput, AtsCategoryScores, AtsKeywordAnalysis } from "./ats.types.js";
+import type {
+  AtsScoreResult,
+  ScoreResumeInput,
+  AtsCategoryScores,
+  AtsKeywordAnalysis,
+} from "./ats.types.js";
 import type { Prisma } from "@prisma/client";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -17,7 +22,6 @@ const __dirname = path.dirname(__filename);
 const SCORE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 export class AtsService {
-
   async scoreResume(studentId: number, input: ScoreResumeInput) {
     // IDOR check: verify the resume belongs to this student
     const user = await prisma.user.findUnique({
@@ -50,10 +54,17 @@ export class AtsService {
     const resumeText = await this.extractPdfText(input.resumeUrl);
 
     if (!resumeText || resumeText.trim().length < 50) {
-      throw new Error("Could not extract sufficient text from the resume PDF. Make sure it is not a scanned image.");
+      throw new Error(
+        "Could not extract sufficient text from the resume PDF. Make sure it is not a scanned image.",
+      );
     }
 
-    const result = await this.callAI(resumeText, studentId, input.jobTitle, input.jobDescription);
+    const result = await this.callAI(
+      resumeText,
+      studentId,
+      input.jobTitle,
+      input.jobDescription,
+    );
 
     const atsScore = await prisma.atsScore.create({
       data: {
@@ -62,10 +73,18 @@ export class AtsService {
         jobTitle: input.jobTitle ?? null,
         jobDescription: input.jobDescription ?? null,
         overallScore: result.overallScore,
-        categoryScores: JSON.parse(JSON.stringify(result.categoryScores)) as Prisma.InputJsonValue,
-        suggestions: JSON.parse(JSON.stringify(result.suggestions)) as Prisma.InputJsonValue,
-        keywordAnalysis: JSON.parse(JSON.stringify(result.keywordAnalysis)) as Prisma.InputJsonValue,
-        rawResponse: JSON.parse(JSON.stringify(result)) as Prisma.InputJsonValue,
+        categoryScores: JSON.parse(
+          JSON.stringify(result.categoryScores),
+        ) as Prisma.InputJsonValue,
+        suggestions: JSON.parse(
+          JSON.stringify(result.suggestions),
+        ) as Prisma.InputJsonValue,
+        keywordAnalysis: JSON.parse(
+          JSON.stringify(result.keywordAnalysis),
+        ) as Prisma.InputJsonValue,
+        rawResponse: JSON.parse(
+          JSON.stringify(result),
+        ) as Prisma.InputJsonValue,
       },
     });
 
@@ -81,7 +100,10 @@ export class AtsService {
     } else if (resumeUrl.startsWith("/uploads/")) {
       // Local uploads - sanitize to prevent path traversal
       const uploadsDir = path.resolve(__dirname, "../../../uploads");
-      const resolved = path.resolve(uploadsDir, resumeUrl.replace(/^\/uploads\//, ""));
+      const resolved = path.resolve(
+        uploadsDir,
+        resumeUrl.replace(/^\/uploads\//, ""),
+      );
       if (!resolved.startsWith(uploadsDir)) {
         throw new Error("Invalid resume path");
       }
@@ -114,8 +136,9 @@ export class AtsService {
     jobTitle?: string | undefined,
     jobDescription?: string | undefined,
   ): string {
-    const jobContext = jobTitle || jobDescription
-      ? `
+    const jobContext =
+      jobTitle || jobDescription
+        ? `
 TARGET JOB INFORMATION:
 ${jobTitle ? `Job Title: ${jobTitle}` : ""}
 ${jobDescription ? `Job Description: ${jobDescription}` : ""}
@@ -123,7 +146,7 @@ ${jobDescription ? `Job Description: ${jobDescription}` : ""}
 When scoring keywords and skills, evaluate specifically against this job posting.
 When listing missing keywords, focus on terms from this job description that are absent from the resume.
 `
-      : `
+        : `
 No specific job description provided. Evaluate the resume for general ATS compatibility
 using common industry standards for software/tech roles.
 `;
@@ -231,25 +254,33 @@ Respond with ONLY valid JSON (no markdown formatting, no code blocks, no explana
 
     const obj = parsed as Record<string, unknown>;
 
-    const overallScore = typeof obj["overallScore"] === "number"
-      ? Math.max(0, Math.min(100, Math.round(obj["overallScore"])))
-      : 50;
+    const overallScore =
+      typeof obj["overallScore"] === "number"
+        ? Math.max(0, Math.min(100, Math.round(obj["overallScore"])))
+        : 50;
 
     const categoryScores = this.validateCategoryScores(obj["categoryScores"]);
     const suggestions = this.validateSuggestions(obj["suggestions"]);
-    const keywordAnalysis = this.validateKeywordAnalysis(obj["keywordAnalysis"]);
+    const keywordAnalysis = this.validateKeywordAnalysis(
+      obj["keywordAnalysis"],
+    );
 
     return { overallScore, categoryScores, suggestions, keywordAnalysis };
   }
 
   private validateCategoryScores(raw: unknown): AtsCategoryScores {
     const defaults: AtsCategoryScores = {
-      formatting: 50, keywords: 50, experience: 50,
-      skills: 50, education: 50, impact: 50,
+      formatting: 50,
+      keywords: 50,
+      experience: 50,
+      skills: 50,
+      education: 50,
+      impact: 50,
     };
     if (!raw || typeof raw !== "object") return defaults;
     const obj = raw as Record<string, unknown>;
-    const clamp = (v: unknown) => typeof v === "number" ? Math.max(0, Math.min(100, Math.round(v))) : 50;
+    const clamp = (v: unknown) =>
+      typeof v === "number" ? Math.max(0, Math.min(100, Math.round(v))) : 50;
     return {
       formatting: clamp(obj["formatting"]),
       keywords: clamp(obj["keywords"]),
@@ -270,8 +301,12 @@ Respond with ONLY valid JSON (no markdown formatting, no code blocks, no explana
     if (!raw || typeof raw !== "object") return defaults;
     const obj = raw as Record<string, unknown>;
     return {
-      found: Array.isArray(obj["found"]) ? obj["found"].filter((s): s is string => typeof s === "string") : [],
-      missing: Array.isArray(obj["missing"]) ? obj["missing"].filter((s): s is string => typeof s === "string") : [],
+      found: Array.isArray(obj["found"])
+        ? obj["found"].filter((s): s is string => typeof s === "string")
+        : [],
+      missing: Array.isArray(obj["missing"])
+        ? obj["missing"].filter((s): s is string => typeof s === "string")
+        : [],
     };
   }
 
@@ -286,7 +321,7 @@ Respond with ONLY valid JSON (no markdown formatting, no code blocks, no explana
         resumeUrl: true,
         createdAt: true,
       },
-      orderBy: { createdAt: "desc" },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: 30,
     });
     return rows.reverse();

--- a/server/src/module/ats/ats.service.ts
+++ b/server/src/module/ats/ats.service.ts
@@ -274,4 +274,21 @@ Respond with ONLY valid JSON (no markdown formatting, no code blocks, no explana
       missing: Array.isArray(obj["missing"]) ? obj["missing"].filter((s): s is string => typeof s === "string") : [],
     };
   }
+
+  async getScoreHistory(studentId: number) {
+    // latest 30, reversed to chronological order
+    const rows = await prisma.atsScore.findMany({
+      where: { studentId },
+      select: {
+        id: true,
+        overallScore: true,
+        jobTitle: true,
+        resumeUrl: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+      take: 30,
+    });
+    return rows.reverse();
+  }
 }

--- a/server/src/module/ats/ats.service.ts
+++ b/server/src/module/ats/ats.service.ts
@@ -310,8 +310,8 @@ Respond with ONLY valid JSON (no markdown formatting, no code blocks, no explana
     };
   }
 
+  /** Returns the latest 30 ATS scores for a student, sorted oldest-first for charting. */
   async getScoreHistory(studentId: number) {
-    // latest 30, reversed to chronological order
     const rows = await prisma.atsScore.findMany({
       where: { studentId },
       select: {

--- a/server/src/module/ats/cover-letter.service.ts
+++ b/server/src/module/ats/cover-letter.service.ts
@@ -1,9 +1,16 @@
-import type { GenerateCoverLetterInput, UserProfile } from "./cover-letter.validation.js";
+import type {
+  GenerateCoverLetterInput,
+  UserProfile,
+} from "./cover-letter.validation.js";
 import { getProviderForService } from "../../lib/ai-provider-registry.js";
 import { logAIRequest } from "../../lib/ai-request-logger.js";
 
 export class CoverLetterService {
-  async generate(input: GenerateCoverLetterInput, profile?: UserProfile, userId?: number): Promise<string> {
+  async generate(
+    input: GenerateCoverLetterInput,
+    profile?: UserProfile,
+    userId?: number,
+  ): Promise<string> {
     const provider = getProviderForService("COVER_LETTER");
     const prompt = this.buildPrompt(input, profile);
     const response = await provider.generateText(prompt);
@@ -18,7 +25,8 @@ export class CoverLetterService {
     if (profile.bio) parts.push(`About: ${profile.bio}`);
     if (profile.college) {
       let edu = `Education: ${profile.college}`;
-      if (profile.graduationYear) edu += ` (Graduation: ${String(profile.graduationYear)})`;
+      if (profile.graduationYear)
+        edu += ` (Graduation: ${String(profile.graduationYear)})`;
       parts.push(edu);
     }
     if (profile.company) {
@@ -27,13 +35,15 @@ export class CoverLetterService {
       parts.push(work);
     }
     if (profile.location) parts.push(`Location: ${profile.location}`);
-    if (profile.skills.length > 0) parts.push(`Skills: ${profile.skills.join(", ")}`);
+    if (profile.skills.length > 0)
+      parts.push(`Skills: ${profile.skills.join(", ")}`);
 
     if (profile.projects.length > 0) {
       parts.push("Projects:");
       for (const p of profile.projects) {
         let line = `  - ${p.title}: ${p.description}`;
-        if (p.techStack.length > 0) line += ` [Tech: ${p.techStack.join(", ")}]`;
+        if (p.techStack.length > 0)
+          line += ` [Tech: ${p.techStack.join(", ")}]`;
         parts.push(line);
       }
     }
@@ -50,14 +60,31 @@ export class CoverLetterService {
     return parts.join("\n");
   }
 
-  private buildPrompt(input: GenerateCoverLetterInput, profile?: UserProfile): string {
+  private buildPrompt(
+    input: GenerateCoverLetterInput,
+    profile?: UserProfile,
+  ): string {
     const toneInstructions: Record<string, string> = {
-      professional: "Use a formal, professional tone. Be confident and direct. Avoid overly casual language.",
-      friendly: "Use a warm, approachable tone while staying professional. Show enthusiasm naturally without being overly formal.",
-      enthusiastic: "Use an energetic, passionate tone. Express genuine excitement about the role and company. Be dynamic and engaging.",
+      professional:
+        "Use a formal, professional tone. Be confident and direct. Avoid overly casual language.",
+      friendly:
+        "Use a warm, approachable tone while staying professional. Show enthusiasm naturally without being overly formal.",
+      enthusiastic:
+        "Use an energetic, passionate tone. Express genuine excitement about the role and company. Be dynamic and engaging.",
+      technical:
+        "Use precise technical language. Name specific tools, frameworks, and methodologies where relevant. Assume the reader is an engineer or technical hiring manager, not HR. Demonstrate depth of knowledge.",
+      creative:
+        "Use a distinctive, expressive voice. Lead with a hook or narrative. Show personality through word choice. Avoid corporate clichés. Make the letter memorable.",
+      formal:
+        "Use measured, precise language. Prefer structured paragraphs with clear logical progression. Avoid casual contractions. Match the tone of executive or senior-track communication.",
+      concise:
+        "Be extremely brief and direct. Use short sentences. Cut all filler. Aim for 200 words maximum. Every sentence must earn its place.",
+      startup:
+        "Use bold, mission-driven language. Show that you understand the startup's vision and want to help build something meaningful. Be direct, energetic, and avoid corporate speak.",
     };
 
-    const toneGuide = toneInstructions[input.tone] ?? toneInstructions["professional"];
+    const toneGuide =
+      toneInstructions[input.tone] ?? toneInstructions["professional"];
 
     const profileBlock = profile
       ? `\nCANDIDATE PROFILE:\n${this.buildProfileSection(profile)}\n`
@@ -77,7 +104,7 @@ ${profileBlock}${input.keySkills ? `CANDIDATE'S KEY SKILLS & EXPERIENCE:\n${inpu
 
 INSTRUCTIONS:
 - Write a 3-4 paragraph cover letter
-- ${profile ? `Use the candidate's name "${profile.name}" to sign the letter` : "End with \"Sincerely,\" followed by a blank line (the user will add their name)"}
+- ${profile ? `Use the candidate's name "${profile.name}" to sign the letter` : 'End with "Sincerely," followed by a blank line (the user will add their name)'}
 - ${input.companyName ? `Address it to the hiring team at ${input.companyName}` : "Address it to 'Dear Hiring Manager'"}
 - Open with a strong hook that shows genuine interest in the role
 - Highlight relevant skills and experience that match the job requirements

--- a/server/src/module/ats/cover-letter.validation.ts
+++ b/server/src/module/ats/cover-letter.validation.ts
@@ -5,7 +5,7 @@ export const generateCoverLetterSchema = z.object({
   jobTitle: z.string().optional(),
   companyName: z.string().optional(),
   keySkills: z.string().optional(),
-  tone: z.enum(["professional", "friendly", "enthusiastic"]),
+  tone: z.enum(["professional", "friendly", "enthusiastic", "technical", "creative", "formal", "concise", "startup"]),
   useProfile: z.boolean().optional(),
 });
 


### PR DESCRIPTION
Closes #65

## Problem
The cover letter generator had only 3 tone options: Professional, Friendly, and Enthusiastic. This limited choice made students produce similar outputs that didn't fit the culture of their target roles. A student applying to a deep-tech startup needs to sound different from one seeking a VP-track finance position.

## Changes

### `CoverLetterPage.tsx`
- Increased the tone selector from 3 to 8 options: Professional, Friendly, Enthusiastic, Technical, Creative, Formal, Concise, and Startup.
- Updated the grid to `grid-cols-4` so all 8 tones display in 2 neat rows without any empty cells.
- Added `useEffect` to automatically select the most relevant tone based on job description keywords:
  - VP / director / executive / C-suite keywords lead to Formal.
  - Engineer / developer / backend / frontend / devops keywords lead to Technical.
  - Designer / creative / brand / storytelling keywords lead to Creative.
  - Startup / founder / mission / seed / series keywords lead to Startup.
- Changed the empty state tag from "3 tones" to "8 tones."

### `cover-letter.service.ts`
- Introduced tone-specific style instructions for each new tone in `toneInstructions.` Each tone now provides detailed writing guidance to the Gemini prompt, instead of just the tone label.
- Technical: uses engineer-friendly language, mentions tech stacks, assumes a technical reader.
- Creative: showcases a unique voice, includes engaging hooks, avoids corporate clichés.
- Formal: maintains a careful tone, follows executive-level standards.
- Concise: limits to 200 words, no unnecessary words.
- Startup: adopts a bold approach, focuses on mission, avoids corporate jargon.

### `cover-letter.validation.ts`
- Updated Zod enum to include all 8 tone values.

### `client/src/lib/types.ts`
- Adjusted the `CoverLetterTone` type to include all 8 values.

## Testing
1. Open the cover letter page — 8 tone options should be visible in a clean 2×4 grid.
2. Paste a job description with "software engineer, React, Node.js" — the tone should automatically select Technical.
3. Paste a job description with "VP, executive, C-suite" — the tone should automatically select Formal.
4. Paste a job description with "startup, founder, mission" — the tone should automatically select Startup.
5. Manually select any tone and generate — the output should match the selected tone's style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Score history tracking and visualization — view your ATS score progression over time with an interactive chart
* Expanded cover letter tone options — now 8 tones available including technical, creative, formal, concise, and startup (previously 3)
* Enhanced score breakdown display with animated percentage bars for better visual progress tracking

**UI/UX Improvements**
* Refined layout and styling across ATS and cover letter pages for improved readability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/162)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->