### PR TITLE
ISSUE 126:Add job share on job detail and fix student profile visibility JSX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,63 @@
+# InternHack · root environment template (Docker Compose + reference for local dev)
+#
+# Quick start:
+#   cp .env.example .env
+#   Fill in at least JWT_SECRET plus any OAuth/API keys you need.
+#   docker compose up --build
+#
+# Redis is intentionally not documented here — InternHack does not use Redis yet.
+#
+
+# ── Docker Compose: PostgreSQL ─────────────────────────────────────────
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=internhack
+
+# Used by docker compose compose-time interpolation (healthchecks, URLs).
+# The server container also receives DATABASE_URL from docker-compose.yml (postgres hostname).
+
+# ── Database (required) ────────────────────────────────────────────────
+# Non-Docker / host Node: keep localhost here. Compose overrides this inside the API container.
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/internhack
+
+# ── Server (minimum boot: DATABASE_URL + JWT_SECRET in server/src/index.ts) ──
+JWT_SECRET=
+
+DODO_PAYMENTS_API_KEY=
+DODO_PAYMENTS_WEBHOOK_KEY=
+DODO_PAYMENTS_ENVIRONMENT=live_mode
+DODO_PRODUCT_ID_MONTHLY=
+DODO_PRODUCT_ID_YEARLY=
+ADZUNA_APP_ID=
+ADZUNA_APP_KEY=
+GEMINI_API_KEY=
+AWS_REGION=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_S3_BUCKET=
+CALENDLY_URL=
+VITE_API_URL=
+ALLOWED_ORIGINS=http://localhost:5173
+GOOGLE_CLIENT_ID=
+RESEND_API_KEY=
+EMAIL_FROM=
+GROQ_API_KEY=
+OPENROUTER_API_KEY=
+CODESTRAL_API_KEY=
+JUDGE0_RAPIDAPI_KEY_1=
+JUDGE0_RAPIDAPI_KEY_2=
+JUDGE0_RAPIDAPI_KEY_3=
+JUDGE0_RAPIDAPI_KEY_4=
+INBOUND_FORWARD_TO=
+RESEND_WEBHOOK_SECRET=
+CLAUDE_API=
+EXA_API_KEY=
+EXTERNAL_JOB_API_KEY=
+# LeetCode import server flag — false to disable (default: enabled)
+LEETCODE_IMPORT_ENABLED=true
+
+# ── Client (Vite · exposed to the browser — prefix required) ────────────
+VITE_GOOGLE_CLIENT_ID=
+VITE_DODO_MODE=test_mode
+# LeetCode import client flag — set to false to disable (default: enabled)
+VITE_LEETCODE_IMPORT_ENABLED=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,8 @@ This guide walks you through everything from setting up the project to submittin
 | PostgreSQL | 14+ | Database |
 | Git | 2.30+ | Version control |
 
