### PR TITLE
fix: show filtered count in stats row when search is active

### DIFF
--- a/client/src/module/student/applications/MyApplicationsPage.tsx
+++ b/client/src/module/student/applications/MyApplicationsPage.tsx
@@ -260,6 +260,7 @@ export default function MyApplicationsPage() {
   }, [externalApplications, debouncedSearch]);
 
   const totalAll = applications.length + externalApplications.length;
+  const totalFiltered = filtered.length + filteredExternal.length;
 
   const handleWithdraw = useCallback(
     async (id: number) => {
@@ -310,13 +311,16 @@ export default function MyApplicationsPage() {
           </p>
         </div>
         {totalAll > 0 && (
-          <div className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
-            total{" "}
-            <span className="text-stone-900 dark:text-stone-50 text-sm font-bold tabular-nums ml-1">
-              {totalAll}
-            </span>
-          </div>
-        )}
+           <div className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
+           {hasSearch ? "showing" : "total"}{" "}
+           <span className="text-stone-900 dark:text-stone-50 text-sm font-bold tabular-nums ml-1">
+           {hasSearch ? totalFiltered : totalAll}
+          </span>
+          {hasSearch && (
+          <span className="ml-1">of {totalAll}</span>
+           )}
+        </div>
+       )}
       </motion.div>
 
       {/* Search */}


### PR DESCRIPTION
Closes #42 
Problem:

The stats row in the applications page always displayed the total count of all applications regardless of any active search filter. This was misleading — if a student searched for "Google" and only 2 results appeared out of 10 total applications, the counter still showed "total 10" instead of reflecting the filtered results.
Root Cause:
The totalAll variable was always calculated from the full applications and externalApplications arrays, and was never updated to reflect the filtered state.
Fix:

Added a totalFiltered variable that combines the lengths of filtered and filteredExternal arrays. The stats row now conditionally displays:

"showing X of Y" when a search is active — making it clear how many results match vs total
"total X" when no search is active — preserving existing behavior

Changes made:

Added totalFiltered computed variable
Updated stats row UI to conditionally show filtered vs total count with clear labeling

Files changed:

client/src/module/student/applications/MyApplicationsPage.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated application count display to accurately reflect search results. When searching, the header now shows the filtered count alongside the total count for better clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->