### PR TITLE
feat: display question count and best attempt on pre-start screen

### DIFF
--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -498,7 +498,14 @@ export interface SkillTestQuestion {
 export interface SkillTestWithQuestions extends SkillTest {
   questions: SkillTestQuestion[];
   existingVerification?: VerifiedSkill | null;
-  bestAttempt?: { id: number; score: number; passed: boolean } | null;
+
+  questionsPerSession?: number;
+
+  bestAttempt?: {
+    id: number;
+    score: number;
+    passed: boolean;
+  } | null;
 }
 
 export interface SkillTestAttempt {

--- a/client/src/module/student/skill-verification/SkillTestPage.tsx
+++ b/client/src/module/student/skill-verification/SkillTestPage.tsx
@@ -380,10 +380,9 @@ export default function SkillTestPage() {
     {
       label: "Best Attempt",
       value:
-        test.bestAttempt !== null &&
-        test.bestAttempt !== undefined
-          ? `${test.bestAttempt}%`
-          : "—",
+  test.bestAttempt?.score !== undefined
+    ? `${test.bestAttempt.score}%`
+    : "—",
       icon: Trophy,
     },
   ].map((item) => (

--- a/client/src/module/student/skill-verification/SkillTestPage.tsx
+++ b/client/src/module/student/skill-verification/SkillTestPage.tsx
@@ -16,6 +16,8 @@ import {
   Camera,
   Ban,
   Shield,
+  FileText,
+  Trophy,
 } from "lucide-react";
 import api from "../../../lib/axios";
 import toast from "@/components/ui/toast";
@@ -358,33 +360,50 @@ export default function SkillTestPage() {
               </p>
             )}
 
-            <div className="grid grid-cols-2 gap-3">
-              {[
-                {
-                  label: "Time Limit",
-                  value: `${Math.ceil(test.timeLimitSecs / 60)} min`,
-                  icon: Clock,
-                },
-                {
-                  label: "Pass Score",
-                  value: `${test.passThreshold}%`,
-                  icon: CheckCircle2,
-                },
-              ].map((item) => (
-                <div
-                  key={item.label}
-                  className="bg-gray-50 dark:bg-gray-800 rounded-xl p-3 text-center"
-                >
-                  <item.icon className="w-4 h-4 text-gray-400 mx-auto mb-1" />
-                  <p className="text-sm font-bold text-gray-900 dark:text-gray-100">
-                    {item.value}
-                  </p>
-                  <p className="text-[11px] text-gray-500 dark:text-gray-400">
-                    {item.label}
-                  </p>
-                </div>
-              ))}
-            </div>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+  {[
+    {
+      label: "Time Limit",
+      value: `${Math.ceil(test.timeLimitSecs / 60)} min`,
+      icon: Clock,
+    },
+    {
+      label: "Pass Score",
+      value: `${test.passThreshold}%`,
+      icon: CheckCircle2,
+    },
+    {
+      label: "Questions",
+      value: test.questionsPerSession ?? "—",
+      icon: FileText,
+    },
+    {
+      label: "Best Attempt",
+      value:
+        test.bestAttempt !== null &&
+        test.bestAttempt !== undefined
+          ? `${test.bestAttempt}%`
+          : "—",
+      icon: Trophy,
+    },
+  ].map((item) => (
+    <div
+      key={item.label}
+      className="bg-gray-50 dark:bg-gray-800 rounded-xl p-3 text-center"
+    >
+      <item.icon className="w-4 h-4 text-gray-400 mx-auto mb-1" />
+
+      <p className="text-sm font-bold text-gray-900 dark:text-gray-100">
+        {item.value}
+      </p>
+
+      <p className="text-[11px] text-gray-500 dark:text-gray-400">
+        {item.label}
+      </p>
+    </div>
+  ))}
+</div>  
+             
 
             {test.existingVerification && (
               <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-xl p-3 text-center">


### PR DESCRIPTION
## Summary

Enhanced the skill test pre-start info section by displaying additional metadata already returned from the backend API.

### Changes Made

* Added `questionsPerSession` display
* Added `bestAttempt` display with fallback handling
* Expanded the stats grid from 2 columns to 4 columns
* Updated responsive layout for smaller devices
* Updated frontend type definitions for API response alignment

## Technical Notes

The backend already returned these fields through the existing API response. This PR focuses on rendering the available metadata within the frontend pre-start screen UI.

## Testing

* [x] Verified TypeScript compilation

* [x] Verified fallback handling for missing values
* [x] Confirmed no runtime errors

Fixes #88 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced skill test preview: expanded stats now show Time Limit, Pass Score, Questions per Session, and Best Attempt (handles no previous attempts).
  * Improved pre-start layout for clearer presentation of the four stat cards on medium+ screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/184)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->