### PR TITLE
feat: generate personalized PDF certificate on roadmap completion

### DIFF
--- a/server/src/module/roadmap/roadmap.controller.ts
+++ b/server/src/module/roadmap/roadmap.controller.ts
@@ -30,7 +30,8 @@ import {
   generateAiRoadmap,
   slugifyRoadmap,
 } from "./roadmap.ai.service.js";
-import { generateRoadmapPdf } from "./roadmap.pdf.js";
+
+import { generateRoadmapPdf, generateCertificatePdf } from "./roadmap.pdf.js";
 import { sendEmail } from "../../utils/email.utils.js";
 import { roadmapWelcomeEmailHtml } from "../../utils/email-templates.js";
 
@@ -287,7 +288,8 @@ export async function patchTopicProgress(req: Request, res: Response, next: Next
       return;
     }
 
-    const progress = await updateTopicProgress({
+
+  const { progress, roadmapCompleted } = await updateTopicProgress({
       userId: req.user!.id,
       enrollmentId: params.data.id,
       topicId: params.data.topicId,
@@ -295,7 +297,9 @@ export async function patchTopicProgress(req: Request, res: Response, next: Next
       bookmarked: body.data.bookmarked,
       notes: body.data.notes,
     });
-    res.json({ progress });
+    res.json({ progress, roadmapCompleted });
+
+
   } catch (err) {
     if (typeof err === "object" && err && "status" in err) {
       const e = err as { status: number; message: string };
@@ -645,3 +649,62 @@ export async function postAiGenerate(req: Request, res: Response, next: NextFunc
     next(err);
   }
 }
+
+
+
+
+export async function downloadCertificate(req: Request, res: Response, next: NextFunction) {
+  try {
+    const params = enrollmentIdParam.safeParse(req.params);
+    if (!params.success) {
+      validationError(res, params.error.flatten().fieldErrors);
+      return;
+    }
+
+    const themeQuery = pdfThemeQuery.safeParse(req.query);
+    const theme = themeQuery.success ? themeQuery.data.theme : "light";
+
+    const enrollment = await getEnrollmentForUser({
+      userId: req.user!.id,
+      enrollmentId: params.data.id,
+    });
+    if (!enrollment) {
+      res.status(404).json({ message: "Enrollment not found" });
+      return;
+    }
+
+    // Guard: only allow download if 100% complete
+    const summary = summarizeProgress(enrollment);
+    if (summary.percentComplete < 100) {
+      res.status(403).json({
+        message: "Complete all topics to download your certificate.",
+        percentComplete: summary.percentComplete,
+      });
+      return;
+    }
+
+    const userRecord = await prisma.user.findUnique({
+      where: { id: req.user!.id },
+      select: { name: true },
+    });
+
+    const pdfBuffer = await generateCertificatePdf({
+      theme,
+      userName: userRecord?.name ?? "Learner",
+      roadmapTitle: enrollment.roadmap.title,
+      completedAt: new Date(),
+    });
+
+    const suffix = theme === "dark" ? "-dark" : "";
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${enrollment.roadmap.slug}-certificate${suffix}.pdf"`,
+    );
+    res.send(pdfBuffer);
+  } catch (err) {
+    next(err);
+  }
+}
+
+

--- a/server/src/module/roadmap/roadmap.controller.ts
+++ b/server/src/module/roadmap/roadmap.controller.ts
@@ -688,12 +688,22 @@ export async function downloadCertificate(req: Request, res: Response, next: Nex
       select: { name: true },
     });
 
+
+
+    const completedTopics = enrollment.topicProgress
+      .filter((p) => p.status === "COMPLETED" && p.completedAt)
+      .sort((a, b) => b.completedAt!.getTime() - a.completedAt!.getTime());
+    const actualCompletedAt = completedTopics[0]?.completedAt ?? new Date();
+
     const pdfBuffer = await generateCertificatePdf({
       theme,
       userName: userRecord?.name ?? "Learner",
       roadmapTitle: enrollment.roadmap.title,
-      completedAt: new Date(),
+      completedAt: actualCompletedAt,
     });
+
+
+
 
     const suffix = theme === "dark" ? "-dark" : "";
     res.setHeader("Content-Type", "application/pdf");

--- a/server/src/module/roadmap/roadmap.pdf.ts
+++ b/server/src/module/roadmap/roadmap.pdf.ts
@@ -935,3 +935,146 @@ function expLabel(e: string): string {
     default: return e;
   }
 }
