### PR TITLE
fix: add rate limiting to OTP verify-email and resend-otp endpoints

### DIFF
--- a/server/src/module/auth/auth.routes.ts
+++ b/server/src/module/auth/auth.routes.ts
@@ -4,14 +4,16 @@ import { AuthService } from "./auth.service.js";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
 import rateLimit from "express-rate-limit";
 
-const otpRateLimit = rateLimit({
-  windowMs: 15 * 60 * 1000, 
-  max:5 , // max 5 attempts
-  message: { message: "Too many attempts, please try again after 15 minutes" },
+const createOtpRateLimit = (max: number, message: string) => rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max,
+  message: { message },
   standardHeaders: true,
   legacyHeaders: false,
-  
 });
+
+const verifyEmailRateLimit = createOtpRateLimit(5, "Too many attempts, please try again after 15 minutes");
+const resendOtpRateLimit = createOtpRateLimit(3, "Too many resend attempts, please try again after 15 minutes");
 
 const authService = new AuthService();
 const authController = new AuthController(authService);
@@ -21,8 +23,8 @@ export const authRouter = Router();
 authRouter.post("/register", (req, res) => authController.register(req, res));
 authRouter.post("/login", (req, res) => authController.login(req, res));
 authRouter.post("/google", (req, res) => authController.googleAuth(req, res));
-authRouter.post("/verify-email", otpRateLimit, (req, res) => authController.verifyEmail(req, res));
-authRouter.post("/resend-otp", otpRateLimit, (req, res) => authController.resendOtp(req, res));
+authRouter.post("/verify-email", verifyEmailRateLimit, (req, res) => authController.verifyEmail(req, res));
+authRouter.post("/resend-otp", resendOtpRateLimit, (req, res) => authController.resendOtp(req, res));
 authRouter.post("/forgot-password", (req, res) => authController.forgotPassword(req, res));
 authRouter.post("/reset-password", (req, res) => authController.resetPassword(req, res));
 authRouter.post("/logout", (req, res) => authController.logout(req, res));

--- a/server/src/module/auth/auth.routes.ts
+++ b/server/src/module/auth/auth.routes.ts
@@ -2,6 +2,16 @@ import { Router } from "express";
 import { AuthController } from "./auth.controller.js";
 import { AuthService } from "./auth.service.js";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
+import rateLimit from "express-rate-limit";
+
+const otpRateLimit = rateLimit({
+  windowMs: 15 * 60 * 1000, 
+  max:5 , // max 5 attempts
+  message: { message: "Too many attempts, please try again after 15 minutes" },
+  standardHeaders: true,
+  legacyHeaders: false,
+  
+});
 
 const authService = new AuthService();
 const authController = new AuthController(authService);
@@ -11,8 +21,8 @@ export const authRouter = Router();
 authRouter.post("/register", (req, res) => authController.register(req, res));
 authRouter.post("/login", (req, res) => authController.login(req, res));
 authRouter.post("/google", (req, res) => authController.googleAuth(req, res));
-authRouter.post("/verify-email", (req, res) => authController.verifyEmail(req, res));
-authRouter.post("/resend-otp", (req, res) => authController.resendOtp(req, res));
+authRouter.post("/verify-email", otpRateLimit, (req, res) => authController.verifyEmail(req, res));
+authRouter.post("/resend-otp", otpRateLimit, (req, res) => authController.resendOtp(req, res));
 authRouter.post("/forgot-password", (req, res) => authController.forgotPassword(req, res));
 authRouter.post("/reset-password", (req, res) => authController.resetPassword(req, res));
 authRouter.post("/logout", (req, res) => authController.logout(req, res));


### PR DESCRIPTION
Closes #209 

Added rate limiting to the email OTP verification and resend OTP endpoints to prevent brute force attacks.
Previously users could enter wrong OTP codes unlimited times with no restrictions — as shown in the before screenshot with 9+ failed attempts all returning 400 with no lockout.
Now after 5 failed attempts the endpoint returns 429 (Too Many Requests) with a clear message: "Too many attempts, please try again after 15 minutes".
Changes made:

Added express-rate-limit middleware to auth.routes.ts
Applied rate limiter to /verify-email and /resend-otp routes
Max 5 attempts per 15 minute window per IP

Before:
<img width="1919" height="913" alt="Screenshot 2026-05-15 101543" src="https://github.com/user-attachments/assets/e99bd8f8-df9e-4c9d-bc5a-69df53e3be3b" />

After:
<img width="1575" height="895" alt="Screenshot 2026-05-15 144409" src="https://github.com/user-attachments/assets/d2c5500e-644a-4bb9-9bd7-aa7c85c68f52" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate limiting applied to OTP verification and resend endpoints (5 attempts per 15-minute window).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/221)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->