### PR TITLE
fix: persist interview lesson progress across devices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# InternHack, Codex Instructions
+
+## Project Overview
+InternHack is a full-stack internship/career platform for students with AI-powered tools, learning modules, and recruiter features.
+
+## Quick Start
+- **Server:** `cd server && npm run dev` (runs `tsx watch src/index.ts`)
+- **Client:** `cd client && npm run dev` (Vite on port 5173)
+- **Migrations:** Must run from `server/src/database/`, that's where `prisma.config.ts` lives
+
+## Repo Map
+**Always read `.Codex/REPO_MAP.md` before any editing task.** It maps every module, route, model, and component.
+
+## Stack
+- **Client:** React 18 + Vite 7 + TailwindCSS 4 + React Router 7 + Framer Motion + Zustand + React Query
+- **Server:** Express 5 + TypeScript 5 + Prisma 7 + PostgreSQL
+- **AI:** Google Gemini (`gemini-2.5-flash-lite`)
+- **Auth:** JWT in `Authorization: Bearer <token>` header; Zustand auth store on client
+- **Payments:** dodo payment
+- **Storage:** AWS S3 with local fallback
+
+## Code Style Rules
+
+### TailwindCSS v4
+- Use canonical TW v4 classes only
+- No `bg-gradient-*` shorthand, use `bg-linear-to-*` instead
+- No arbitrary bracket sizes like `text-[17px]`, use standard scale classes
+- No gradient backgrounds on icons, use flat color or bare colored icons
+
+### UI Conventions
+- **No pill badges**, do not use `rounded-full` category/section tag pills above page headings. Use `mt-6` on the header wrapper for top spacing instead
+- Company avatars: first-letter initial in neutral box, not generic icon
+- DRY: no duplicate helpers, shared animation variants per file
+
+### TypeScript
+- Strict mode enabled on both client and server
+- Use Zod for all server-side validation (see `*.validation.ts` files)
+- Client types mirror server models in `client/src/lib/types.ts`
+
+### Module Pattern (Server)
+Every server module follows: `<name>.routes.ts` → `<name>.controller.ts` → `<name>.service.ts`
+- Routes: Express router with middleware chain (auth, role, usage-limit, validation)
+- Controller: Handles request/response, calls service, formats errors
+- Service: Business logic, DB queries, external API calls
+
+### Premium Gating Pattern
+For premium-only features (see `latex-chat.controller.ts`):
+```typescript
+const user = await prisma.user.findUnique({
+  where: { id: req.user.id },
+  select: { subscriptionPlan: true, subscriptionStatus: true },
+});
+const isPremium =
+  (user.subscriptionPlan === "MONTHLY" || user.subscriptionPlan === "YEARLY") &&
+  user.subscriptionStatus === "ACTIVE";
+```
+
+### Usage Limits
+Daily usage limits are enforced via `usageLimit(action)` middleware.
+Actions: `ATS_SCORE`, `COVER_LETTER`, `GENERATE_RESUME`, `JOB_APPLICATION`, `MOCK_INTERVIEW`
+Config in `server/src/config/usage-limits.ts`.
+
+## Key Patterns
+
+### Adding a New API Endpoint
+1. Create/update `*.routes.ts` with Express router
+2. Create/update `*.controller.ts` with request handling
+3. Create/update `*.service.ts` with business logic
+4. Create/update `*.validation.ts` with Zod schemas
+5. Register routes in `server/src/index.ts`
+
+### Adding a New Client Page
+1. Create page component in `client/src/module/<area>/<PageName>.tsx`
+2. Add lazy import in `client/src/App.tsx`
+3. Add route in the appropriate route group (public/student/recruiter/admin)
+
+### AI Integration (Gemini)
+- Use `GoogleGenerativeAI` from `@google/generative-ai`
+- Model: `gemini-2.5-flash-lite`
+- For structured responses with LaTeX content, use XML tags (`<reply>`, `<latex>`) instead of JSON
+- Always handle parse failures with fallbacks
+
+### Button Component
+Use the reusable `Button` from `client/src/components/ui/button.tsx` (CVA-based) for all new buttons.
+- Variants: `primary`, `secondary`, `mono`, `ghost`, `danger`
+- Modes: `button` (default), `icon`, `link`
+- Sizes: `sm`, `md`, `lg`
+- Supports `asChild` (Radix Slot) for composing with `<Link>` or other elements
+- Import: `import { Button } from "../../components/ui/button"`
+
+### SEO on Internal Pages
+All admin and recruiter pages must include `<SEO title="Page Title" noIndex />`. Public pages use full SEO props.
+
+### File Upload Validation
+`DynamicFieldRenderer.tsx` validates file uploads client-side (size ≤ 5 MB, allowed types). Follow this pattern for any new file upload UI.
+
+### React.memo Convention
+Wrap list-rendered child components (cards, badges, list items) with `React.memo` when they receive stable props and don't have internal state that changes frequently. Use named function form:
+```tsx
+export const MyCard = React.memo(function MyCard({ data }: Props) { ... });
+```
+
+### Repo Request Approval Flow
+Students can suggest repos via `POST /api/opensource/requests`. Admin reviews at `/admin/repo-requests`. On approval, the repo is auto-created and the student gets an email. Routes are in `opensource.routes.ts`, `/requests/*` routes must appear BEFORE `/:id` to avoid route conflicts.
+
+## Do NOT
+- Create Prisma migrations without confirming, run from `server/src/database/`
+- Use `bg-gradient-*` in TailwindCSS, use `bg-linear-to-*`
+- Add `rounded-full` pill badges above headings
+- Fabricate new UsageAction enum values, reuse existing ones to avoid migrations
+- Push to remote without explicit permission

