### PR TITLE
fix: add aria-label to password toggle button

### DIFF
--- a/client/src/module/auth/RegisterPage.tsx
+++ b/client/src/module/auth/RegisterPage.tsx
@@ -245,6 +245,7 @@ export default function RegisterPage() {
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
+                    aria-label={showPassword ? "Hide password" : "Show password"}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-500 hover:text-stone-900 dark:hover:text-stone-50 bg-transparent border-0 cursor-pointer"
                   >
                     {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}


### PR DESCRIPTION
Closes #22 
## Summary

Added an accessible `aria-label` to the password visibility toggle button in the authentication flow to improve screen reader support and accessibility compliance.

## Changes

* Added dynamic `aria-label` for password visibility toggle button
* Improved accessibility for screen reader users
* Ensured label updates correctly between:

  * "Show password"
  * "Hide password"