### PR TITLE
fix: close Dodo payment overlay on dismiss and navigation

### DIFF
--- a/client/src/module/student/checkout/CheckoutPage.tsx
+++ b/client/src/module/student/checkout/CheckoutPage.tsx
@@ -189,11 +189,19 @@ export default function CheckoutPage() {
           }
         }
         if (event.event_type === "checkout.closed") {
+          DodoPayments.Checkout.close();
           setLoading(null);
         }
       },
     });
   }, [pollSubscription]);
+
+  // Close overlay if user navigates away mid-checkout
+  useEffect(() => {
+    return () => {
+      DodoPayments.Checkout.close();
+    };
+  }, []);
 
   const handleSelectPlan = async (planKey: PlanKey) => {
     if (planKey === "free") return;


### PR DESCRIPTION
## Problem
The Dodo Payments checkout overlay cannot be closed once opened:

✕ button does nothing — clicking close has no effect, user is stuck
Overlay persists on navigation — pressing the browser back button changes the URL but the overlay iframe remains on screen on top of unrelated pages.

## Root Cause
In CheckoutPage.tsx, the checkout.closed event was handled but DodoPayments.Checkout.close() was never called. Since Dodo injects the iframe directly into <body> outside React's tree, nothing dismissed it. There was also no cleanup when the component unmounted.

## Changes
File: CheckoutPage.tsx

Change 1 — Call DodoPayments.Checkout.close() in the checkout.closed event handler.

Change 2 — Add a cleanup useEffect to close the overlay when the component unmounts.

## After This Fix

- Clicking ✕ now properly closes the checkout overlay
- Navigating away automatically removes stale payment iframes
- Users can safely return to previous pages without getting stuck
- Prevents overlay persistence across route changes

Fixes #281 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the checkout overlay would persist when users navigated away during the checkout process. The overlay now properly closes and clears state when checkout is completed or dismissed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->