### PR TITLE
fix : resolve  play button issue in algorithm visualizers

### DIFF
--- a/client/src/components/dsa-theory/algo/StepPlayer.tsx
+++ b/client/src/components/dsa-theory/algo/StepPlayer.tsx
@@ -29,7 +29,7 @@ export function useStepPlayer<T>(frames: T[], speedMs = 700): StepPlayer<T> {
   }, [frames]);
 
   useEffect(() => {
-    if (!isPlaying) return;
+    if (!isPlaying) return;``
     const t = setInterval(() => {
       setIndex((i) => {
         const max = framesRef.current.length - 1;

--- a/client/src/module/student/learn/dsa-foundations/lessons/L4_BFS.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L4_BFS.tsx
@@ -263,7 +263,7 @@ function QueueViz({ items }: { items: string[] }) {
 function VisualizeTab() {
   const [inputStr, setInputStr] = useState("A-B, A-C, B-D, C-D, C-E, D-F, E-F, F-G");
   const [source, setSource] = useState("A");
-  const parsed = parseEdgeList(inputStr);
+  const parsed = useMemo(() => parseEdgeList(inputStr), [inputStr]);
   const ids = parsed?.nodeIds ?? [];
   const edges = parsed?.edges ?? [];
 

--- a/client/src/module/student/learn/dsa-foundations/lessons/L4_BellmanFord.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L4_BellmanFord.tsx
@@ -307,7 +307,7 @@ function EdgeTable({ edges, rowStates }: { edges: { from: string; to: string; w:
 function VisualizeTab() {
   const [inputStr, setInputStr] = useState("A>B:6, A>C:7, B>C:8, B>D:5, B>E:-4, C>D:-3, C>E:9, D>B:-2, E>D:7, E>A:2");
   const [source, setSource] = useState("A");
-  const parsed = parseBF(inputStr);
+  const parsed = useMemo(() => parseBF(inputStr), [inputStr]);
   const ids = parsed?.ids ?? [];
   const edges = parsed?.edges ?? [];
 

--- a/client/src/module/student/learn/dsa-foundations/lessons/L4_DFS.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L4_DFS.tsx
@@ -316,7 +316,7 @@ function StackViz({ items }: { items: string[] }) {
 function VisualizeTab() {
   const [inputStr, setInputStr] = useState("A>B, A>C, B>D, C>D, D>E, E>B, C>E");
   const [source, setSource] = useState("A");
-  const parsed = parseEdgeList(inputStr);
+  const parsed = useMemo(() => parseEdgeList(inputStr), [inputStr]);
   const ids = parsed?.nodeIds ?? [];
   const rawEdges = parsed?.edges ?? [];
 

--- a/client/src/module/student/learn/dsa-foundations/lessons/L4_Dijkstra.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L4_Dijkstra.tsx
@@ -255,7 +255,7 @@ function PQPanel({ items }: { items: { id: string; d: number }[] }) {
 function VisualizeTab() {
   const [inputStr, setInputStr] = useState("A-B:4, A-C:2, B-C:1, B-D:5, C-D:8, C-E:10, D-E:2");
   const [source, setSource] = useState("A");
-  const parsed = parseWeighted(inputStr);
+  const parsed = useMemo(() => parseWeighted(inputStr), [inputStr]);
   const ids = parsed?.ids ?? [];
   const edges = parsed?.edges ?? [];
 

--- a/client/src/module/student/learn/dsa-foundations/lessons/L4_GraphRepresentation.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L4_GraphRepresentation.tsx
@@ -226,7 +226,7 @@ function GraphDiagram({
 function VisualizeTab() {
   const [inputStr, setInputStr] = useState(DEFAULT_GRAPH);
   const [directed, setDirected] = useState(false);
-  const parsed = parseEdgeList(inputStr);
+  const parsed = useMemo(() => parseEdgeList(inputStr), [inputStr]);
 
   const { ids, edges, pos, adj, matrix } = useMemo(() => {
     const p = parsed ?? { nodeIds: [], edges: [] };

--- a/client/src/module/student/learn/dsa-foundations/lessons/L4_MST.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L4_MST.tsx
@@ -475,7 +475,7 @@ function VisualizeTab() {
   const [mode, setMode] = useState<"kruskal" | "prim">("kruskal");
   const [inputStr, setInputStr] = useState("A-B:4, A-C:3, B-C:1, B-D:2, C-D:4, C-E:5, D-E:6");
   const [start, setStart] = useState("A");
-  const parsed = parseWeighted(inputStr);
+  const parsed = useMemo(() => parseWeighted(inputStr), [inputStr]);
   const ids = parsed?.ids ?? [];
   const edges = parsed?.edges ?? [];
 

--- a/client/src/module/student/learn/dsa-foundations/lessons/L4_TopologicalSort.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L4_TopologicalSort.tsx
@@ -492,7 +492,7 @@ function DFSTopoViz({ ids, edges, inputStr, setInputStr }: {
 function VisualizeTab() {
   const [mode, setMode] = useState<"kahn" | "dfs">("kahn");
   const [inputStr, setInputStr] = useState("A>B, A>C, B>D, C>D, D>E, C>E");
-  const parsed = parseDirected(inputStr);
+  const parsed = useMemo(() => parseDirected(inputStr), [inputStr]);
   const ids = parsed?.ids ?? [];
   const edges = parsed?.edges ?? [];
 

--- a/client/src/module/student/learn/dsa-foundations/lessons/L5_BinarySearch.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L5_BinarySearch.tsx
@@ -323,8 +323,14 @@ function VisualizeTab() {
   const [variant, setVariant] = useState<Variant>("basic");
   const [inputStr, setInputStr] = useState("1, 3, 5, 7, 9, 11, 13, 15 | 9");
 
-  const parsed = parseInputs(inputStr) ?? { arr: [1, 3, 5, 7, 9, 11, 13, 15], target: 9 };
-  const arr = variant === "rotated" ? parsed.arr : [...parsed.arr].sort((a, b) => a - b);
+  const parsed = useMemo(
+    () => parseInputs(inputStr) ?? { arr: [1, 3, 5, 7, 9, 11, 13, 15], target: 9 },
+    [inputStr],
+  );
+  const arr = useMemo(
+    () => (variant === "rotated" ? parsed.arr : [...parsed.arr].sort((a, b) => a - b)),
+    [variant, parsed.arr],
+  );
 
   const frames = useMemo(() => {
     if (variant === "basic") return buildBasic(arr, parsed.target);

--- a/client/src/module/student/learn/dsa-foundations/lessons/L5_BubbleSelection.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L5_BubbleSelection.tsx
@@ -363,7 +363,7 @@ function parseArr(s: string): number[] | null {
 function VisualizeTab() {
   const [algo, setAlgo] = useState<"bubble" | "selection">("bubble");
   const [inputStr, setInputStr] = useState("5, 2, 8, 1, 9, 3");
-  const parsed = parseArr(inputStr) ?? [5, 2, 8, 1, 9, 3];
+  const parsed = useMemo(() => parseArr(inputStr) ?? [5, 2, 8, 1, 9, 3], [inputStr]);
 
   const frames = useMemo(
     () => (algo === "bubble" ? buildBubbleFrames(parsed) : buildSelectionFrames(parsed)),

--- a/client/src/module/student/learn/dsa-foundations/lessons/L5_Insertion.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L5_Insertion.tsx
@@ -285,7 +285,7 @@ function FloatingKey({ frame }: { frame: Frame | undefined }) {
 
 function VisualizeTab() {
   const [inputStr, setInputStr] = useState("5, 2, 4, 6, 1, 3");
-  const parsed = parseArr(inputStr) ?? [5, 2, 4, 6, 1, 3];
+  const parsed = useMemo(() => parseArr(inputStr) ?? [5, 2, 4, 6, 1, 3], [inputStr]);
 
   const frames = useMemo(() => buildFrames(parsed), [parsed]);
   const player = useStepPlayer(frames);

--- a/client/src/module/student/learn/dsa-foundations/lessons/L5_Merge.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L5_Merge.tsx
@@ -369,7 +369,7 @@ function parseArr(s: string): number[] | null {
 
 function VisualizeTab() {
   const [inputStr, setInputStr] = useState("5, 2, 4, 6, 1, 3, 7, 8");
-  const parsed = parseArr(inputStr) ?? [5, 2, 4, 6, 1, 3, 7, 8];
+  const parsed = useMemo(() => parseArr(inputStr) ?? [5, 2, 4, 6, 1, 3, 7, 8], [inputStr]);
 
   const frames = useMemo(() => buildFrames(parsed), [parsed]);
   const player = useStepPlayer(frames);

--- a/client/src/module/student/learn/dsa-foundations/lessons/L5_Quick.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L5_Quick.tsx
@@ -347,7 +347,7 @@ function VisualizeTab() {
   const [inputStr, setInputStr] = useState("7, 2, 1, 8, 6, 3, 5, 4");
   const [strategy, setStrategy] = useState<PivotStrategy>("last");
 
-  const parsed = parseArr(inputStr) ?? [7, 2, 1, 8, 6, 3, 5, 4];
+  const parsed = useMemo(() => parseArr(inputStr) ?? [7, 2, 1, 8, 6, 3, 5, 4], [inputStr]);
   const frames = useMemo(() => buildFrames(parsed, strategy), [parsed, strategy]);
   const player = useStepPlayer(frames);
   const frame = player.current;


### PR DESCRIPTION
Fix: Play button not working in Graph and Sorting visualizations
Root Cause

The affected visualizers recreated parsed input objects and derived frame data on every render. During playback, state updates triggered rerenders which regenerated frames and unintentionally reset the player state.

Changes Made
Memoized parsed graph/sorting input data using useMemo

Stabilized frame dependencies across affected visualizers
Memoized derived sorted array in Binary Search to prevent unnecessary frame regeneration
Validation
Tested Graph visualizers
Tested Sorting & Searching visualizers
Confirmed playback now advances correctly
No TypeScript errors introduced

<img width="1093" height="565" alt="Screenshot 2026-05-16 102643" src="https://github.com/user-attachments/assets/8bf4c69c-39f0-4db6-9700-84cf990115cd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized algorithm visualization lessons across multiple topics including graph traversal, shortest path finding, minimum spanning trees, and sorting algorithms. Computational efficiency improvements reduce unnecessary recalculations during interactive use, enhancing overall responsiveness when exploring visualizations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->