+**Docker Compose shortcut:** You can run Postgres + API + client with only Docker by following the README “Docker Compose (alternative)” section (root `.env.example` plus `docker compose up`). That path does **not** use Redis — the app stack is PostgreSQL only.
+
 You'll also need:
 - A **Google Cloud Console** project for OAuth (client ID)
 - A **Gemini API key** ([free at aistudio.google.com](https://aistudio.google.com/apikey))
@@ -57,13 +59,19 @@ cd InternHack
 
 ### Step 2: Set up environment variables
 
-```bash
-# Server environment
-cp server/.env.example server/.env
+**Docker Compose:** copy the template at the repo root:
 
-# Client environment
+```bash
+cp .env.example .env
+```
+
+**Classic setup:** separate client and server copies:
+
+```bash
+cp server/.env.example server/.env
 cp client/.env.example client/.env
 ```
+
 
 Open `server/.env` and fill in the **required** values:
 

--- a/README.md
+++ b/README.md
@@ -75,17 +75,48 @@ git clone https://github.com/Sachinchaurasiya360/InternHack.git
 cd InternHack
 ```
 
+### Docker Compose (alternative)
+
+Requires [Docker Desktop](https://docs.docker.com/get-docker/) or Docker Engine plus Compose v2. You do **not** need a host-installed PostgreSQL or Node for this path. (**Redis is not used** by InternHack.) The API service image is defined in [`server/Dockerfile.dev`](server/Dockerfile.dev) for local dev only; production deploy continues to use [`server/dockerfile`](server/dockerfile).
+
+From the repo root:
+
+```bash
+cp .env.example .env
+# Set JWT_SECRET at minimum; add OAuth/AI keys as needed (see Environment Variables below).
+
+docker compose up --build
+```
+
+Compose falls back to the same Postgres defaults as `.env.example` when variables are absent, but the API refuses to boot without **`JWT_SECRET`**, which your root `.env` must supply.
+
+- Frontend **http://localhost:5173** — API **http://localhost:3000**
+- Source trees are bind-mounted into the containers; `CHOKIDAR_USEPOLLING` helps file watching on Docker Desktop for macOS.
+- On startup, the API container runs `prisma migrate deploy`, then `npm run dev`.
+- The frontend service runs **Vite in dev mode** (`npm run dev`) for hot reload; production client builds (`cd client && npm run build`) are still separate from this Compose file.
+
+Optional sample data:
+
+```bash
+docker compose exec server npm run seed
+```
+
+Uncomment the `postgres` `ports` section in `docker-compose.yml` if you need to reach Postgres from tools on your host defaulting to localhost.
+
+To install Node and Postgres on your machine instead, follow the numbered steps below.
+
 ### 2. Set up environment variables
 
 ```bash
-# Server
+# Without Docker — per-package env files
 cp server/.env.example server/.env
-# Fill in your values (see Environment Variables section below)
-
-# Client
 cp client/.env.example client/.env
-# Fill in VITE_GOOGLE_CLIENT_ID
+
+# Docker Compose — single consolidated file at the repo root
+cp .env.example .env
 ```
+
+Fill values as described below (Compose uses `.env`; per-package copies use `server/.env` and `client/.env`).
 
 ### 3. Install dependencies
 
@@ -140,7 +171,9 @@ Open **http://localhost:5173** and you're in!
 
 ## Environment Variables
 
-### Server (`server/.env`)
+For Docker Compose, use the **repo root [`.env.example`](.env.example)** as the master template (`cp .env.example .env`).
+
+### Server (`server/.env` or root `.env` with Compose)
 
 | Variable | Required | Description |
 |----------|----------|-------------|
@@ -167,7 +200,7 @@ Open **http://localhost:5173** and you're in!
 
 > Only `DATABASE_URL`, `JWT_SECRET`, `GOOGLE_CLIENT_ID`, `GEMINI_API_KEY`, and `ALLOWED_ORIGINS` are required to run the app locally. Other services degrade gracefully.
 
-### Client (`client/.env`)
+### Client (`client/.env`, or root `.env` — only `VITE_*` vars are exposed to Vite)
 
 | Variable | Required | Description |
 |----------|----------|-------------|
@@ -180,6 +213,8 @@ Open **http://localhost:5173** and you're in!
 
 ```
 InternHack/
+├── docker-compose.yml        # Postgres + API + client (dev, hot reload)
+├── .env.example              # Compose + combined env documentation
 ├── client/                   # React frontend (Vite)
 │   ├── src/
 │   │   ├── components/       # Shared UI components

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.env
+.env.*
+.git
+.github
+*.md

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,3 +1,5 @@
+# See .env.example at the repository root for a Compose-oriented combined template.
+
 VITE_GOOGLE_CLIENT_ID=
 VITE_DODO_MODE=test_mode
 # LeetCode import feature flag — set to false to disable (default: enabled)

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,15 @@
+# ── Dependencies (shared) ──────────────────────────────────────
+FROM node:20-bookworm-slim AS deps
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ── Local development (docker compose bind-mounts ./client → /app) ──
+FROM deps AS development
+
+ENV NODE_ENV=development
+
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/client/src/module/student/jobs/JobDetailPage.tsx
+++ b/client/src/module/student/jobs/JobDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useParams, Link, useLocation } from "react-router";
 import { motion } from "framer-motion";
-import { ArrowLeft, MapPin, IndianRupee, Users, Send, Check, Building2, Clock, ArrowUpRight } from "lucide-react";
+import { ArrowLeft, MapPin, IndianRupee, Users, Send, Check, Building2, Clock, ArrowUpRight, Share2 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Navbar } from "../../../components/Navbar";
 import { SEO } from "../../../components/SEO";
@@ -11,6 +11,8 @@ import { queryKeys } from "../../../lib/query-keys";
 import { useAuthStore } from "../../../lib/auth.store";
 import type { Job } from "../../../lib/types";
 import { LoadingScreen } from "../../../components/LoadingScreen";
+import { Button } from "../../../components/ui/button";
+import toast from "../../../components/ui/toast";
 
 const fadeUp = { hidden: { opacity: 0, y: 16 }, show: { opacity: 1, y: 0 } };
 const stagger = { show: { transition: { staggerChildren: 0.07 } } };
@@ -110,6 +112,39 @@ export default function JobDetailPage() {
   }
 
   const deadlineInfo = job.deadline ? getDeadlineInfo(job.deadline) : null;
+  const shareUrl = canonicalUrl(`/jobs/${id}`);
+
+  const copyJobLink = async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      toast.success("Link copied!");
+    } catch {
+      toast.error("Failed to copy link");
+    }
+  };
+
+  const handleShareJob = async () => {
+    const canShare = typeof navigator !== "undefined" && typeof navigator.share === "function";
+    if (canShare) {
+      try {
+        await navigator.share({
+          title: `${job.title} at ${job.company}`,
+          text: `Check out this role: ${job.title} at ${job.company}`,
+          url: shareUrl,
+        });
+      } catch (e) {
+        if (
+          (e instanceof DOMException || e instanceof Error) &&
+          e.name === "AbortError"
+        ) {
+          return;
+        }
+        await copyJobLink();
+      }
+      return;
+    }
+    await copyJobLink();
+  };
 
   const ctaButton = isAuthenticated && user?.role === "STUDENT" ? (
     applicationStatus?.applied ? (
@@ -161,7 +196,19 @@ export default function JobDetailPage() {
                 </h1>
                 <p className="mt-2 text-sm text-stone-500">{job.company}</p>
               </div>
-              <div className="shrink-0">{ctaButton}</div>
+              <div className="shrink-0 flex flex-wrap items-center gap-2 sm:justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  mode="icon"
+                  size="lg"
+                  aria-label="Share job"
+                  onClick={() => void handleShareJob()}
+                >
+                  <Share2 />
+                </Button>
+                {ctaButton}
+              </div>
             </div>
 
             {/* Meta row */}

--- a/client/src/module/student/profile/StudentProfilePage.tsx
+++ b/client/src/module/student/profile/StudentProfilePage.tsx
@@ -695,9 +695,10 @@ export default function StudentProfilePage() {
                     {profileUrlCopied ? "Copied!" : "Copy URL"}
                   </button>
                 </div>
-              )}
+               )}
               {/* Visibility */}
               <div className="flex items-start justify-between gap-3 mt-4 pt-4 border-t border-stone-200 dark:border-white/10">
+                <div className="min-w-0">
                   <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
                     recruiter visibility
                   </p>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -46,6 +46,9 @@ const PRERENDER_ROUTES = [
 const skipPrerender =
   process.env.SKIP_PRERENDER === '1' || process.env.VERCEL === '1'
 
+// Dev-only: Vite Node process proxies `/sitemap.xml`; in Docker Compose the API hostname is `server`.
+const dockerInternalApiOrigin =
+  process.env.DOCKER_INTERNAL_API_ORIGIN ?? 'http://127.0.0.1:3000'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -87,7 +90,7 @@ export default defineConfig({
     proxy: {
       // Proxy sitemap.xml to backend so it works in development
       '/sitemap.xml': {
-        target: 'http://localhost:3000',
+        target: dockerInternalApiOrigin,
         changeOrigin: true,
       },
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-internhack}
+    volumes:
+      - internhack_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-internhack}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    # Map only if you need host tools against DB; uncomment if nothing else uses port 5432 locally.
+    # ports:
+    #   - "5432:5432"
+
+  server:
+    build:
+      context: ./server
+      dockerfile: Dockerfile.dev
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-internhack}
+      CHOKIDAR_USEPOLLING: "true"
+    volumes:
+      - ./server:/app
+      - server_node_modules:/app/node_modules
+    ports:
+      - "3000:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  client:
+    build:
+      context: ./client
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      DOCKER_INTERNAL_API_ORIGIN: http://server:3000
+      CHOKIDAR_USEPOLLING: "true"
+    volumes:
+      - ./client:/app
+      - client_node_modules:/app/node_modules
+    ports:
+      - "5173:5173"
+    depends_on:
+      - server
+
+volumes:
+  internhack_pgdata:
+  server_node_modules:
+  client_node_modules:

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,5 @@
+# See .env.example at the repository root for a Compose-oriented combined template.
+
 DATABASE_URL=
 DODO_PAYMENTS_API_KEY=
 DODO_PAYMENTS_WEBHOOK_KEY=
@@ -30,4 +32,4 @@ RESEND_WEBHOOK_SECRET=
 CLAUDE_API=
 EXA_API_KEY=
 # LeetCode import feature flag — set to false to disable (default: enabled)
-LEETCODE_IMPORT_ENABLED=true
+LEETCODE_IMPORT_ENABLED=true

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -1,0 +1,21 @@
+# API image for local development only (docker compose). Production deploy still uses `server/dockerfile`.
+
+FROM node:20-bookworm-slim AS deps
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM deps AS development
+
+ENV NODE_ENV=development
+
+COPY docker-entrypoint.dev.sh /usr/local/bin/docker-entrypoint-dev.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-dev.sh
+
+EXPOSE 3000
+ENTRYPOINT ["docker-entrypoint-dev.sh"]

--- a/server/docker-entrypoint.dev.sh
+++ b/server/docker-entrypoint.dev.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+cd /app
+
+npx prisma generate --config src/database/prisma.config.ts
+npx prisma migrate deploy --config src/database/prisma.config.ts
+
+exec npm run dev


### PR DESCRIPTION
## Summary
- Add a **Share** control (Lucide `Share2`, outline icon `Button`) beside the Apply CTA on the internal job detail page. Uses the **Web Share API** when `navigator.share` is available; otherwise copies the **canonical** listing URL (`canonicalUrl(/jobs/:id)`) and shows **Sonner** toasts (`Link copied!` / failure).
- Handles **user cancel** (`AbortError`) without error noise; on other share errors, **falls back to clipboard**.
- Fix **invalid JSX** in `StudentProfilePage` (recruiter visibility row: toggle was outside the flex wrapper), which broke Vite/esbuild parsing.
