### PR TITLE
fix: play button in graph and sorting visualizations

### DIFF
--- a/client/src/components/dsa-theory/algo/StepPlayer.tsx
+++ b/client/src/components/dsa-theory/algo/StepPlayer.tsx
@@ -24,9 +24,9 @@ export function useStepPlayer<T>(frames: T[], speedMs = 700): StepPlayer<T> {
 
   // Reset when frames change
   useEffect(() => {
-    setIndex(0);
-    setIsPlaying(false);
-  }, [frames]);
+  setIndex(0);
+  setIsPlaying(false);
+}, [frames.length]);
 
   useEffect(() => {
     if (!isPlaying) return;


### PR DESCRIPTION
## Problem
The play button in Algorithm Visualization (Graphs and 
Sorting & Searching sections) was not working. Clicking 
play would immediately reset due to a continuous re-render loop.

## Root Cause
In `StepPlayer.tsx`, the `useEffect` that resets the player 
used `[frames]` as its dependency. Since `frames` is a new 
array reference on every render, it kept resetting 
`isPlaying` to `false` immediately after play was clicked.

## Fix
Changed the dependency from `[frames]` to `[frames.length]` 
so the reset only triggers when the number of frames 
actually changes, not on every render.

## Files Changed
- `client/src/components/dsa-theory/algo/StepPlayer.tsx`

Closes #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback behavior in the step player to prevent unnecessary state resets when frame data is updated. The playback now correctly handles frame changes and maintains more stable playback during animation sequences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->