### PR TITLE
Add support for resume URL to set analyzed file name and size

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -413,6 +413,10 @@ export default function AtsScorePage() {
     if (file) {
       setAnalyzedFileName(file.name);
       setAnalyzedFileSize(file.size);
+    } else if (resumeUrl) {
+      const fileName = (resumeUrl.split("?")[0] || resumeUrl).split("/").pop() || "profile-resume.pdf";
+      setAnalyzedFileName(fileName);
+      setAnalyzedFileSize(0);
     }
     analyzeMutation.mutate();
   };
@@ -806,7 +810,7 @@ export default function AtsScorePage() {
                           {analyzedFileName}
                         </p>
                         <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mt-0.5">
-                          {(analyzedFileSize / 1024).toFixed(1)} kb · pdf
+                          {analyzedFileSize > 0 ? `${(analyzedFileSize / 1024).toFixed(1)} kb · ` : ""}pdf
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
## Resolved

1. Updated `handleAnalyze` to derive `analyzedFileName` from `resumeUrl` when `file` is unavailable.

2. Added fallback handling for missing file size data — if `analyzedFileSize` resolves to `0`, the UI now displays only `pdf` instead of `0.0 kb · pdf`.

---

## Proof
1. You can see that this is the second `reanalyse` attempt for `resumeURL` check which comes perfectly with `fileName` and `fileSize`.

## Work Done

- Improved resume analysis metadata handling for URL-based uploads.
- Fixed incorrect zero-size file display issue in the UI.

![Work Done Screenshot](https://github.com/user-attachments/assets/52635f49-2ad4-4f91-9e4c-b5471f0c9168)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume file information display on the ATS scoring page. When analyzing an existing resume, the file name is now properly derived from the resume path, and file size is only displayed when available, eliminating unnecessary zero-size indicators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/179)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->