### PR TITLE
fix: add hover highlight to Starter and Scale pricing cards

### DIFF
--- a/client/src/module/recruiter/RecruiterLandingPage.tsx
+++ b/client/src/module/recruiter/RecruiterLandingPage.tsx
@@ -473,7 +473,7 @@ export default function RecruiterLandingPage() {
                 className={
                   plan.highlighted
                     ? "relative rounded-2xl border-2 border-lime-400/50 shadow-2xl shadow-lime-400/10 bg-white dark:bg-stone-900 flex flex-col"
-                    : "relative rounded-2xl border border-stone-200 dark:border-white/10 bg-white dark:bg-stone-900 flex flex-col"
+                    : "relative rounded-2xl border border-stone-200 dark:border-white/10 bg-white dark:bg-stone-900 flex flex-col hover:border-lime-400 hover:shadow-2xl hover:shadow-lime-400/10 hover:-translate-y-1 transition-all duration-300"
                 }
               >
                 {plan.highlighted && (


### PR DESCRIPTION
## Summary
Add hover highlight effect to Starter and Scale pricing cards on the /for-recruiters page. Previously only the Growth (Most Popular) card had a persistent highlight , the other two cards were completely flat on hover with no visual feedback.

## Changes
- Added hover states (border, shadow, translate) to non-highlighted pricing cards in RecruiterLandingPage.tsx

## How to test
1. Go to /for-recruiters
2. Hover over the Starter and Scale cards
3. Confirm highlight effect appears on hover
4. Confirm Growth card retains its permanent highlight

Closes #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced hover effects on pricing plan cards with improved visual feedback including border color changes, stronger shadow effects, and smooth upward animation on interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->