### PR TITLE
fix: remove unnecessary empty space in recruiters section grid

### DIFF
--- a/client/src/module/recruiter/RecruiterLandingPage.tsx
+++ b/client/src/module/recruiter/RecruiterLandingPage.tsx
@@ -30,7 +30,7 @@ const FEATURES: {
   desc: string;
   icon: typeof Briefcase;
   stat: string;
-  span?: "single" | "double";
+  span?: "single" | "double" | "full";
 }[] = [
   {
     title: "Hiring pipelines",
@@ -68,6 +68,7 @@ const FEATURES: {
     desc: "Cycles from draft to completion, measurable goals, self and manager assessments.",
     icon: TrendingUp,
     stat: "review cycles",
+    span: "double",
   },
   {
     title: "Compliance and workflows",
@@ -80,7 +81,7 @@ const FEATURES: {
     desc: "Real-time headcount, attrition, leave patterns, attendance trends, payroll summaries.",
     icon: BarChart3,
     stat: "live dashboard",
-    span: "double",
+    span: "full",
   },
 ];
 
@@ -359,7 +360,7 @@ export default function RecruiterLandingPage() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, margin: "-60px" }}
                 transition={{ duration: 0.4 }}
-                className={f.span === "double" ? "md:col-span-2" : ""}
+                className={f.span === "full" ? "md:col-span-3" : f.span === "double" ? "md:col-span-2" : ""}
               >
                 <div className="relative h-full flex flex-col p-8 bg-white dark:bg-stone-950 hover:bg-stone-50 dark:hover:bg-stone-900 transition-colors">
                   <div className="flex items-center justify-between mb-8">


### PR DESCRIPTION
## Changes made

- Fixed visually empty gaps in the recruiters feature grid layout
- Updated card span configuration for better grid balance
- Changed "Performance reviews" card to use double span
- Updated "HR analytics" from double span to full width
- Added support for full-span layout handling
- Preserved responsiveness and existing UI styling

## Before
<img width="1441" height="967" alt="image" src="https://github.com/user-attachments/assets/6ae78e26-894d-4e4c-aa99-521ea22cf171" />



## After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/55416a54-977e-47eb-a1b4-b6c29becfd1f" />


Fixes #208 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the feature card layout on the recruiter landing page for improved visual hierarchy and spacing.
  * Performance reviews and HR analytics features now display with enhanced prominence in the grid.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/228)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->