### PR TITLE
fix: validate Google OAuth access token audience

### DIFF
--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -135,6 +135,14 @@ export class AuthService {
       name = payload.name;
       picture = payload.picture;
     } else if (data.accessToken) {
+      const tokenInfoResp = await fetch(`https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=${encodeURIComponent(data.accessToken)}`);
+      if (!tokenInfoResp.ok) {
+        throw new Error("Invalid Google token");
+      }
+      const tokenInfo = await tokenInfoResp.json() as { aud?: string; azp?: string };
+      if (tokenInfo.aud !== process.env["GOOGLE_CLIENT_ID"] && tokenInfo.azp !== process.env["GOOGLE_CLIENT_ID"]) {
+        throw new Error("Invalid Google token");
+      }
       const resp = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", {
         headers: { Authorization: `Bearer ${data.accessToken}` },
       });


### PR DESCRIPTION
The /api/auth/google endpoint accepts a Google access token and uses it to fetch user info, but it never checked whether the token was actually issued for InternHack. Any valid Google token from any app worked.

Before fetching user info, it now verifies the token's audience matches GOOGLE_CLIENT_ID via Google's tokeninfo endpoint. If the aud claim doesn't match, the request is rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes #191

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Google OAuth authentication with stricter token validation to verify token authenticity and origin before user access is granted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/192)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->