### PR TITLE
feat(roadmap): implement in-memory caching for roadmap detail API

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -35,6 +35,7 @@
         "jsonwebtoken": "^9.0.3",
         "morgan": "^1.10.1",
         "multer": "^2.0.2",
+        "node-cache": "^5.1.2",
         "node-cron": "^4.2.1",
         "nodemailer": "^8.0.2",
         "openai": "^6.27.0",
@@ -5666,6 +5667,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/node-cron": {

--- a/server/package.json
+++ b/server/package.json
@@ -43,6 +43,7 @@
     "jsonwebtoken": "^9.0.3",
     "morgan": "^1.10.1",
     "multer": "^2.0.2",
+    "node-cache": "^5.1.2",
     "node-cron": "^4.2.1",
     "nodemailer": "^8.0.2",
     "openai": "^6.27.0",

--- a/server/src/middleware/cache.middleware.ts
+++ b/server/src/middleware/cache.middleware.ts
@@ -1,0 +1,39 @@
+import type { Request, Response, NextFunction } from "express";
+import NodeCache from "node-cache";
+
+export const appCache = new NodeCache({ stdTTL: 300, checkperiod: 60 });
+
+export const cacheMiddleware = (ttl: number = 300, keyPrefix: string = "cache") => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (req.method !== "GET") {
+      return next();
+    }
+    const key = `${keyPrefix}:${req.originalUrl || req.url}`;
+    const cachedResponse = appCache.get(key);
+
+    if (cachedResponse) {
+      res.setHeader("X-Cache", "HIT");
+      return res.json(cachedResponse);
+    }
+
+    const originalJson = res.json;
+    res.json = function (data) {
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        appCache.set(key, data, ttl);
+      }
+      res.setHeader("X-Cache", "MISS");
+      return originalJson.call(this, data);
+    };
+
+    next();
+  };
+};
+
+export const clearCache = (pattern: string) => {
+  const keys = appCache.keys();
+  const matchedKeys = keys.filter((key) => key.startsWith(pattern));
+  if (matchedKeys.length > 0) {
+    appCache.del(matchedKeys);
+    console.log(`[Cache] Cleared ${matchedKeys.length} keys matching: ${pattern}`);
+  }
+};

--- a/server/src/middleware/cache.middleware.ts
+++ b/server/src/middleware/cache.middleware.ts
@@ -11,7 +11,7 @@ export const cacheMiddleware = (ttl: number = 300, keyPrefix: string = "cache") 
     const key = `${keyPrefix}:${req.originalUrl || req.url}`;
     const cachedResponse = appCache.get(key);
 
-    if (cachedResponse) {
+    if (cachedResponse !== undefined) {
       res.setHeader("X-Cache", "HIT");
       return res.json(cachedResponse);
     }

--- a/server/src/module/roadmap/roadmap.routes.ts
+++ b/server/src/module/roadmap/roadmap.routes.ts
@@ -18,10 +18,7 @@ import {
 
 export const roadmapRouter = Router();
 
-// ── AI generation (registered BEFORE /:slug to avoid conflicts) ──────────
 roadmapRouter.post("/ai/generate", authMiddleware, aiRoadmapLimiter, postAiGenerate);
-
-// ── Authenticated "me" routes (also BEFORE /:slug) ────────────────────────
 roadmapRouter.get("/me/enrollments", authMiddleware, getMyEnrollments);
 roadmapRouter.get("/me/enrollments/:id", authMiddleware, getMyEnrollment);
 roadmapRouter.get("/me/enrollments/:id/certificate", authMiddleware, downloadCertificate);
@@ -36,10 +33,7 @@ roadmapRouter.post(
   postRecomputePace,
 );
 
-// ── Public ────────────────────────────────────────────────────────────────
 roadmapRouter.get("/", getRoadmaps);
 roadmapRouter.get("/:slug", optionalAuthMiddleware, cacheMiddleware(600, "roadmap"), getRoadmap);
 roadmapRouter.get("/:slug/topics/:topicSlug", optionalAuthMiddleware, getTopic);
-
-// ── Auth: enrollment ──────────────────────────────────────────────────────
 roadmapRouter.post("/:slug/enroll", authMiddleware, enroll);

--- a/server/src/module/roadmap/roadmap.routes.ts
+++ b/server/src/module/roadmap/roadmap.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authMiddleware, optionalAuthMiddleware } from "../../middleware/auth.middleware.js";
 import { aiRoadmapLimiter } from "../../middleware/rate-limit.middleware.js";
+import { cacheMiddleware } from "../../middleware/cache.middleware.js";
 import {
   downloadCertificate,
   downloadPdf,
@@ -37,12 +38,8 @@ roadmapRouter.post(
 
 // ── Public ────────────────────────────────────────────────────────────────
 roadmapRouter.get("/", getRoadmaps);
-roadmapRouter.get("/:slug", optionalAuthMiddleware, getRoadmap);
+roadmapRouter.get("/:slug", optionalAuthMiddleware, cacheMiddleware(600, "roadmap"), getRoadmap);
 roadmapRouter.get("/:slug/topics/:topicSlug", optionalAuthMiddleware, getTopic);
-
 
 // ── Auth: enrollment ──────────────────────────────────────────────────────
 roadmapRouter.post("/:slug/enroll", authMiddleware, enroll);
-
-
-


### PR DESCRIPTION
Title: feat(roadmap): implement server-side caching for roadmap detail API (#94)

Description: This PR adds server-side caching for the GET /roadmaps/:slug endpoint to optimize performance and reduce unnecessary database load for popular roadmaps.

Fixes: #94

Implemented Technical Suggestions:

✅ In-memory store: Implemented a robust caching layer using node-cache.
✅ Slug-based strategy: Caching is keyed by the roadmap slug to ensure high hit rates for frequently accessed paths.
✅ Custom TTL: Set an appropriate TTL (10 minutes) to balance freshness and performance.
✅ Middleware Implementation: Replicated the "NestJS Interceptor" pattern using a custom Express middleware to intercept and cache the roadmap detail responses.
Key Features:

Added X-Cache: HIT/MISS headers for transparency and monitoring.
Included a clearCache utility for future manual invalidations on roadmap updates or deletions.
Refactored roadmap.routes.ts for a cleaner, more maintainable structure.
Verification:

Confirmed that subsequent requests return X-Cache: HIT and bypass the database layer.