### PR TITLE
fix: prevent startup failure with empty AWS env vars  

### DIFF
--- a/server/src/utils/s3.utils.ts
+++ b/server/src/utils/s3.utils.ts
@@ -7,15 +7,15 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 const s3Client = new S3Client({
-  region: process.env["AWS_REGION"] ?? "ap-south-1",
+  region: process.env["AWS_REGION"] || "ap-south-1",
   credentials: {
-    accessKeyId: process.env["AWS_ACCESS_KEY_ID"] ?? "",
-    secretAccessKey: process.env["AWS_SECRET_ACCESS_KEY"] ?? "",
+    accessKeyId: process.env["AWS_ACCESS_KEY_ID"] || "",
+    secretAccessKey: process.env["AWS_SECRET_ACCESS_KEY"] || "",
   },
 });
 
-const BUCKET = process.env["AWS_S3_BUCKET"] ?? "";
-const REGION = process.env["AWS_REGION"] ?? "ap-south-1";
+const BUCKET = process.env["AWS_S3_BUCKET"] || "";
+const REGION = process.env["AWS_REGION"] || "ap-south-1";
 
 function getBucketUrl(): string {
   return `https://${BUCKET}.s3.${REGION}.amazonaws.com`;


### PR DESCRIPTION
Fixes #261

## Summary

This PR fixes a server startup failure in `s3.utils.ts` when AWS environment variables are present but empty.

Previously, the code used `??` for region fallback:

```ts id="a2v5ud"
process.env["AWS_REGION"] ?? "ap-south-1"
```

If `AWS_REGION=` existed in `.env`, the value became an empty string instead of falling back to `"ap-south-1"`, causing the AWS SDK to throw:

`Error: Region is missing`

This PR replaces `??` with `||` so empty strings are handled correctly during local development.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated S3 configuration to properly handle empty environment variable values, improving fallback behavior for AWS region and bucket settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->