--- a/client/src/module/student/interview-prep/InterviewLessonsPage.tsx
+++ b/client/src/module/student/interview-prep/InterviewLessonsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { motion } from "framer-motion";
 import { CheckCircle2, ArrowUpRight, Lock } from "lucide-react";
@@ -10,24 +10,7 @@ import { courseSchema, breadcrumbSchema } from "../../../lib/structured-data";
 import { useAuthStore } from "../../../lib/auth.store";
 import { LoginGate } from "../../../components/LoginGate";
 import { CircularProgress } from "../../../components/ui/CircularProgress";
-
-const STORAGE_KEY = "interview-progress";
-
-function getLocalProgress(): InterviewProgress {
-  try {
-    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
-    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
-    const out: InterviewProgress = {};
-    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-      if (v && typeof v === "object" && typeof (v as { completed?: unknown }).completed === "boolean") {
-        out[k] = { completed: (v as { completed: boolean }).completed };
-      }
-    }
-    return out;
-  } catch {
-    return {};
-  }
-}
+import { useInterviewProgress } from "./interviewProgress";
 
 const LEVEL_STYLE: Record<string, string> = {
   Beginner:     "text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/60",
@@ -46,26 +29,7 @@ function MetaChip({ children, className = "" }: { children: React.ReactNode; cla
 export default function InterviewLessonsPage() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const [showGate, setShowGate] = useState(false);
-  const [progress, setProgress] = useState<InterviewProgress>(() => getLocalProgress());
-
-  const refreshProgress = useCallback(() => setProgress(getLocalProgress()), []);
-
-  useEffect(() => {
-    const onStorage = (e: StorageEvent) => {
-      if (e.key === STORAGE_KEY || e.key === null) refreshProgress();
-    };
-    const onVisible = () => {
-      if (document.visibilityState === "visible") refreshProgress();
-    };
-    window.addEventListener("storage", onStorage);
-    document.addEventListener("visibilitychange", onVisible);
-    window.addEventListener("focus", refreshProgress);
-    return () => {
-      window.removeEventListener("storage", onStorage);
-      document.removeEventListener("visibilitychange", onVisible);
-      window.removeEventListener("focus", refreshProgress);
-    };
-  }, [refreshProgress]);
+  const { progress, isLoading } = useInterviewProgress();
 
   const sectionStats = useMemo(() => {
     return sections.map((section) => {
@@ -76,7 +40,7 @@ export default function InterviewLessonsPage() {
     });
   }, [progress]);
 
-  const totalCompleted = Object.values(progress).filter((p) => p.completed).length;
+  const totalCompleted = Object.values(progress as InterviewProgress).filter((p) => p.completed).length;
   const totalQuestions = questions.length;
   const overallPct = totalQuestions > 0 ? Math.round((totalCompleted / totalQuestions) * 100) : 0;
 
@@ -172,7 +136,7 @@ export default function InterviewLessonsPage() {
         >
           <div className="flex items-center justify-between gap-4 mb-2">
             <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
-              overall progress
+              {isLoading ? "syncing progress" : "overall progress"}
             </span>
             <span className="text-xs font-mono uppercase tracking-widest text-stone-900 dark:text-stone-50 tabular-nums">
               {totalCompleted} / {totalQuestions}

--- a/client/src/module/student/interview-prep/InterviewQuestionPage.tsx
+++ b/client/src/module/student/interview-prep/InterviewQuestionPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, Link, useNavigate, Navigate } from "react-router";
 import { motion } from "framer-motion";
 import {
@@ -18,30 +18,7 @@ import { SEO } from "../../../components/SEO";
 import { canonicalUrl } from "../../../lib/seo.utils";
 import { useAuthStore } from "../../../lib/auth.store";
 import { reportMilestone } from "../../../lib/milestone.utils";
-
-function getLocalProgress(): InterviewProgress {
-  try {
-    const raw = JSON.parse(localStorage.getItem("interview-progress") || "{}");
-    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
-    const out: InterviewProgress = {};
-    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-      if (v && typeof v === "object" && typeof (v as { completed?: unknown }).completed === "boolean") {
-        out[k] = { completed: (v as { completed: boolean }).completed };
-      }
-    }
-    return out;
-  } catch {
-    return {};
-  }
-}
-
-function toggleProgress(questionId: string): boolean {
-  const progress = getLocalProgress();
-  const current = progress[questionId]?.completed ?? false;
-  progress[questionId] = { completed: !current };
-  localStorage.setItem("interview-progress", JSON.stringify(progress));
-  return !current;
-}
+import { useInterviewProgress } from "./interviewProgress";
 
 const DIFF_STYLE: Record<string, string> = {
   Beginner:     "text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/60",
@@ -138,11 +115,7 @@ export default function InterviewQuestionPage() {
   const navigate = useNavigate();
   const basePath = "/learn/interview";
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
-
-  const [completed, setCompleted] = useState(() => {
-    const p = getLocalProgress();
-    return !!p[questionId ?? ""]?.completed;
-  });
+  const { progress, toggleComplete, recordVisit } = useInterviewProgress();
 
   const section = sections.find((s) => s.id === sectionSlug);
   const sectionQuestions = useMemo(
@@ -151,20 +124,27 @@ export default function InterviewQuestionPage() {
   );
 
   const question = sectionQuestions.find((q) => q.id === questionId);
+  const completed = !!(questionId && progress[questionId]?.completed);
   const currentIndex = question ? sectionQuestions.findIndex((q) => q.id === question.id) : -1;
   const prevQuestion = currentIndex > 0 ? sectionQuestions[currentIndex - 1] : null;
   const nextQuestion = currentIndex < sectionQuestions.length - 1 ? sectionQuestions[currentIndex + 1] : null;
 
   const handleToggleComplete = useCallback(() => {
     if (!questionId) return;
-    const newVal = toggleProgress(questionId);
-    setCompleted(newVal);
-    if (newVal && isAuthenticated && sectionSlug) {
-      const progress = getLocalProgress();
-      const allDone = sectionQuestions.every((q) => progress[q.id]?.completed);
-      if (allDone) reportMilestone("INTERVIEW_SECTION_COMPLETE", sectionSlug);
-    }
-  }, [questionId, isAuthenticated, sectionSlug, sectionQuestions]);
+    void toggleComplete(questionId)
+      .then((newVal) => {
+        if (newVal && isAuthenticated && sectionSlug) {
+          const nextProgress: InterviewProgress = { ...progress, [questionId]: { completed: true } };
+          const allDone = sectionQuestions.every((q) => nextProgress[q.id]?.completed);
+          if (allDone) reportMilestone("INTERVIEW_SECTION_COMPLETE", sectionSlug);
+        }
+      })
+      .catch(() => {});
+  }, [questionId, toggleComplete, isAuthenticated, sectionSlug, sectionQuestions, progress]);
+
+  useEffect(() => {
+    if (questionId) recordVisit(questionId);
+  }, [questionId, recordVisit]);
 
   if (section && !section.freeTier && !isAuthenticated) {
     return <Navigate to={basePath} replace />;

--- a/client/src/module/student/interview-prep/InterviewSectionPage.tsx
+++ b/client/src/module/student/interview-prep/InterviewSectionPage.tsx
@@ -3,26 +3,10 @@ import { useParams, Link, Navigate } from "react-router";
 import { motion } from "framer-motion";
 import { CheckCircle2, ArrowUpRight } from "lucide-react";
 import { sections, questions } from "./data";
-import type { InterviewProgress } from "./data/types";
 import { SEO } from "../../../components/SEO";
 import { canonicalUrl } from "../../../lib/seo.utils";
 import { useAuthStore } from "../../../lib/auth.store";
-
-function getLocalProgress(): InterviewProgress {
-  try {
-    const raw = JSON.parse(localStorage.getItem("interview-progress") || "{}");
-    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
-    const out: InterviewProgress = {};
-    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-      if (v && typeof v === "object" && typeof (v as { completed?: unknown }).completed === "boolean") {
-        out[k] = { completed: (v as { completed: boolean }).completed };
-      }
-    }
-    return out;
-  } catch {
-    return {};
-  }
-}
+import { useInterviewProgress } from "./interviewProgress";
 
 const DIFF_STYLE: Record<string, string> = {
   Beginner:     "text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/60",
@@ -50,18 +34,17 @@ export default function InterviewSectionPage() {
   const { sectionSlug } = useParams();
   const basePath = "/learn/interview";
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
-
-  const progress: InterviewProgress = getLocalProgress();
+  const { progress, isLoading } = useInterviewProgress();
   const section = sections.find((s) => s.id === sectionSlug);
-
-  if (section && !section.freeTier && !isAuthenticated) {
-    return <Navigate to={basePath} replace />;
-  }
 
   const sectionQuestions = useMemo(
     () => questions.filter((q) => q.sectionId === sectionSlug).sort((a, b) => a.orderIndex - b.orderIndex),
     [sectionSlug],
   );
+
+  if (section && !section.freeTier && !isAuthenticated) {
+    return <Navigate to={basePath} replace />;
+  }
 
   if (!section) {
     return (
@@ -147,7 +130,7 @@ export default function InterviewSectionPage() {
         >
           <div className="flex items-center justify-between gap-4 mb-2">
             <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
-              section progress
+              {isLoading ? "syncing progress" : "section progress"}
             </span>
             <span className="text-xs font-mono uppercase tracking-widest text-stone-900 dark:text-stone-50 tabular-nums">
               {completedCount} / {sectionQuestions.length}

--- a/client/src/module/student/interview-prep/interviewProgress.ts
+++ b/client/src/module/student/interview-prep/interviewProgress.ts
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import toast from "../../../components/ui/toast";
+import api from "../../../lib/axios";
+import { useAuthStore } from "../../../lib/auth.store";
+import type { InterviewProgress } from "./data/types";
+
+const LEGACY_PROGRESS_KEY = "interview-progress";
+const LEGACY_COMPLETED_KEY = "interview_completed";
+const LEGACY_BOOKMARKS_KEY = "interview_bookmarks";
+const LEGACY_LAST_VISITED_KEY = "interview_last_visited";
+const MIGRATION_KEY = "interview_progress_migrated_v1";
+const VISIT_DEBOUNCE_MS = 1200;
+
+export interface InterviewServerProgress {
+  completedIds: string[];
+  bookmarkedIds: string[];
+  lastVisitedId: string | null;
+  lastVisitedAt: string | null;
+}
+
+function parseJson<T>(value: string | null, fallback: T): T {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function uniqueIds(ids: string[]) {
+  return Array.from(new Set(ids.map((id) => id.trim()).filter(Boolean))).slice(0, 1000);
+}
+
+function readStringArray(key: string) {
+  const value = parseJson<unknown>(localStorage.getItem(key), []);
+  return Array.isArray(value) ? uniqueIds(value.filter((id): id is string => typeof id === "string")) : [];
+}
+
+function normalizeServerProgress(progress: Partial<InterviewServerProgress> | null): InterviewServerProgress {
+  return {
+    completedIds: Array.isArray(progress?.completedIds) ? uniqueIds(progress.completedIds) : [],
+    bookmarkedIds: Array.isArray(progress?.bookmarkedIds) ? uniqueIds(progress.bookmarkedIds) : [],
+    lastVisitedId: progress?.lastVisitedId || null,
+    lastVisitedAt: progress?.lastVisitedAt || null,
+  };
+}
+
+function readLegacyProgress(): InterviewServerProgress {
+  const objectProgress = parseJson<unknown>(
+    localStorage.getItem(LEGACY_PROGRESS_KEY),
+    {},
+  );
+  const safeObjectProgress =
+    objectProgress && typeof objectProgress === "object" && !Array.isArray(objectProgress)
+      ? (objectProgress as Record<string, { completed?: unknown }>)
+      : {};
+  const objectCompleted = Object.entries(safeObjectProgress)
+    .filter(([, value]) => value && typeof value === "object" && value.completed === true)
+    .map(([id]) => id);
+
+  const completedIds = uniqueIds([
+    ...objectCompleted,
+    ...readStringArray(LEGACY_COMPLETED_KEY),
+  ]);
+  const bookmarkedIds = readStringArray(LEGACY_BOOKMARKS_KEY);
+  const lastVisitedId = localStorage.getItem(LEGACY_LAST_VISITED_KEY) || null;
+
+  return {
+    completedIds,
+    bookmarkedIds,
+    lastVisitedId,
+    lastVisitedAt: null,
+  };
+}
+
+function progressCacheKey(userId?: number) {
+  return userId ? `${LEGACY_PROGRESS_KEY}:${userId}` : LEGACY_PROGRESS_KEY;
+}
+
+function readStoredProgress(userId?: number): InterviewServerProgress {
+  if (!userId) return readLegacyProgress();
+
+  const raw = parseJson<Partial<InterviewServerProgress> | null>(
+    localStorage.getItem(progressCacheKey(userId)),
+    null,
+  );
+
+  return normalizeServerProgress(raw);
+}
+
+function hasLegacyProgress(progress: InterviewServerProgress) {
+  return progress.completedIds.length > 0 || progress.bookmarkedIds.length > 0 || !!progress.lastVisitedId;
+}
+
+function toProgressMap(progress: InterviewServerProgress): InterviewProgress {
+  return progress.completedIds.reduce<InterviewProgress>((acc, id) => {
+    acc[id] = { completed: true };
+    return acc;
+  }, {});
+}
+
+function mergeProgress(
+  server: InterviewServerProgress,
+  legacy: InterviewServerProgress,
+): InterviewServerProgress {
+  return {
+    completedIds: uniqueIds([...server.completedIds, ...legacy.completedIds]),
+    bookmarkedIds: uniqueIds([...server.bookmarkedIds, ...legacy.bookmarkedIds]),
+    lastVisitedId: server.lastVisitedId ?? legacy.lastVisitedId,
+    lastVisitedAt: server.lastVisitedAt,
+  };
+}
+
+function writeStoredProgress(progress: InterviewServerProgress, userId?: number) {
+  if (userId) {
+    localStorage.setItem(progressCacheKey(userId), JSON.stringify(progress));
+    return;
+  }
+
+  localStorage.setItem(LEGACY_PROGRESS_KEY, JSON.stringify(toProgressMap(progress)));
+  localStorage.setItem(LEGACY_COMPLETED_KEY, JSON.stringify(progress.completedIds));
+  localStorage.setItem(LEGACY_BOOKMARKS_KEY, JSON.stringify(progress.bookmarkedIds));
+  if (progress.lastVisitedId) localStorage.setItem(LEGACY_LAST_VISITED_KEY, progress.lastVisitedId);
+}
+
+async function fetchServerProgress() {
+  const { data } = await api.get<InterviewServerProgress>("/learn/interview/progress");
+  return data;
+}
+
+export function useInterviewProgress() {
+  const user = useAuthStore((s) => s.user);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const userId = user?.id;
+  const [progress, setProgress] = useState<InterviewServerProgress>(() => readStoredProgress(userId));
+  const [isLoading, setIsLoading] = useState(isAuthenticated);
+  const progressRef = useRef(progress);
+  const visitTimerRef = useRef<number | null>(null);
+  const lastVisitRef = useRef<string | null>(null);
+
+  const migrationKey = userId ? `${MIGRATION_KEY}:${userId}` : MIGRATION_KEY;
+
+  useEffect(() => {
+    progressRef.current = progress;
+  }, [progress]);
+
+  const hydrate = useCallback(async () => {
+    if (!isAuthenticated) {
+      const legacyProgress = readStoredProgress();
+      progressRef.current = legacyProgress;
+      setProgress(legacyProgress);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const serverProgress = await fetchServerProgress();
+      const legacyProgress = readLegacyProgress();
+      const shouldMigrate = !localStorage.getItem(migrationKey) && hasLegacyProgress(legacyProgress);
+
+      if (shouldMigrate) {
+        const { data } = await api.post<InterviewServerProgress>(
+          "/learn/interview/progress/bulk-migrate",
+          {
+            completedIds: legacyProgress.completedIds,
+            bookmarkedIds: legacyProgress.bookmarkedIds,
+            lastVisitedId: legacyProgress.lastVisitedId,
+          },
+        );
+        const merged = mergeProgress(data, legacyProgress);
+        progressRef.current = merged;
+        setProgress(merged);
+        writeStoredProgress(merged, userId);
+      } else {
+        progressRef.current = serverProgress;
+        setProgress(serverProgress);
+        writeStoredProgress(serverProgress, userId);
+      }
+
+      localStorage.setItem(migrationKey, "1");
+    } catch {
+      const cachedProgress = readStoredProgress(userId);
+      progressRef.current = cachedProgress;
+      setProgress(cachedProgress);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isAuthenticated, migrationKey, userId]);
+
+  useEffect(() => {
+    void hydrate();
+
+    const onStorage = (event: StorageEvent) => {
+      if (!isAuthenticated && (event.key === LEGACY_PROGRESS_KEY || event.key === null)) {
+        setProgress(readLegacyProgress());
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [hydrate, isAuthenticated]);
+
+  const progressMap = useMemo(() => toProgressMap(progress), [progress]);
+
+  const updateProgress = useCallback(
+    async (questionId: string, action: "complete" | "uncomplete" | "bookmark" | "unbookmark" | "visit") => {
+      const progress = progressRef.current;
+      const previous = progress;
+      const next: InterviewServerProgress = {
+        ...progress,
+        completedIds:
+          action === "complete"
+            ? uniqueIds([...progress.completedIds, questionId])
+            : action === "uncomplete"
+              ? progress.completedIds.filter((id) => id !== questionId)
+              : progress.completedIds,
+        bookmarkedIds:
+          action === "bookmark"
+            ? uniqueIds([...progress.bookmarkedIds, questionId])
+            : action === "unbookmark"
+              ? progress.bookmarkedIds.filter((id) => id !== questionId)
+              : progress.bookmarkedIds,
+        lastVisitedId: action === "visit" ? questionId : progress.lastVisitedId,
+        lastVisitedAt: action === "visit" ? new Date().toISOString() : progress.lastVisitedAt,
+      };
+
+      setProgress(next);
+      progressRef.current = next;
+      writeStoredProgress(next, userId);
+
+      if (!isAuthenticated) return next;
+
+      try {
+        const { data } = await api.post<InterviewServerProgress>(
+          `/learn/interview/progress/${encodeURIComponent(questionId)}`,
+          { action },
+        );
+        progressRef.current = data;
+        setProgress(data);
+        writeStoredProgress(data, userId);
+        return data;
+      } catch (error) {
+        progressRef.current = previous;
+        setProgress(previous);
+        writeStoredProgress(previous, userId);
+        if (action !== "visit") toast.error("Could not save progress. Check your connection.");
+        throw error;
+      }
+    },
+    [isAuthenticated, userId],
+  );
+
+  const toggleComplete = useCallback(
+    async (questionId: string) => {
+      const isComplete = progressRef.current.completedIds.includes(questionId);
+      const next = await updateProgress(questionId, isComplete ? "uncomplete" : "complete");
+      return next.completedIds.includes(questionId);
+    },
+    [updateProgress],
+  );
+
+  const recordVisit = useCallback(
+    (questionId: string) => {
+      lastVisitRef.current = questionId;
+      if (visitTimerRef.current) window.clearTimeout(visitTimerRef.current);
+      visitTimerRef.current = window.setTimeout(() => {
+        const id = lastVisitRef.current;
+        lastVisitRef.current = null;
+        if (id) void updateProgress(id, "visit").catch(() => {});
+      }, VISIT_DEBOUNCE_MS);
+    },
+    [updateProgress],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (visitTimerRef.current) window.clearTimeout(visitTimerRef.current);
+      const id = lastVisitRef.current;
+      if (!id) return;
+
+      const nextProgress = {
+        ...progressRef.current,
+        lastVisitedId: id,
+        lastVisitedAt: new Date().toISOString(),
+      };
+      writeStoredProgress(nextProgress, userId);
+
+      if (isAuthenticated) {
+        void api
+          .post<InterviewServerProgress>(`/learn/interview/progress/${encodeURIComponent(id)}`, { action: "visit" })
+          .then(({ data }) => writeStoredProgress(data, userId))
+          .catch(() => {});
+      }
+    };
+  }, [isAuthenticated, userId]);
+
+  return {
+    progress: progressMap,
+    serverProgress: progress,
+    isLoading,
+    refreshProgress: hydrate,
+    toggleComplete,
+    recordVisit,
+  };
+}

--- a/server/src/database/prisma/migrations/20260516000000_add_user_interview_progress/migration.sql
+++ b/server/src/database/prisma/migrations/20260516000000_add_user_interview_progress/migration.sql
@@ -1,0 +1,20 @@
+-- Persist interview lesson progress per student so completion state survives browser and device switches.
+CREATE TABLE "userInterviewProgress" (
+    "id" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "completedIds" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "bookmarkedIds" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "lastVisitedId" TEXT,
+    "lastVisitedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "userInterviewProgress_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "userInterviewProgress_userId_key" ON "userInterviewProgress"("userId");
+CREATE INDEX "userInterviewProgress_userId_idx" ON "userInterviewProgress"("userId");
+
+ALTER TABLE "userInterviewProgress"
+ADD CONSTRAINT "userInterviewProgress_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/src/database/prisma/migrations/20260516000000_add_user_interview_progress/migration.sql
+++ b/server/src/database/prisma/migrations/20260516000000_add_user_interview_progress/migration.sql
@@ -13,7 +13,6 @@ CREATE TABLE "userInterviewProgress" (
 );
 
 CREATE UNIQUE INDEX "userInterviewProgress_userId_key" ON "userInterviewProgress"("userId");
-CREATE INDEX "userInterviewProgress_userId_idx" ON "userInterviewProgress"("userId");
 
 ALTER TABLE "userInterviewProgress"
 ADD CONSTRAINT "userInterviewProgress_userId_fkey"

--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -85,6 +85,7 @@ model user {
   generatedResumes      generatedResume[]           @relation("UserGeneratedResumes")
   leetcodeImports       leetcodeImportLog[]          @relation("UserLeetcodeImports")
   generatedCoverLetters generatedCoverLetter[]       @relation("StudentCoverLetters")
+  interviewProgress     userInterviewProgress?       @relation("UserInterviewProgress")
 
   @@index([role])
   @@index([role, isActive])
@@ -697,6 +698,20 @@ model studentSqlProgress {
 
   @@unique([studentId, exerciseId])
   @@index([studentId])
+}
+
+model userInterviewProgress {
+  id            String   @id @default(cuid())
+  userId        Int      @unique
+  user          user     @relation("UserInterviewProgress", fields: [userId], references: [id], onDelete: Cascade)
+  completedIds  String[] @default([])
+  bookmarkedIds String[] @default([])
+  lastVisitedId String?
+  lastVisitedAt DateTime?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([userId])
 }
 
 model aptitudeCategory {

--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -710,8 +710,6 @@ model userInterviewProgress {
   lastVisitedAt DateTime?
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
-
-  @@index([userId])
 }
 
 model aptitudeCategory {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -58,6 +58,7 @@ import { jobAgentRouter } from "./module/job-agent/job-agent.routes.js";
 import { emailInboundRouter } from "./module/email-inbound/email-inbound.routes.js";
 import { milestoneRouter } from "./module/milestone/milestone.routes.js";
 import { roadmapRouter } from "./module/roadmap/roadmap.routes.js";
+import { learnRouter } from "./module/learn/learn.routes.js";
 import { botSeoMiddleware } from "./middleware/bot-seo.middleware.js";
 import { errorMiddleware } from "./middleware/error.middleware.js";
 import { prisma } from "./database/db.js";
@@ -242,6 +243,7 @@ app.use("/api/hr/analytics", hrAnalyticsRouter);
 app.use("/api/email-inbound", emailInboundRouter);
 app.use("/api/milestones", milestoneRouter);
 app.use("/api/roadmaps", roadmapRouter);
+app.use("/api/learn", learnRouter);
 
 // Public external jobs endpoints (no auth)
 const publicAdminController = new AdminController(new AdminService());

--- a/server/src/module/learn/learn.controller.ts
+++ b/server/src/module/learn/learn.controller.ts
@@ -1,0 +1,73 @@
+import type { Request, Response } from "express";
+import type { LearnService } from "./learn.service.js";
+import { bulkInterviewProgressSchema, interviewProgressActionSchema } from "./learn.validation.js";
+
+export class LearnController {
+  constructor(private readonly learnService: LearnService) {}
+
+  async getInterviewProgress(req: Request, res: Response) {
+    try {
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
+
+      const progress = await this.learnService.getInterviewProgress(req.user.id);
+      return res.json(progress);
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Internal Server Error" });
+    }
+  }
+
+  async updateInterviewProgress(req: Request, res: Response) {
+    try {
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
+      const rawQuestionId = req.params["questionId"];
+      const questionId = Array.isArray(rawQuestionId) ? rawQuestionId[0]?.trim() : rawQuestionId?.trim();
+      if (!questionId) return res.status(400).json({ message: "Question ID is required" });
+      if (questionId.length > 160) return res.status(400).json({ message: "Question ID is too long" });
+
+      const result = interviewProgressActionSchema.safeParse(req.body);
+      if (!result.success) {
+        return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
+      }
+
+      const progress = await this.learnService.updateInterviewProgress(
+        req.user.id,
+        questionId,
+        result.data.action,
+      );
+      return res.json(progress);
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Internal Server Error" });
+    }
+  }
+
+  async bulkMigrateInterviewProgress(req: Request, res: Response) {
+    try {
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
+
+      const result = bulkInterviewProgressSchema.safeParse(req.body);
+      if (!result.success) {
+        return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
+      }
+
+      const progress = await this.learnService.bulkMigrateInterviewProgress(req.user.id, result.data);
+      return res.json(progress);
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Internal Server Error" });
+    }
+  }
+
+  async resetInterviewProgress(req: Request, res: Response) {
+    try {
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
+
+      const progress = await this.learnService.resetInterviewProgress(req.user.id);
+      return res.json(progress);
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Internal Server Error" });
+    }
+  }
+}

--- a/server/src/module/learn/learn.routes.ts
+++ b/server/src/module/learn/learn.routes.ts
@@ -1,0 +1,38 @@
+import { Router } from "express";
+import { authMiddleware } from "../../middleware/auth.middleware.js";
+import { requireRole } from "../../middleware/role.middleware.js";
+import { LearnController } from "./learn.controller.js";
+import { LearnService } from "./learn.service.js";
+
+const learnService = new LearnService();
+const learnController = new LearnController(learnService);
+
+export const learnRouter = Router();
+
+learnRouter.get(
+  "/interview/progress",
+  authMiddleware,
+  requireRole("STUDENT"),
+  (req, res) => learnController.getInterviewProgress(req, res),
+);
+
+learnRouter.post(
+  "/interview/progress/bulk-migrate",
+  authMiddleware,
+  requireRole("STUDENT"),
+  (req, res) => learnController.bulkMigrateInterviewProgress(req, res),
+);
+
+learnRouter.post(
+  "/interview/progress/:questionId",
+  authMiddleware,
+  requireRole("STUDENT"),
+  (req, res) => learnController.updateInterviewProgress(req, res),
+);
+
+learnRouter.delete(
+  "/interview/progress",
+  authMiddleware,
+  requireRole("STUDENT"),
+  (req, res) => learnController.resetInterviewProgress(req, res),
+);

--- a/server/src/module/learn/learn.service.ts
+++ b/server/src/module/learn/learn.service.ts
@@ -1,0 +1,163 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "../../database/db.js";
+import type { InterviewProgressAction, BulkInterviewProgressInput } from "./learn.validation.js";
+
+export interface InterviewProgressDto {
+  completedIds: string[];
+  bookmarkedIds: string[];
+  lastVisitedId: string | null;
+  lastVisitedAt: Date | null;
+}
+
+const EMPTY_PROGRESS: InterviewProgressDto = {
+  completedIds: [],
+  bookmarkedIds: [],
+  lastVisitedId: null,
+  lastVisitedAt: null,
+};
+
+function uniqueIds(ids: string[]) {
+  return Array.from(new Set(ids.map((id) => id.trim()).filter(Boolean))).slice(0, 1000);
+}
+
+function serializeProgress(progress: {
+  completedIds: string[];
+  bookmarkedIds: string[];
+  lastVisitedId: string | null;
+  lastVisitedAt: Date | null;
+}): InterviewProgressDto {
+  return {
+    completedIds: progress.completedIds,
+    bookmarkedIds: progress.bookmarkedIds,
+    lastVisitedId: progress.lastVisitedId,
+    lastVisitedAt: progress.lastVisitedAt,
+  };
+}
+
+async function runSerializable<T>(operation: (tx: Prisma.TransactionClient) => Promise<T>): Promise<T> {
+  const maxAttempts = 3;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await prisma.$transaction(operation, {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      });
+    } catch (error) {
+      const canRetry =
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2034" &&
+        attempt < maxAttempts;
+
+      if (!canRetry) throw error;
+    }
+  }
+
+  throw new Error("Could not save interview progress");
+}
+
+export class LearnService {
+  async getInterviewProgress(userId: number): Promise<InterviewProgressDto> {
+    const progress = await prisma.userInterviewProgress.findUnique({
+      where: { userId },
+      select: {
+        completedIds: true,
+        bookmarkedIds: true,
+        lastVisitedId: true,
+        lastVisitedAt: true,
+      },
+    });
+
+    return progress ? serializeProgress(progress) : EMPTY_PROGRESS;
+  }
+
+  async updateInterviewProgress(
+    userId: number,
+    questionId: string,
+    action: InterviewProgressAction,
+  ): Promise<InterviewProgressDto> {
+    const progress = await runSerializable(async (tx) => {
+      const existing = await tx.userInterviewProgress.findUnique({ where: { userId } });
+      const completedIds = new Set(existing?.completedIds ?? []);
+      const bookmarkedIds = new Set(existing?.bookmarkedIds ?? []);
+      let lastVisitedId = existing?.lastVisitedId ?? null;
+      let lastVisitedAt = existing?.lastVisitedAt ?? null;
+
+      if (action === "complete") completedIds.add(questionId);
+      if (action === "uncomplete") completedIds.delete(questionId);
+      if (action === "bookmark") bookmarkedIds.add(questionId);
+      if (action === "unbookmark") bookmarkedIds.delete(questionId);
+      if (action === "visit") {
+        lastVisitedId = questionId;
+        lastVisitedAt = new Date();
+      }
+
+      return tx.userInterviewProgress.upsert({
+        where: { userId },
+        update: {
+          completedIds: Array.from(completedIds),
+          bookmarkedIds: Array.from(bookmarkedIds),
+          lastVisitedId,
+          lastVisitedAt,
+        },
+        create: {
+          userId,
+          completedIds: Array.from(completedIds),
+          bookmarkedIds: Array.from(bookmarkedIds),
+          lastVisitedId,
+          lastVisitedAt,
+        },
+        select: {
+          completedIds: true,
+          bookmarkedIds: true,
+          lastVisitedId: true,
+          lastVisitedAt: true,
+        },
+      });
+    });
+
+    return serializeProgress(progress);
+  }
+
+  async bulkMigrateInterviewProgress(
+    userId: number,
+    input: BulkInterviewProgressInput,
+  ): Promise<InterviewProgressDto> {
+    const progress = await runSerializable(async (tx) => {
+      const existing = await tx.userInterviewProgress.findUnique({ where: { userId } });
+      const completedIds = uniqueIds([...(existing?.completedIds ?? []), ...input.completedIds]);
+      const bookmarkedIds = uniqueIds([...(existing?.bookmarkedIds ?? []), ...input.bookmarkedIds]);
+      const lastVisitedId = existing?.lastVisitedId ?? input.lastVisitedId ?? null;
+      const lastVisitedAt = existing?.lastVisitedAt ?? (lastVisitedId ? new Date() : null);
+
+      return tx.userInterviewProgress.upsert({
+        where: { userId },
+        update: {
+          completedIds,
+          bookmarkedIds,
+          lastVisitedId,
+          lastVisitedAt,
+        },
+        create: {
+          userId,
+          completedIds,
+          bookmarkedIds,
+          lastVisitedId,
+          lastVisitedAt,
+        },
+        select: {
+          completedIds: true,
+          bookmarkedIds: true,
+          lastVisitedId: true,
+          lastVisitedAt: true,
+        },
+      });
+    });
+
+    return serializeProgress(progress);
+  }
+
+  async resetInterviewProgress(userId: number): Promise<InterviewProgressDto> {
+    await prisma.userInterviewProgress.deleteMany({ where: { userId } });
+    return EMPTY_PROGRESS;
+  }
+}

--- a/server/src/module/learn/learn.validation.ts
+++ b/server/src/module/learn/learn.validation.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+const questionIdSchema = z.string().trim().min(1).max(160);
+const idArraySchema = z.array(questionIdSchema).max(1000);
+
+export const interviewProgressActionSchema = z.object({
+  action: z.enum(["complete", "uncomplete", "bookmark", "unbookmark", "visit"]),
+});
+
+export const bulkInterviewProgressSchema = z.object({
+  completedIds: idArraySchema.default([]),
+  bookmarkedIds: idArraySchema.default([]),
+  lastVisitedId: questionIdSchema.nullish(),
+});
+
+export type InterviewProgressAction = z.infer<typeof interviewProgressActionSchema>["action"];
+export type BulkInterviewProgressInput = z.infer<typeof bulkInterviewProgressSchema>;


### PR DESCRIPTION
## Summary

Fixes #73.

This PR moves interview lesson progress from browser-only localStorage to authenticated server-side persistence, while keeping a safe local fallback for guests/offline states.

## What Changed

- Added `userInterviewProgress` Prisma model with one row per user.
- Added migration for persisted interview progress:
  - `completedIds`
  - `bookmarkedIds`
  - `lastVisitedId`
  - `lastVisitedAt`
- Added authenticated student endpoints under `/api/learn`:
  - `GET /learn/interview/progress`
  - `POST /learn/interview/progress/:questionId`
  - `POST /learn/interview/progress/bulk-migrate`
  - `DELETE /learn/interview/progress`
- Updated interview prep pages to use a shared `useInterviewProgress` hook.
- Added one-time migration from legacy localStorage progress.
- Added optimistic UI updates with rollback on failed save.
- Debounced `visit` updates to avoid excessive writes during rapid navigation.
- Kept legacy localStorage keys as a safety net instead of deleting user data immediately.

## Production Safeguards

- Server routes are auth-gated and restricted to `STUDENT`.
- Request bodies are validated with Zod.
- Bulk migration arrays are capped at 1000 IDs to avoid abuse.
- Migration merges local and server progress instead of overwriting server data.
- Server progress writes use serializable transactions with retry to reduce lost-update risk from multiple tabs/devices.
- Client cache is scoped by user ID to avoid progress leaking between accounts.
- Failed completion/bookmark writes roll back optimistic UI and show a toast.

## Testing

Passed:

- `npx.cmd tsc -b` in `client`
- `npx.cmd prisma validate` from `server/src/database`
- `npx.cmd prisma generate` from `server/src/database`
- `git diff --cached --check`

Note: `npm.cmd run build` in `server` is currently blocked by pre-existing unrelated TypeScript errors in:
- `src/middleware/cache.middleware.ts`
- `src/module/ats/cover-letter.service.ts`
- `src/module/roadmap/roadmap.pdf.ts`
- `src/module/student/student.routes.ts`

Those errors are outside the scope of this interview progress PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interview progress now saves to your account and automatically syncs across devices
  * Automatic migration of previous local progress into your account
  * Visual feedback shows “syncing progress” while progress is loading/syncing
  * Faster, optimistic marking/bookmarking and visit tracking with reduced server writes
  * Option to reset all interview progress

* **Documentation**
  * Added repository-wide contributor guidance and conventions (usage, UI/style, and workflow rules)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->