+
+
+
+
+// ── Completion Certificate ────────────────────────────────────────────────────
+export interface CertificateInput {
+  theme?: PdfTheme;
+  userName: string;
+  roadmapTitle: string;
+  completedAt: Date;
+}
+
+export async function generateCertificatePdf(input: CertificateInput): Promise<Buffer> {
+  COLORS = input.theme === "dark" ? DARK_COLORS : LIGHT_COLORS;
+
+  return new Promise((resolve, reject) => {
+    const W = 841.89; // A4 landscape width
+    const H = 595.28; // A4 landscape height
+    const cx = W / 2;
+
+    const doc = new PDFDocument({
+      size: "A4",
+      layout: "landscape",
+      margin: MARGIN,
+      bufferPages: true,
+      info: {
+        Title: `Certificate of Completion – ${input.roadmapTitle}`,
+        Author: "InternHack",
+        Subject: "Roadmap completion certificate",
+      },
+    });
+
+    if (input.theme === "dark") {
+      doc.save();
+      doc.rect(0, 0, W, H).fill(DARK_COLORS.pageBg);
+      doc.restore();
+    }
+
+    const chunks: Buffer[] = [];
+    doc.on("data", (c: Buffer) => chunks.push(c));
+    doc.on("end", () => resolve(Buffer.concat(chunks)));
+    doc.on("error", reject);
+
+    // Outer border
+    doc.rect(24, 24, W - 48, H - 48).lineWidth(3).stroke(COLORS.accent);
+    doc.rect(32, 32, W - 64, H - 64).lineWidth(1).stroke(COLORS.accentSoft);
+
+    // Top band
+    doc.rect(0, 0, W, 90).fill(COLORS.coverBand);
+
+    // Platform name in band
+    doc.fillColor(COLORS.accentSoft).fontSize(11).font("Helvetica-Bold");
+    doc.text("INTERNHACK", MARGIN, 28, {
+      characterSpacing: 3,
+      width: W - MARGIN * 2,
+      align: "center",
+    });
+    doc.fillColor("#ffffff").fontSize(9).font("Helvetica");
+    doc.text("internhack.xyz  ·  Certificate of Completion", MARGIN, 48, {
+      width: W - MARGIN * 2,
+      align: "center",
+    });
+
+    // Title
+    doc.fillColor(COLORS.ink).fontSize(34).font("Helvetica-Bold");
+    doc.text("Certificate of Completion", MARGIN, 120, {
+      width: W - MARGIN * 2,
+      align: "center",
+    });
+
+    // Accent rule
+    doc.rect(cx - 60, 166, 120, 2).fill(COLORS.accent);
+
+    // "This certifies that"
+    doc.fillColor(COLORS.mute).fontSize(12).font("Helvetica");
+    doc.text("This certifies that", MARGIN, 185, {
+      width: W - MARGIN * 2,
+      align: "center",
+    });
+
+    // User name
+    doc.fillColor(COLORS.ink).fontSize(30).font("Helvetica-Bold");
+    doc.text(input.userName, MARGIN, 210, {
+      width: W - MARGIN * 2,
+      align: "center",
+    });
+
+    // Underline the name
+    const nameWidth = Math.min(
+      doc.widthOfString(input.userName, { fontSize: 30 }),
+      380,
+    );
+    doc.rect(cx - nameWidth / 2, 250, nameWidth, 1).fill(COLORS.accent);
+
+    // Body
+    doc.fillColor(COLORS.mute).fontSize(12).font("Helvetica");
+    doc.text("has successfully completed all topics in", MARGIN, 265, {
+      width: W - MARGIN * 2,
+      align: "center",
+    });
+
+    // Roadmap title
+    doc.fillColor(COLORS.accent).fontSize(20).font("Helvetica-Bold");
+    doc.text(input.roadmapTitle, MARGIN, 292, {
+      width: W - MARGIN * 2,
+      align: "center",
+    });
+
+    // Completion date
+    const dateStr = input.completedAt.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+    doc.fillColor(COLORS.faint).fontSize(11).font("Helvetica");
+    doc.text(`Completed on ${dateStr}`, MARGIN, 332, {
+      width: W - MARGIN * 2,
+      align: "center",
+    });
+
+    // Signature line
+    doc.rect(cx - 80, H - 115, 160, 0.5).fill(COLORS.faintest);
+    doc.fillColor(COLORS.faint).fontSize(9).font("Helvetica");
+    doc.text("InternHack Team", MARGIN, H - 100, {
+      width: W - MARGIN * 2,
+      align: "center",
+    });
+
+    // Bottom footer rule
+    doc.rect(MARGIN, H - 60, W - MARGIN * 2, 0.5).fill(COLORS.faintest);
+    doc.fillColor(COLORS.faint).fontSize(7.5).font("Helvetica");
+    doc.text(
+      `INTERNHACK · CERTIFICATE OF COMPLETION · ${input.roadmapTitle.toUpperCase()}`,
+      MARGIN,
+      H - 46,
+      { width: W - MARGIN * 2, align: "center", characterSpacing: 1 },
+    );
+
+    doc.end();
+  });
+}
+
+

