### PR TITLE
Fix ATS analysis progress timer on re-analyze

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -220,6 +220,7 @@ export default function AtsScorePage() {
 
   const [currentStep, setCurrentStep] = useState(-1);
   const [analysisComplete, setAnalysisComplete] = useState(false);
+  const [analysisRunId, setAnalysisRunId] = useState(0);
   const [analyzedFileName, setAnalyzedFileName] = useState("");
   const [analyzedFileSize, setAnalyzedFileSize] = useState(0);
   const [emailSent, setEmailSent] = useState(false);
@@ -265,10 +266,8 @@ export default function AtsScorePage() {
   const loading = analyzeMutation.isPending;
 
   useEffect(() => {
-    if (!loading) {
-      if (currentStep >= 0) setAnalysisComplete(true);
-      return;
-    }
+    if (analysisRunId === 0 || !loading) return;
+
     setAnalysisComplete(false);
     setCurrentStep(0);
     const timers: ReturnType<typeof setTimeout>[] = [];
@@ -276,7 +275,7 @@ export default function AtsScorePage() {
       timers.push(setTimeout(() => setCurrentStep(i), i * 2200));
     }
     return () => timers.forEach(clearTimeout);
-  }, [loading]);
+  }, [analysisRunId, loading]);
 
   useEffect(() => {
     if (!file) {
@@ -341,6 +340,7 @@ export default function AtsScorePage() {
     setActiveTab("suggestions");
     setAnalysisComplete(false);
     setCurrentStep(0);
+    setAnalysisRunId((id) => id + 1);
     if (file) {
       setAnalyzedFileName(file.name);
       setAnalyzedFileSize(file.size);


### PR DESCRIPTION
## Problem

Clicking **Re-analyze** after a previous ATS result should restart the animated analysis steps. Previously, the progress animation completed instantly on re-analysis because the animation `useEffect` reacted to `loading === false` while `currentStep >= 0`, immediately setting `analysisComplete` to `true`.

## Solution

- Added an `analysisRunId` state to identify each new analysis attempt.
- Incremented `analysisRunId` inside `handleAnalyze()`.
- Refactored the progress animation `useEffect` so it only starts when a real analysis run is pending.
- Kept the existing success behavior where the final step is marked complete after the API returns.

## Testing

Verified successfully:

- `npx.cmd eslint src/module/student/ats/AtsScorePage.tsx`
- `npx.cmd tsc -b --pretty false`
- `npx.cmd vite build`

No database migration required.
No runtime behavior changes beyond fixing the re-analyze progress animation.

Fixes #137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed resume analysis progress tracking to properly restart when analyzing resumes multiple times. Step progress timers now reliably reset on each new analysis execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/176)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->