### PR TITLE
feat: add voice input to JobAgent with Web Speech API

### DIFF
--- a/client/src/module/student/job-agent/JobAgentPage.tsx
+++ b/client/src/module/student/job-agent/JobAgentPage.tsx
@@ -10,6 +10,8 @@ import {
   Zap,
   Crown,
   ArrowUpIcon,
+  Mic,
+  MicOff,
 } from "lucide-react";
 import { Link } from "react-router";
 import { cn } from "@/lib/utils";
@@ -20,6 +22,7 @@ import type { JobAgentMessage, JobAgentResponse, JobFeedMatch } from "../../../l
 import { SEO } from "../../../components/SEO";
 import { AgentMessage } from "./AgentMessage";
 import { ThinkingIndicator } from "./ThinkingIndicator";
+import { useSpeechRecognition } from "./useSpeechRecognition";
 
 interface DisplayMessage {
   role: "user" | "assistant";
@@ -76,11 +79,24 @@ export default function JobAgentPage() {
 
   const qc = useQueryClient();
   const [input, setInput] = useState("");
+  const [interimText, setInterimText] = useState("");
   const [localMessages, setLocalMessages] = useState<DisplayMessage[]>([]);
   const [manualHitFreeLimit, setManualHitFreeLimit] = useState(false);
   const [hasChatted, setHasChatted] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const { textareaRef, adjustHeight } = useAutoResizeTextarea({ minHeight: 44, maxHeight: 200 });
+
+  // Voice input
+  const { supported: voiceSupported, isListening, error: voiceError, start: startListening, stop: stopListening } = useSpeechRecognition({
+    onInterim: (text) => setInterimText(text),
+    onFinal: (text) => {
+      setInput((prev) => (prev ? `${prev} ${text}` : text));
+      setInterimText("");
+      setTimeout(() => adjustHeight(), 0);
+    },
+  });
+
+  const displayValue = input + (interimText ? " " + interimText : "");
 
   const { data: conversation } = useQuery({
     queryKey: queryKeys.jobAgent.conversation(),
@@ -155,9 +171,11 @@ export default function JobAgentPage() {
   });
 
   const handleSend = (text?: string) => {
-    const msg = (text ?? input).trim();
+    const committedInput = interimText ? (input ? `${input} ${interimText}` : interimText) : input;
+    const msg = (text ?? committedInput).trim();
     if (!msg || chatMut.isPending) return;
     setInput("");
+    setInterimText("");
     adjustHeight(true);
     setHasChatted(true);
     setLocalMessages([...messages, { role: "user", content: msg }]);
@@ -334,7 +352,7 @@ export default function JobAgentPage() {
             <div className="overflow-y-auto">
               <textarea
                 ref={textareaRef}
-                value={input}
+                value={displayValue}
                 onChange={(e) => {
                   setInput(e.target.value);
                   adjustHeight();
@@ -367,20 +385,38 @@ export default function JobAgentPage() {
               <span className="text-[10px] font-mono uppercase tracking-widest text-stone-400 dark:text-stone-500">
                 {hitFreeLimit ? "limit reached" : "enter to send, shift + enter for newline"}
               </span>
-              <button
-                type="button"
-                onClick={() => handleSend()}
-                disabled={!input.trim() || inputDisabled}
-                className={cn(
-                  "inline-flex items-center justify-center w-8 h-8 rounded-md transition-colors cursor-pointer disabled:cursor-not-allowed",
-                  input.trim() && !inputDisabled
-                    ? "bg-lime-400 hover:bg-lime-300 text-stone-950"
-                    : "bg-stone-200 dark:bg-white/10 text-stone-400 dark:text-stone-600",
+              <div className="flex items-center gap-1">
+                {voiceSupported && (
+                  <button
+                    type="button"
+                    onClick={isListening ? stopListening : startListening}
+                    aria-label={isListening ? "Stop recording" : "Start voice input"}
+                    aria-pressed={isListening}
+                    className={cn(
+                      "inline-flex items-center justify-center w-8 h-8 rounded-md transition-colors cursor-pointer",
+                      isListening
+                        ? "bg-red-50 dark:bg-red-950/30 text-red-600 dark:text-red-400"
+                        : "text-stone-400 hover:text-stone-700 dark:hover:text-stone-200 hover:bg-stone-100 dark:hover:bg-stone-800",
+                    )}
+                  >
+                    {isListening ? <MicOff className="w-4 h-4" /> : <Mic className="w-4 h-4" />}
+                  </button>
                 )}
-                aria-label="Send"
-              >
-                <ArrowUpIcon className="w-4 h-4" />
-              </button>
+                <button
+                  type="button"
+                  onClick={() => handleSend()}
+                  disabled={!input.trim() || inputDisabled}
+                  className={cn(
+                    "inline-flex items-center justify-center w-8 h-8 rounded-md transition-colors cursor-pointer disabled:cursor-not-allowed",
+                    input.trim() && !inputDisabled
+                      ? "bg-lime-400 hover:bg-lime-300 text-stone-950"
+                      : "bg-stone-200 dark:bg-white/10 text-stone-400 dark:text-stone-600",
+                  )}
+                  aria-label="Send"
+                >
+                  <ArrowUpIcon className="w-4 h-4" />
+                </button>
+              </div>
             </div>
           </div>
           <p className="text-center text-[10px] font-mono uppercase tracking-widest text-stone-400 dark:text-stone-600 mt-2">

--- a/client/src/module/student/job-agent/JobAgentPage.tsx
+++ b/client/src/module/student/job-agent/JobAgentPage.tsx
@@ -13,6 +13,7 @@ import {
   Mic,
   MicOff,
 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { Link } from "react-router";
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "../../../lib/auth.store";
@@ -260,7 +261,7 @@ export default function JobAgentPage() {
                 </span>
               )}
               {messages.length > 0 && (
-                <button
+                <Button
                   type="button"
                   onClick={() => resetMut.mutate()}
                   disabled={resetMut.isPending}
@@ -268,7 +269,7 @@ export default function JobAgentPage() {
                 >
                   <RotateCcw className="w-3 h-3" />
                   new chat
-                </button>
+                </Button>
               )}
             </div>
           </div>
@@ -306,7 +307,7 @@ export default function JobAgentPage() {
                 {/* Quick prompt numbered grid */}
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-0 w-full max-w-2xl border-t border-l border-stone-200 dark:border-white/10">
                   {QUICK_PROMPTS.map((q, i) => (
-                    <button
+                    <Button
                       key={q.text}
                       type="button"
                       onClick={() => handleSend(q.text)}
@@ -323,7 +324,7 @@ export default function JobAgentPage() {
                           </span>
                         </div>
                       </div>
-                    </button>
+                    </Button>
                   ))}
                 </div>
 
@@ -426,9 +427,18 @@ export default function JobAgentPage() {
               </span>
               <div className="flex items-center gap-1">
                 {voiceSupported && (
-                  <button
+                  <Button
                     type="button"
-                    onClick={isListening ? stopListening : startListening}
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => {
+                      if (isListening) {
+                        setInterimText("");
+                        stopListening();
+                      } else {
+                        startListening();
+                      }
+                    }}
                     aria-label={isListening ? "Stop recording" : "Start voice input"}
                     aria-pressed={isListening}
                     className={cn(
@@ -449,10 +459,11 @@ export default function JobAgentPage() {
                     ) : (
                       <Mic className="w-4 h-4" />
                     )}
-                  </button>
+                  </Button>
                 )}
-                <button
+                <Button
                   type="button"
+                  size="icon"
                   onClick={() => handleSend()}
                   disabled={!(input.trim() || interimText.trim()) || inputDisabled}
                   className={cn(
@@ -464,7 +475,7 @@ export default function JobAgentPage() {
                   aria-label="Send"
                 >
                   <ArrowUpIcon className="w-4 h-4" />
-                </button>
+                </Button>
               </div>
             </div>
             </div>
@@ -474,7 +485,7 @@ export default function JobAgentPage() {
               </p>
             )}
             <p className="text-center text-[10px] font-mono uppercase tracking-widest text-stone-400 dark:text-stone-600 mt-2">
-              powered by Neural Network , always verify job details
+              powered by Neural Network, always verify job details
             </p>
         </div>
       </div>

--- a/client/src/module/student/job-agent/JobAgentPage.tsx
+++ b/client/src/module/student/job-agent/JobAgentPage.tsx
@@ -98,6 +98,20 @@ export default function JobAgentPage() {
 
   const displayValue = input + (interimText ? " " + interimText : "");
 
+  const [voiceHint, setVoiceHint] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (voiceError === "not-allowed") {
+      setVoiceHint("Microphone access blocked - check browser settings");
+    }
+  }, [voiceError]);
+
+  useEffect(() => {
+    if (!voiceHint) return;
+    const timer = setTimeout(() => setVoiceHint(null), 5000);
+    return () => clearTimeout(timer);
+  }, [voiceHint]);
+
   const { data: conversation } = useQuery({
     queryKey: queryKeys.jobAgent.conversation(),
     queryFn: async () => {
@@ -188,6 +202,30 @@ export default function JobAgentPage() {
       handleSend();
     }
   };
+
+  useEffect(() => {
+    if (!isListening) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        stopListening();
+        setInterimText("");
+      }
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isListening, stopListening]);
+
+  useEffect(() => {
+    if (!isListening) {
+      const raf = requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+        const len = input.length;
+        textareaRef.current?.setSelectionRange(len, len);
+      });
+      return () => cancelAnimationFrame(raf);
+    }
+  }, [isListening]);
 
   const isEmpty = messages.length === 0;
   const inputDisabled = chatMut.isPending || hitFreeLimit;
@@ -354,6 +392,7 @@ export default function JobAgentPage() {
                 ref={textareaRef}
                 value={displayValue}
                 onChange={(e) => {
+                  setInterimText("");
                   setInput(e.target.value);
                   adjustHeight();
                 }}
@@ -399,16 +438,26 @@ export default function JobAgentPage() {
                         : "text-stone-400 hover:text-stone-700 dark:hover:text-stone-200 hover:bg-stone-100 dark:hover:bg-stone-800",
                     )}
                   >
-                    {isListening ? <MicOff className="w-4 h-4" /> : <Mic className="w-4 h-4" />}
+                    {isListening ? (
+                      <motion.span
+                        animate={{ scale: [1, 1.15, 1] }}
+                        transition={{ repeat: Infinity, duration: 1.2, ease: "easeInOut" }}
+                        className="inline-flex items-center justify-center"
+                      >
+                        <MicOff className="w-4 h-4" />
+                      </motion.span>
+                    ) : (
+                      <Mic className="w-4 h-4" />
+                    )}
                   </button>
                 )}
                 <button
                   type="button"
                   onClick={() => handleSend()}
-                  disabled={!input.trim() || inputDisabled}
+                  disabled={!(input.trim() || interimText.trim()) || inputDisabled}
                   className={cn(
                     "inline-flex items-center justify-center w-8 h-8 rounded-md transition-colors cursor-pointer disabled:cursor-not-allowed",
-                    input.trim() && !inputDisabled
+                    (input.trim() || interimText.trim()) && !inputDisabled
                       ? "bg-lime-400 hover:bg-lime-300 text-stone-950"
                       : "bg-stone-200 dark:bg-white/10 text-stone-400 dark:text-stone-600",
                   )}
@@ -418,10 +467,15 @@ export default function JobAgentPage() {
                 </button>
               </div>
             </div>
-          </div>
-          <p className="text-center text-[10px] font-mono uppercase tracking-widest text-stone-400 dark:text-stone-600 mt-2">
-            powered by Neural Network , always verify job details
-          </p>
+            </div>
+            {voiceHint && (
+              <p className="text-xs text-red-500 dark:text-red-400 mt-1 text-center">
+                {voiceHint}
+              </p>
+            )}
+            <p className="text-center text-[10px] font-mono uppercase tracking-widest text-stone-400 dark:text-stone-600 mt-2">
+              powered by Neural Network , always verify job details
+            </p>
         </div>
       </div>
     </div>

--- a/client/src/module/student/job-agent/useSpeechRecognition.ts
+++ b/client/src/module/student/job-agent/useSpeechRecognition.ts
@@ -1,0 +1,106 @@
+import { useState, useRef, useCallback, useMemo, useEffect } from "react";
+
+/* ------------------------------------------------------------------ */
+/*  Types — the public API is fully typed; browser SpeechRecognition   */
+/*  internals are cast to `any` inside the hook so `any` never leaks  */
+/*  out to consumers.                                                 */
+/* ------------------------------------------------------------------ */
+
+interface UseSpeechRecognitionOptions {
+  onInterim: (text: string) => void;
+  onFinal: (text: string) => void;
+}
+
+interface SpeechRecognitionResult {
+  supported: boolean;
+  isListening: boolean;
+  error: string | null;
+  start: () => void;
+  stop: () => void;
+}
+
+export function useSpeechRecognition({
+  onInterim,
+  onFinal,
+}: UseSpeechRecognitionOptions): SpeechRecognitionResult {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const recognitionRef = useRef<any>(null);
+  const [isListening, setIsListening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Stable callback refs so the recognition instance always calls the latest
+  const onInterimRef = useRef(onInterim);
+  const onFinalRef = useRef(onFinal);
+  useEffect(() => {
+    onInterimRef.current = onInterim;
+    onFinalRef.current = onFinal;
+  }, [onInterim, onFinal]);
+
+  const supported = useMemo(() => {
+    if (typeof window === "undefined") return false;
+    return "SpeechRecognition" in window || "webkitSpeechRecognition" in window;
+  }, []);
+
+  const start = useCallback(() => {
+    if (!supported) return;
+
+    // Abort any existing instance before creating a new one
+    recognitionRef.current?.abort();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = window as any;
+    const SpeechRecognitionCtor = w.SpeechRecognition || w.webkitSpeechRecognition;
+
+    if (!SpeechRecognitionCtor) return;
+
+    const recognition = new SpeechRecognitionCtor();
+    recognition.continuous = false;
+    recognition.interimResults = true;
+    recognition.lang = navigator.language || "en-US";
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    recognition.onresult = (event: any) => {
+      let interim = "";
+      let final = "";
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const transcript = event.results[i][0].transcript;
+        if (event.results[i].isFinal) {
+          final += transcript;
+        } else {
+          interim += transcript;
+        }
+      }
+      if (interim) onInterimRef.current(interim);
+      if (final) onFinalRef.current(final);
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    recognition.onerror = (event: any) => {
+      setError(event.error);
+      setIsListening(false);
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+    };
+
+    recognitionRef.current = recognition;
+    setError(null);
+    recognition.start();
+    setIsListening(true);
+  }, [supported]);
+
+  const stop = useCallback(() => {
+    recognitionRef.current?.stop();
+    setIsListening(false);
+  }, []);
+
+  // Abort on unmount — use abort (not stop) so onresult doesn't fire with stale data
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.abort();
+    };
+  }, []);
+
+  return { supported, isListening, error, start, stop };
+}

--- a/client/src/module/student/job-agent/useSpeechRecognition.ts
+++ b/client/src/module/student/job-agent/useSpeechRecognition.ts
@@ -1,11 +1,5 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from "react";
 
-/* ------------------------------------------------------------------ */
-/*  Types — the public API is fully typed; browser SpeechRecognition   */
-/*  internals are cast to `any` inside the hook so `any` never leaks  */
-/*  out to consumers.                                                 */
-/* ------------------------------------------------------------------ */
-
 interface UseSpeechRecognitionOptions {
   onInterim: (text: string) => void;
   onFinal: (text: string) => void;
@@ -25,10 +19,10 @@ export function useSpeechRecognition({
 }: UseSpeechRecognitionOptions): SpeechRecognitionResult {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const recognitionRef = useRef<any>(null);
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isListening, setIsListening] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Stable callback refs so the recognition instance always calls the latest
   const onInterimRef = useRef(onInterim);
   const onFinalRef = useRef(onFinal);
   useEffect(() => {
@@ -44,7 +38,6 @@ export function useSpeechRecognition({
   const start = useCallback(() => {
     if (!supported) return;
 
-    // Abort any existing instance before creating a new one
     recognitionRef.current?.abort();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -54,12 +47,20 @@ export function useSpeechRecognition({
     if (!SpeechRecognitionCtor) return;
 
     const recognition = new SpeechRecognitionCtor();
-    recognition.continuous = false;
+    recognition.continuous = true;
     recognition.interimResults = true;
     recognition.lang = navigator.language || "en-US";
 
+    const resetSilenceTimer = () => {
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+      silenceTimerRef.current = setTimeout(() => {
+        recognitionRef.current?.stop();
+      }, 2000);
+    };
+    
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     recognition.onresult = (event: any) => {
+      resetSilenceTimer();
       let interim = "";
       let final = "";
       for (let i = event.resultIndex; i < event.results.length; i++) {
@@ -91,13 +92,14 @@ export function useSpeechRecognition({
   }, [supported]);
 
   const stop = useCallback(() => {
+    if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
     recognitionRef.current?.stop();
     setIsListening(false);
   }, []);
 
-  // Abort on unmount — use abort (not stop) so onresult doesn't fire with stale data
   useEffect(() => {
     return () => {
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
       recognitionRef.current?.abort();
     };
   }, []);


### PR DESCRIPTION
Closes #40 

## Summary
- Added a voice input (mic) button to the JobAgent chat input bar, allowing users to speak their job queries instead of typing them. Uses the browser-native Web Speech API, no backend changes needed.

## Changes
- Created `client/src/module/student/job-agent/useSpeechRecognition.ts` - a custom hook that wraps the Web Speech API (`SpeechRecognition` / `webkitSpeechRecognition`) and exposes `supported`, `isListening`, `error`, `start()`, `stop()`
- Updated `client/src/module/student/job-agent/JobAgentPage.tsx`:
  - Wired `useSpeechRecognition` hook with interim and final transcript handling
  - Added mic button next to the send button (conditionally rendered - hidden on unsupported browsers like Firefox)
  - Mic icon swaps to `MicOff` with a red tint and Framer Motion pulse animation while listening
  - Interim transcription shows live in the textarea; final text appends to committed input with a space separator
  - Existing typed text is preserved - voice appends, doesn't replace
  - Pressing Escape cancels listening without committing interim text
  - Focus returns to textarea with cursor at end after recognition ends
  - Send button activates when voice text is present (not just typed text)
  - Inline hint "Microphone access blocked - check browser settings" shown for 5 seconds if mic permission is denied
  - Auto-stops after ~2 seconds of silence (using `continuous: true` with a custom silence timer to avoid cutting first words)
  - Proper `aria-label` and `aria-pressed` for screen readers

## How to test
1. Open the JobAgent page in **Chrome** or **Edge**
2. You should see a **mic icon** next to the send button
3. Click the mic → icon turns red and pulses → speak a query like "find me remote python internships above 6 LPA"
4. Watch the textarea - interim text appears live as you speak, then locks in as final text when you pause
5. Stop speaking for ~2 seconds → recognition auto-stops, focus returns to textarea
6. Click mic while listening → stops immediately
7. Press **Escape** while listening → cancels without committing interim text
8. Type some text, then use voice → voice appends with a space separator
9. Deny mic permission → red hint appears for 5 seconds, then clears
10. Open the same page in **Firefox** → mic button should be **hidden entirely**

## Screenshots 
Note - the blue border around the mic is due to screenshot capture

### When the user is speaking
<img width="1026" height="141" alt="Screenshot 2026-05-16 at 12 21 14 PM" src="https://github.com/user-attachments/assets/2a889b31-2ac4-49a3-a585-ed4f79ad5126" />

### When the user stops speaking focus shifts to the text area
<img width="999" height="121" alt="Screenshot 2026-05-16 at 12 21 27 PM" src="https://github.com/user-attachments/assets/86f80343-d178-4062-ab6b-949967eb14ba" />

### When mic access is denied
<img width="1006" height="147" alt="Screenshot 2026-05-16 at 12 12 47 PM" src="https://github.com/user-attachments/assets/187749ca-e6a1-462b-820a-2d98fef42f5c" />

### Mobile view
<img width="381" height="181" alt="image" src="https://github.com/user-attachments/assets/563d93fc-663b-42d5-b2f1-b9b6a03110b0" />

### Mic not visible in Firefox
<img width="1009" height="147" alt="image" src="https://github.com/user-attachments/assets/f8af7e13-5105-4fee-a3d0-f22f2c96bde3" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice input for Job Agent—speak queries aloud
  * Microphone control in the message input bar
  * Interim speech text combines with typed input for sending
  * Send button enables/disables based on typed or interim speech
  * Press Escape to stop listening and clear interim speech; refocuses input when not listening
  * Temporary hint shown when microphone access is blocked and auto-dismisses

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->