### PR TITLE
fix: exclude dodo webhook from global limiter

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -88,6 +88,7 @@ process.on("uncaughtException", (err) => {
 const app = express();
 app.set("trust proxy", 1);
 const PORT = process.env["PORT"] || 3000;
+const PAYMENT_WEBHOOK_PATH = "/api/payments/webhook";
 
 // ── Security headers ──
 app.use(
@@ -147,7 +148,7 @@ app.get("/api/health", (_req, res) => {
 });
 
 // Raw body for Dodo Payments webhook (must be BEFORE express.json())
-app.use("/api/payments/webhook", express.raw({ type: "application/json" }));
+app.use(PAYMENT_WEBHOOK_PATH, express.raw({ type: "application/json" }));
 
 app.use(express.json());
 app.use(cookieParser());
@@ -171,6 +172,7 @@ const globalLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { message: "Too many requests, please try again later" },
+  skip: (req) => req.originalUrl.split("?")[0] === PAYMENT_WEBHOOK_PATH,
 });
 app.use("/api/", globalLimiter);
 


### PR DESCRIPTION
## Summary
- Excludes the Dodo payment webhook endpoint from the general `/api/` rate limiter so provider callbacks can reach signature verification and webhook processing.

## Changes
- Added a shared `PAYMENT_WEBHOOK_PATH` constant in `server/src/index.ts`.
- Reused that constant for the Dodo raw-body parser route.
- Added an `express-rate-limit` `skip` condition for `/api/payments/webhook` while keeping the global limiter active for normal API routes.

## How to test
1. Checkout this branch: `git checkout fix/dodo-webhook-rate-limit`
2. Install server dependencies: `cd server && npm install`
3. Run the backend build: `npm run build`
4. Confirm requests to `/api/payments/webhook` are allowed to pass the global `/api/` limiter and reach the payment webhook route, while other `/api/*` routes remain rate-limited.

Validation performed locally:
- `git diff --check` passed.
- `cd server && npm run build` was attempted after generating Prisma Client. It currently fails on unrelated existing TypeScript errors in `src/module/ats/cover-letter.service.ts` involving the `generatedCoverLetter.length` Prisma field. This PR only changes `server/src/index.ts` and does not touch that module.

## Screenshots (if UI changes)
- Not applicable. This is a backend payment webhook reliability fix.

Closes #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where rate-limiting was being applied to payment webhook requests, which could cause payment processing failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/219)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->