--- a/server/src/module/roadmap/roadmap.pdf.ts
+++ b/server/src/module/roadmap/roadmap.pdf.ts
@@ -948,7 +948,7 @@ export interface CertificateInput {
 }
 
 export async function generateCertificatePdf(input: CertificateInput): Promise<Buffer> {
-  COLORS = input.theme === "dark" ? DARK_COLORS : LIGHT_COLORS;
+  const colors = input.theme === "dark" ? DARK_COLORS : LIGHT_COLORS;
 
   return new Promise((resolve, reject) => {
     const W = 841.89; // A4 landscape width
@@ -979,14 +979,14 @@ export async function generateCertificatePdf(input: CertificateInput): Promise<B
     doc.on("error", reject);
 
     // Outer border
-    doc.rect(24, 24, W - 48, H - 48).lineWidth(3).stroke(COLORS.accent);
-    doc.rect(32, 32, W - 64, H - 64).lineWidth(1).stroke(COLORS.accentSoft);
+    doc.rect(24, 24, W - 48, H - 48).lineWidth(3).stroke(colors.accent);
+    doc.rect(32, 32, W - 64, H - 64).lineWidth(1).stroke(colors.accentSoft);
 
     // Top band
-    doc.rect(0, 0, W, 90).fill(COLORS.coverBand);
+    doc.rect(0, 0, W, 90).fill(colors.coverBand);
 
     // Platform name in band
-    doc.fillColor(COLORS.accentSoft).fontSize(11).font("Helvetica-Bold");
+    doc.fillColor(colors.accentSoft).fontSize(11).font("Helvetica-Bold");
     doc.text("INTERNHACK", MARGIN, 28, {
       characterSpacing: 3,
       width: W - MARGIN * 2,
@@ -999,24 +999,24 @@ export async function generateCertificatePdf(input: CertificateInput): Promise<B
     });
 
     // Title
-    doc.fillColor(COLORS.ink).fontSize(34).font("Helvetica-Bold");
+    doc.fillColor(colors.ink).fontSize(34).font("Helvetica-Bold");
     doc.text("Certificate of Completion", MARGIN, 120, {
       width: W - MARGIN * 2,
       align: "center",
     });
 
     // Accent rule
-    doc.rect(cx - 60, 166, 120, 2).fill(COLORS.accent);
+    doc.rect(cx - 60, 166, 120, 2).fill(colors.accent);
 
     // "This certifies that"
-    doc.fillColor(COLORS.mute).fontSize(12).font("Helvetica");
+    doc.fillColor(colors.mute).fontSize(12).font("Helvetica");
     doc.text("This certifies that", MARGIN, 185, {
       width: W - MARGIN * 2,
       align: "center",
     });
 
     // User name
-    doc.fillColor(COLORS.ink).fontSize(30).font("Helvetica-Bold");
+    doc.fillColor(colors.ink).fontSize(30).font("Helvetica-Bold");
     doc.text(input.userName, MARGIN, 210, {
       width: W - MARGIN * 2,
       align: "center",
@@ -1027,17 +1027,17 @@ export async function generateCertificatePdf(input: CertificateInput): Promise<B
       doc.widthOfString(input.userName, { fontSize: 30 }),
       380,
     );
-    doc.rect(cx - nameWidth / 2, 250, nameWidth, 1).fill(COLORS.accent);
+    doc.rect(cx - nameWidth / 2, 250, nameWidth, 1).fill(colors.accent);
 
     // Body
-    doc.fillColor(COLORS.mute).fontSize(12).font("Helvetica");
+    doc.fillColor(colors.mute).fontSize(12).font("Helvetica");
     doc.text("has successfully completed all topics in", MARGIN, 265, {
       width: W - MARGIN * 2,
       align: "center",
     });
 
     // Roadmap title
-    doc.fillColor(COLORS.accent).fontSize(20).font("Helvetica-Bold");
+    doc.fillColor(colors.accent).fontSize(20).font("Helvetica-Bold");
     doc.text(input.roadmapTitle, MARGIN, 292, {
       width: W - MARGIN * 2,
       align: "center",
@@ -1049,23 +1049,23 @@ export async function generateCertificatePdf(input: CertificateInput): Promise<B
       month: "long",
       day: "numeric",
     });
-    doc.fillColor(COLORS.faint).fontSize(11).font("Helvetica");
+    doc.fillColor(colors.faint).fontSize(11).font("Helvetica");
     doc.text(`Completed on ${dateStr}`, MARGIN, 332, {
       width: W - MARGIN * 2,
       align: "center",
     });
 
     // Signature line
-    doc.rect(cx - 80, H - 115, 160, 0.5).fill(COLORS.faintest);
-    doc.fillColor(COLORS.faint).fontSize(9).font("Helvetica");
+    doc.rect(cx - 80, H - 115, 160, 0.5).fill(colors.faintest);
+    doc.fillColor(colors.faint).fontSize(9).font("Helvetica");
     doc.text("InternHack Team", MARGIN, H - 100, {
       width: W - MARGIN * 2,
       align: "center",
     });
 
     // Bottom footer rule
-    doc.rect(MARGIN, H - 60, W - MARGIN * 2, 0.5).fill(COLORS.faintest);
-    doc.fillColor(COLORS.faint).fontSize(7.5).font("Helvetica");
+    doc.rect(MARGIN, H - 60, W - MARGIN * 2, 0.5).fill(colors.faintest);
+    doc.fillColor(colors.faint).fontSize(7.5).font("Helvetica");
     doc.text(
       `INTERNHACK · CERTIFICATE OF COMPLETION · ${input.roadmapTitle.toUpperCase()}`,
       MARGIN,

--- a/server/src/module/roadmap/roadmap.routes.ts
+++ b/server/src/module/roadmap/roadmap.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { authMiddleware, optionalAuthMiddleware } from "../../middleware/auth.middleware.js";
 import { aiRoadmapLimiter } from "../../middleware/rate-limit.middleware.js";
 import {
+  downloadCertificate,
   downloadPdf,
   enroll,
   getMyEnrollment,
@@ -22,7 +23,7 @@ roadmapRouter.post("/ai/generate", authMiddleware, aiRoadmapLimiter, postAiGener
 // ── Authenticated "me" routes (also BEFORE /:slug) ────────────────────────
 roadmapRouter.get("/me/enrollments", authMiddleware, getMyEnrollments);
 roadmapRouter.get("/me/enrollments/:id", authMiddleware, getMyEnrollment);
-roadmapRouter.get("/me/enrollments/:id/pdf", authMiddleware, downloadPdf);
+roadmapRouter.get("/me/enrollments/:id/certificate", authMiddleware, downloadCertificate);
 roadmapRouter.patch(
   "/me/enrollments/:id/topics/:topicId",
   authMiddleware,
@@ -42,3 +43,6 @@ roadmapRouter.get("/:slug/topics/:topicSlug", optionalAuthMiddleware, getTopic);
 
 // ── Auth: enrollment ──────────────────────────────────────────────────────
 roadmapRouter.post("/:slug/enroll", authMiddleware, enroll);
+
+
+

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -341,12 +341,30 @@ export async function updateTopicProgress(args: {
     create.notes = args.notes;
   }
 
-  return prisma.roadmapTopicProgress.upsert({
+
+  const progress = await prisma.roadmapTopicProgress.upsert({
     where: { enrollmentId_topicId: { enrollmentId: enrollment.id, topicId: topic.id } },
     update: data,
     create,
   });
+
+  // Check if all topics are now complete
+  let roadmapCompleted = false;
+  if (args.status === "COMPLETED") {
+    const fullEnrollment = await getEnrollmentForUser({
+      userId: args.userId,
+      enrollmentId: args.enrollmentId,
+    });
+    if (fullEnrollment) {
+      const summary = summarizeProgress(fullEnrollment);
+      roadmapCompleted = summary.percentComplete === 100;
+    }
+  }
+
+  return { progress, roadmapCompleted };
 }
+
+
 
 export async function recomputePace(args: {
   userId: number;


### PR DESCRIPTION
## Problem
No way to recognize users who complete 100% of roadmap topics.

## Solution
- Added `generateCertificatePdf()` to `roadmap.pdf.ts` using existing pdfkit library
- Added `downloadCertificate` controller that verifies 100% completion before serving PDF
- Added `/me/enrollments/:id/certificate` route (supports `?theme=dark`)
- `updateTopicProgress` now returns `roadmapCompleted: true` when last topic is marked done

## Endpoints
`GET /api/roadmap/me/enrollments/:id/certificate`
- Returns 403 if roadmap not 100% complete
- Returns PDF certificate with user name, roadmap title, completion date

Closes #96 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now download a certificate when completing a roadmap
  * Progress tracking now indicates roadmap completion status

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/229)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->