### PR TITLE
Fix: Resolve roadmap API validation failure caused by invalid limit parameter

### DIFF
--- a/client/src/module/student/roadmap/RoadmapsLandingPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapsLandingPage.tsx
@@ -68,7 +68,7 @@ export default function RoadmapsLandingPage() {
   const tag = searchParams.get("tag") || "";
   const category = searchParams.get("category") || "";
 
-  const params: Record<string, string | number> = { page: 1, limit: 100 };
+  const params: Record<string, string | number> = { page: 1, limit: 50 };
   if (debouncedSearch) params.search = debouncedSearch;
   if (level && level !== "ALL_LEVELS") params.level = level;
   if (tag) params.tag = tag;


### PR DESCRIPTION
### Issue

The frontend was sending the following request parameter:

```txt
limit=100
```

However, the backend validation only allows values less than or equal to `50`.

This mismatch caused:

* `400 Bad Request` responses
* roadmap fetch failures
* empty/error UI state in the Career Roadmaps section

---

### Changes Made

* Updated frontend roadmap API request limit from `100` to `50`
* Verified roadmap data loads successfully
* Confirmed filters and pagination work correctly after the fix

---

### Result

* API now returns `200 OK`
* Roadmap data renders properly
* Error state no longer appears

---

### Screenshots

#### Before Fix

* API returned `400 Bad Request`
* Roadmaps failed to load

#### After Fix

* API returns `200 OK`
* Roadmaps load successfully

---

### Testing Performed

* Tested roadmap loading with filters
* Tested page reload behavior
* Verified no console/network errors
* Confirmed backend request uses valid limit value

---

Closes #183
<img width="959" height="449" alt="Screenshot 2026-05-13 201200" src="https://github.com/user-attachments/assets/35235a87-887f-4c1f-bb80-b13011770caf" />
<img width="959" height="509" alt="Screenshot 2026-05-17 150600" src="https://github.com/user-attachments/assets/5669def4-f821-494b-b08f-553b21264eca" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized roadmap list loading by reducing default initial results returned.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->