### PR TITLE
fix: move logo on login and register promo panels to remove inconsist…

### DIFF
--- a/client/src/module/auth/LoginPage.tsx
+++ b/client/src/module/auth/LoginPage.tsx
@@ -95,17 +95,7 @@ export default function LoginPage() {
         ]}
       />
 
-      <div className="relative flex items-start lg:items-center justify-center px-6 pt-24 pb-12 lg:py-0">
-        <Link
-          to="/"
-          className="absolute top-6 left-6 flex items-center gap-2 text-sm no-underline text-stone-500 hover:text-stone-900 dark:hover:text-stone-50 transition-colors"
-        >
-          <div className="relative">
-            <img src="/logo.png" alt="InternHack" className="h-7 w-7 rounded-md object-contain" />
-            <span className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 bg-lime-400" />
-          </div>
-          <span className="font-bold text-stone-900 dark:text-stone-50">InternHack</span>
-        </Link>
+      <div className="flex items-center justify-center px-6 py-12 lg:py-0">
 
         <motion.div
           initial={{ opacity: 0, y: 16 }}
@@ -262,7 +252,7 @@ function AuthPromoPanel({
   stats: { value: string; suffix: string; label: string }[];
 }) {
   return (
-    <div className="hidden lg:flex relative flex-col justify-between p-12 xl:p-16 bg-stone-900 overflow-hidden">
+    <div className="hidden lg:flex relative flex-col justify-between px-12 xl:px-16 pt-8 pb-12 xl:pb-16 bg-stone-900 overflow-hidden">
       <div aria-hidden className="absolute inset-0 pointer-events-none opacity-[0.06] auth-promo-dots" />
       <div aria-hidden className="absolute inset-0 pointer-events-none auth-promo-lines" />
 

--- a/client/src/module/auth/RegisterPage.tsx
+++ b/client/src/module/auth/RegisterPage.tsx
@@ -126,7 +126,7 @@ return (
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4 }}
-        className="w-full max-w-md mt-16 lg:mt-0"
+        className="w-full max-w-md"
       >
         <div className="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-stone-500 mb-5">
           <span className="h-1.5 w-1.5 bg-lime-400" />

--- a/client/src/module/auth/RegisterPage.tsx
+++ b/client/src/module/auth/RegisterPage.tsx
@@ -120,23 +120,13 @@ return (
       isRecruiter={isRecruiter}
     />
 
-    <div className="relative flex items-center justify-center px-6 py-16 lg:py-0">
-      <Link
-        to="/"
-        className="absolute top-6 left-6 flex items-center gap-2 text-sm no-underline text-stone-500 hover:text-stone-900 dark:hover:text-stone-50 transition-colors"
-      >
-        <div className="relative">
-          <img src="/logo.png" alt="InternHack" className="h-7 w-7 rounded-md object-contain" />
-          <span className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 bg-lime-400" />
-        </div>
-        <span className="font-bold text-stone-900 dark:text-stone-50">InternHack</span>
-      </Link>
+    <div className="flex items-center justify-center px-6 py-12 lg:py-0">
 
       <motion.div
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4 }}
-        className="w-full max-w-md"
+        className="w-full max-w-md mt-16 lg:mt-0"
       >
         <div className="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-stone-500 mb-5">
           <span className="h-1.5 w-1.5 bg-lime-400" />
@@ -336,10 +326,19 @@ function AuthPromoPanel({ isRecruiter }: { isRecruiter: boolean }) {
   const stats = isRecruiter ? recruiterStats : studentStats;
 
   return (
-    <div className="hidden lg:flex relative flex-col justify-center p-12 xl:p-16 bg-stone-900 overflow-hidden">
+    <div className="hidden lg:flex relative flex-col justify-between px-12 xl:px-16 pt-8 pb-12 xl:pb-16 bg-stone-900 overflow-hidden">
       <div aria-hidden className="absolute inset-0 pointer-events-none opacity-[0.06] auth-promo-dots" />
       <div aria-hidden className="absolute inset-0 pointer-events-none auth-promo-lines" />
 
+      <div className="relative mb-auto">
+        <Link to="/" className="inline-flex items-center gap-2.5 no-underline">
+          <div className="relative">
+            <img src="/logo.png" alt="InternHack" className="h-8 w-8 rounded-md object-contain" />
+            <span className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 bg-lime-400" />
+          </div>
+          <span className="text-base font-bold tracking-tight text-stone-50">InternHack</span>
+        </Link>
+      </div>
       <div className="relative max-w-lg">
         <motion.div
           key={isRecruiter ? "r" : "s"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "internHack",
+  "name": "InternHack",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
Closes #280 

## Problem
The InternHack logo was rendered twice on both the Login and Register pages:
- Once correctly in the left dark promo panel
- Once as an `absolute`-positioned element on the right form panel

This caused the logo to visually overlap the page heading (`"Create an account."` / `"Sign in"`) on the form side, making the header section look broken.

## Changes
- Removed the duplicate `absolute`-positioned logo `<Link>` from the right form panel on both `LoginPage.tsx` and `RegisterPage.tsx`
- Added the InternHack logo to the left promo panel on `RegisterPage.tsx` to match `LoginPage.tsx`
- Switched `RegisterPage` promo panel from `justify-center` to `justify-between` to properly space the logo and content
- Cleaned up unnecessary `relative` positioning and excess top padding from the form container
- Reduced top padding on both promo panels so the logo sits closer to the top

## Files Changed
- `client/src/module/auth/LoginPage.tsx`
- `client/src/module/auth/RegisterPage.tsx`

## Screenshots
<img width="1853" height="855" alt="Screenshot 2026-05-16 224446" src="https://github.com/user-attachments/assets/65d5e494-ed84-48dc-aee1-2108a969f47c" />
<img width="1828" height="847" alt="Screenshot 2026-05-16 224506" src="https://github.com/user-attachments/assets/a909ad68-b575-4c5c-a296-7c307138ff00" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Reorganized login and register page layouts for improved visual hierarchy
  * Updated padding and spacing across authentication pages
  * Repositioned branding elements in the authentication interface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->