### PR TITLE
fixed the blank space issue in six tools one workspace section

### DIFF
--- a/client/src/components/FeaturesSection.tsx
+++ b/client/src/components/FeaturesSection.tsx
@@ -63,7 +63,7 @@ const FEATURES: Feature[] = [
     icon: GitBranch,
     href: "/opensource",
     stat: "520+ orgs",
-    span: "double",
+    span: "full",
   },
 ];
 
@@ -111,45 +111,58 @@ export function FeaturesSection() {
           </p>
         </motion.div>
 
-        <motion.div
-          className="grid grid-cols-1 md:grid-cols-3 gap-px bg-stone-200 dark:bg-white/10 border border-stone-200 dark:border-white/10 rounded-2xl overflow-hidden"
-          variants={containerVariants}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, margin: "-60px" }}
-        >
+         <div
+         className="grid grid-cols-1 md:grid-cols-3 auto-rows-fr gap-px bg-stone-200 dark:bg-white/10 border border-stone-200 dark:border-white/10 rounded-2xl overflow-hidden"
+         variants={containerVariants}
+         initial="hidden"
+         whileInView="visible"
+         viewport={{ once: true, margin: "-60px" }}
+         >
           {FEATURES.map((f) => (
-            <motion.div
-              key={f.title}
-              variants={cardVariants}
-              className={f.span === "double" ? "md:col-span-2" : ""}
-            >
-              <Link to={f.href} className="no-underline block group h-full">
-                <div className="relative h-full flex flex-col p-8 bg-white dark:bg-stone-950 hover:bg-stone-50 dark:hover:bg-stone-900 transition-colors">
-                  <div className="flex items-center justify-between mb-8">
-                    <div className="inline-flex items-center justify-center h-10 w-10 rounded-lg bg-lime-400/15 border border-lime-400/30 text-lime-700 dark:text-lime-400">
-                      <f.icon className="w-4.5 h-4.5" strokeWidth={2} />
-                    </div>
-                    <span className="text-xs font-mono uppercase tracking-widest text-stone-500">
-                      {f.stat}
-                    </span>
-                  </div>
+          <motion.div
+           key={f.title}
+           variants={cardVariants}
+           className={
+             f.span === "double"
+              ? "md:col-span-2"
+              : f.span === "full"
+              ? "md:col-span-3"
+              : ""
+           }
+          >
+        <Link to={f.href} className="no-underline block group h-full">
+            <div className="relative h-full flex flex-col p-8 bg-white dark:bg-stone-950 hover:bg-stone-50 dark:hover:bg-stone-900 transition-colors">
+          
+             {/* Top Row */}
+             <div className="flex items-center justify-between mb-8">
+              <div className="inline-flex items-center justify-center h-10 w-10 rounded-lg bg-lime-400/15 border border-lime-400/30 text-lime-700 dark:text-lime-400">
+                <f.icon className="w-4.5 h-4.5" strokeWidth={2} />
+              </div>
 
-                  <h3 className="text-xl md:text-2xl font-bold tracking-tight text-stone-900 dark:text-stone-50 leading-tight">
-                    {f.title}
-                  </h3>
-                  <p className="mt-3 text-sm text-stone-600 dark:text-stone-400 leading-relaxed flex-1">
-                    {f.desc}
-                  </p>
+               <span className="text-xs font-mono uppercase tracking-widest text-stone-500">
+                {f.stat}
+               </span>
+              </div>
 
-                  <span className="mt-8 inline-flex items-center gap-1.5 text-xs font-mono uppercase tracking-widest text-stone-900 dark:text-stone-50 group-hover:gap-2.5 transition-all">
-                    open
-                    <ArrowRight className="w-3.5 h-3.5" />
-                  </span>
-                </div>
-              </Link>
-            </motion.div>
-          ))}
+             {/* Title */}
+             <h3 className="text-xl md:text-2xl font-bold tracking-tight text-stone-900 dark:text-stone-50 leading-tight">
+              {f.title}
+             </h3>
+
+             {/* Description */}
+             <p className="mt-3 text-sm text-stone-600 dark:text-stone-400 leading-relaxed flex-1">
+              {f.desc}
+             </p>
+
+             {/* CTA */}
+             <span className="mt-8 inline-flex items-center gap-1.5 text-xs font-mono uppercase tracking-widest text-stone-900 dark:text-stone-50 group-hover:gap-2.5 transition-all">
+               open
+               <ArrowRight className="w-3.5 h-3.5" />
+             </span>
+           </div>
+         </Link>
+       </motion.div>
+       ))}
         </motion.div>
       </div>
     </section>

--- a/client/src/components/FeaturesSection.tsx
+++ b/client/src/components/FeaturesSection.tsx
@@ -111,7 +111,7 @@ export function FeaturesSection() {
           </p>
         </motion.div>
 
-         <div
+         <motion.div
          className="grid grid-cols-1 md:grid-cols-3 auto-rows-fr gap-px bg-stone-200 dark:bg-white/10 border border-stone-200 dark:border-white/10 rounded-2xl overflow-hidden"
          variants={containerVariants}
          initial="hidden"
@@ -143,18 +143,12 @@ export function FeaturesSection() {
                 {f.stat}
                </span>
               </div>
-
-             {/* Title */}
              <h3 className="text-xl md:text-2xl font-bold tracking-tight text-stone-900 dark:text-stone-50 leading-tight">
               {f.title}
              </h3>
-
-             {/* Description */}
              <p className="mt-3 text-sm text-stone-600 dark:text-stone-400 leading-relaxed flex-1">
               {f.desc}
              </p>
-
-             {/* CTA */}
              <span className="mt-8 inline-flex items-center gap-1.5 text-xs font-mono uppercase tracking-widest text-stone-900 dark:text-stone-50 group-hover:gap-2.5 transition-all">
                open
                <ArrowRight className="w-3.5 h-3.5" />


### PR DESCRIPTION
closes issue #237 

improved the css so that the last open source and gssoc block occupies the whole space in the third row

the odd looking gap is fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced feature card layout with support for full-width display mode for select features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->