### PR TITLE
fix(auth): add field-level validation messages to registration forms

### DIFF
--- a/client/src/module/auth/RegisterPage.tsx
+++ b/client/src/module/auth/RegisterPage.tsx
@@ -34,6 +34,59 @@ export default function RegisterPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  // Validation functions
+  const validateName = (name: string): string => {
+    if (!name.trim()) return "Name is required";
+    if (name.trim().length < 2) return "Name must be at least 2 characters long";
+    return "";
+  };
+
+  const validateEmail = (email: string, userRole: string): string => {
+    if (!email.trim()) return "Email is required";
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return "Invalid email address";
+    if (userRole === "RECRUITER" && isPersonalEmail(email)) {
+      return "Please use your company email. Personal email addresses (Gmail, Yahoo, etc.) are not allowed for recruiter accounts.";
+    }
+    return "";
+  };
+
+  const validatePassword = (password: string): string => {
+    if (!password) return "Password is required";
+    if (password.length < 6) return "Password must be at least 6 characters";
+    return "";
+  };
+
+  const handleFieldChange = (field: string, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    
+    // Real-time validation
+    const newErrors = { ...fieldErrors };
+    if (field === "name") {
+      const nameError = validateName(value);
+      if (nameError) {
+        newErrors.name = nameError;
+      } else {
+        delete newErrors.name;
+      }
+    } else if (field === "email") {
+      const emailError = validateEmail(value, role);
+      if (emailError) {
+        newErrors.email = emailError;
+      } else {
+        delete newErrors.email;
+      }
+    } else if (field === "password") {
+      const passwordError = validatePassword(value);
+      if (passwordError) {
+        newErrors.password = passwordError;
+      } else {
+        delete newErrors.password;
+      }
+    }
+    setFieldErrors(newErrors);
+  };
 
   const redirectAfterAuth = (userRole: string) => {
     if (returnTo) {
@@ -63,13 +116,24 @@ export default function RegisterPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
-    setLoading(true);
-
-    if (role === "RECRUITER" && isPersonalEmail(form.email)) {
-      setError("Please use your company email. Personal email addresses (Gmail, Yahoo, etc.) are not allowed for recruiter accounts.");
-      setLoading(false);
+    setFieldErrors({});
+    
+    // Validate all fields
+    const newErrors: Record<string, string> = {};
+    const nameError = validateName(form.name);
+    const emailError = validateEmail(form.email, role);
+    const passwordError = validatePassword(form.password);
+    
+    if (nameError) newErrors.name = nameError;
+    if (emailError) newErrors.email = emailError;
+    if (passwordError) newErrors.password = passwordError;
+    
+    if (Object.keys(newErrors).length > 0) {
+      setFieldErrors(newErrors);
       return;
     }
+
+    setLoading(true);
 
     try {
       const payload: Record<string, string> = { name: form.name, email: form.email, password: form.password, role };
@@ -87,24 +151,33 @@ export default function RegisterPage() {
           data?: {
             message?: string;
             errors?: {
-              fieldErrors?: {
-                email?: string[];
-              };
+              fieldErrors?: Record<string, string[]>;
             };
           };
         };
       };
 
-      const backendMessage =
-        error.response?.data?.errors?.fieldErrors?.email?.[0] ||
-        error.response?.data?.message ||
-        "Registration failed";
+      // Handle field-level errors from backend
+      const backendFieldErrors = error.response?.data?.errors?.fieldErrors;
+      if (backendFieldErrors && typeof backendFieldErrors === "object") {
+        const fieldErrorsObj: Record<string, string> = {};
+        for (const [field, messages] of Object.entries(backendFieldErrors)) {
+          if (Array.isArray(messages) && messages.length > 0) {
+            fieldErrorsObj[field] = messages[0];
+          }
+        }
+        if (Object.keys(fieldErrorsObj).length > 0) {
+          setFieldErrors(fieldErrorsObj);
+          return;
+        }
+      }
 
+      const backendMessage = error.response?.data?.message || "Registration failed";
       setError(backendMessage);
     } finally {
-    setLoading(false);
-  }
-};
+      setLoading(false);
+    }
+  };
 
 const isRecruiter = role === "RECRUITER";
 
@@ -208,27 +281,35 @@ return (
           </div>
 
           <form onSubmit={handleSubmit} className="space-y-4">
-            <FormField label="Full name">
+            <FormField label="Full name" error={fieldErrors.name}>
               <input
                 type="text"
                 value={form.name}
-                onChange={(e) => setForm({ ...form, name: e.target.value })}
-                className="w-full px-4 py-3 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm"
+                onChange={(e) => handleFieldChange("name", e.target.value)}
+                className={`w-full px-4 py-3 border rounded-md focus:outline-none transition-colors bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm ${
+                  fieldErrors.name
+                    ? "border-red-300 dark:border-red-800 focus:border-red-400"
+                    : "border-stone-300 dark:border-white/10 focus:border-lime-400"
+                }`}
                 placeholder="Jane Doe"
                 required
               />
             </FormField>
 
-            <FormField label={isRecruiter ? "Company email" : "Email"}>
+            <FormField label={isRecruiter ? "Company email" : "Email"} error={fieldErrors.email}>
               <input
                 type="email"
                 value={form.email}
-                onChange={(e) => setForm({ ...form, email: e.target.value })}
-                className="w-full px-4 py-3 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm"
+                onChange={(e) => handleFieldChange("email", e.target.value)}
+                className={`w-full px-4 py-3 border rounded-md focus:outline-none transition-colors bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm ${
+                  fieldErrors.email
+                    ? "border-red-300 dark:border-red-800 focus:border-red-400"
+                    : "border-stone-300 dark:border-white/10 focus:border-lime-400"
+                }`}
                 placeholder={isRecruiter ? "you@company.com" : "you@example.com"}
                 required
               />
-              {isRecruiter && (
+              {!fieldErrors.email && isRecruiter && (
                 <p className="mt-1.5 text-xs font-mono text-amber-600 dark:text-amber-400">
                   no personal gmail, yahoo, or outlook.
                 </p>
@@ -248,13 +329,17 @@ return (
               </FormField>
             )}
 
-            <FormField label="Password">
+            <FormField label="Password" error={fieldErrors.password}>
               <div className="relative">
                 <input
                   type={showPassword ? "text" : "password"}
                   value={form.password}
-                  onChange={(e) => setForm({ ...form, password: e.target.value })}
-                  className="w-full px-4 py-3 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors pr-10 bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm"
+                  onChange={(e) => handleFieldChange("password", e.target.value)}
+                  className={`w-full px-4 py-3 border rounded-md focus:outline-none transition-colors pr-10 bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm ${
+                    fieldErrors.password
+                      ? "border-red-300 dark:border-red-800 focus:border-red-400"
+                      : "border-stone-300 dark:border-white/10 focus:border-lime-400"
+                  }`}
                   placeholder="Min. 6 characters"
                   required
                   minLength={6}
@@ -303,10 +388,12 @@ return (
 function FormField({
   label,
   right,
+  error,
   children,
 }: {
   label: string;
   right?: React.ReactNode;
+  error?: string;
   children: React.ReactNode;
 }) {
   return (
@@ -318,6 +405,11 @@ function FormField({
         {right}
       </div>
       {children}
+      {error && (
+        <p className="mt-1.5 text-xs text-red-600 dark:text-red-400 font-medium">
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/client/src/module/recruiter/auth/RecruiterRegisterPage.tsx
+++ b/client/src/module/recruiter/auth/RecruiterRegisterPage.tsx
@@ -13,10 +13,77 @@ export default function RecruiterRegisterPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  // Validation functions
+  const validateName = (name: string): string => {
+    if (!name.trim()) return "Name is required";
+    if (name.trim().length < 2) return "Name must be at least 2 characters long";
+    return "";
+  };
+
+  const validateEmail = (email: string): string => {
+    if (!email.trim()) return "Email is required";
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return "Invalid email address";
+    return "";
+  };
+
+  const validatePassword = (password: string): string => {
+    if (!password) return "Password is required";
+    if (password.length < 6) return "Password must be at least 6 characters";
+    return "";
+  };
+
+  const handleFieldChange = (field: string, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    
+    // Real-time validation
+    const newErrors = { ...fieldErrors };
+    if (field === "name") {
+      const nameError = validateName(value);
+      if (nameError) {
+        newErrors.name = nameError;
+      } else {
+        delete newErrors.name;
+      }
+    } else if (field === "email") {
+      const emailError = validateEmail(value);
+      if (emailError) {
+        newErrors.email = emailError;
+      } else {
+        delete newErrors.email;
+      }
+    } else if (field === "password") {
+      const passwordError = validatePassword(value);
+      if (passwordError) {
+        newErrors.password = passwordError;
+      } else {
+        delete newErrors.password;
+      }
+    }
+    setFieldErrors(newErrors);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+    setFieldErrors({});
+    
+    // Validate all fields
+    const newErrors: Record<string, string> = {};
+    const nameError = validateName(form.name);
+    const emailError = validateEmail(form.email);
+    const passwordError = validatePassword(form.password);
+    
+    if (nameError) newErrors.name = nameError;
+    if (emailError) newErrors.email = emailError;
+    if (passwordError) newErrors.password = passwordError;
+    
+    if (Object.keys(newErrors).length > 0) {
+      setFieldErrors(newErrors);
+      return;
+    }
+
     setLoading(true);
 
     try {
@@ -35,8 +102,34 @@ export default function RecruiterRegisterPage() {
         navigate("/recruiters");
       }
     } catch (err: unknown) {
-      const error = err as { response?: { data?: { message?: string } } };
-      setError(error.response?.data?.message || "Registration failed");
+      const error = err as {
+        response?: {
+          data?: {
+            message?: string;
+            errors?: {
+              fieldErrors?: Record<string, string[]>;
+            };
+          };
+        };
+      };
+
+      // Handle field-level errors from backend
+      const backendFieldErrors = error.response?.data?.errors?.fieldErrors;
+      if (backendFieldErrors && typeof backendFieldErrors === "object") {
+        const fieldErrorsObj: Record<string, string> = {};
+        for (const [field, messages] of Object.entries(backendFieldErrors)) {
+          if (Array.isArray(messages) && messages.length > 0) {
+            fieldErrorsObj[field] = messages[0];
+          }
+        }
+        if (Object.keys(fieldErrorsObj).length > 0) {
+          setFieldErrors(fieldErrorsObj);
+          return;
+        }
+      }
+
+      const backendMessage = error.response?.data?.message || "Registration failed";
+      setError(backendMessage);
     } finally {
       setLoading(false);
     }
@@ -100,23 +193,31 @@ export default function RecruiterRegisterPage() {
             )}
 
             <form onSubmit={handleSubmit} className="space-y-4">
-              <FormField label="Full name">
+              <FormField label="Full name" error={fieldErrors.name}>
                 <input
                   type="text"
                   value={form.name}
-                  onChange={(e) => setForm({ ...form, name: e.target.value })}
-                  className="w-full px-4 py-3 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm"
+                  onChange={(e) => handleFieldChange("name", e.target.value)}
+                  className={`w-full px-4 py-3 border rounded-md focus:outline-none transition-colors bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm ${
+                    fieldErrors.name
+                      ? "border-red-300 dark:border-red-800 focus:border-red-400"
+                      : "border-stone-300 dark:border-white/10 focus:border-lime-400"
+                  }`}
                   placeholder="Jane Doe"
                   required
                 />
               </FormField>
 
-              <FormField label="Work email">
+              <FormField label="Work email" error={fieldErrors.email}>
                 <input
                   type="email"
                   value={form.email}
-                  onChange={(e) => setForm({ ...form, email: e.target.value })}
-                  className="w-full px-4 py-3 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm"
+                  onChange={(e) => handleFieldChange("email", e.target.value)}
+                  className={`w-full px-4 py-3 border rounded-md focus:outline-none transition-colors bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm ${
+                    fieldErrors.email
+                      ? "border-red-300 dark:border-red-800 focus:border-red-400"
+                      : "border-stone-300 dark:border-white/10 focus:border-lime-400"
+                  }`}
                   placeholder="you@company.com"
                   required
                 />
@@ -133,13 +234,17 @@ export default function RecruiterRegisterPage() {
                 />
               </FormField>
 
-              <FormField label="Password">
+              <FormField label="Password" error={fieldErrors.password}>
                 <div className="relative">
                   <input
                     type={showPassword ? "text" : "password"}
                     value={form.password}
-                    onChange={(e) => setForm({ ...form, password: e.target.value })}
-                    className="w-full px-4 py-3 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors pr-10 bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm"
+                    onChange={(e) => handleFieldChange("password", e.target.value)}
+                    className={`w-full px-4 py-3 border rounded-md focus:outline-none transition-colors pr-10 bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600 text-sm ${
+                      fieldErrors.password
+                        ? "border-red-300 dark:border-red-800 focus:border-red-400"
+                        : "border-stone-300 dark:border-white/10 focus:border-lime-400"
+                    }`}
                     placeholder="Min. 6 characters"
                     required
                     minLength={6}
@@ -206,10 +311,12 @@ export default function RecruiterRegisterPage() {
 function FormField({
   label,
   right,
+  error,
   children,
 }: {
   label: string;
   right?: React.ReactNode;
+  error?: string;
   children: React.ReactNode;
 }) {
   return (
@@ -221,6 +328,11 @@ function FormField({
         {right}
       </div>
       {children}
+      {error && (
+        <p className="mt-1.5 text-xs text-red-600 dark:text-red-400 font-medium">
+          {error}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

This PR improves the registration experience by adding clear field-level validation messages to both student and recruiter registration forms.

Previously, users received little or no actionable feedback when entering invalid inputs. Backend validation already existed, but the client was not properly rendering field-specific errors beneath the corresponding inputs.

Fixes #211

## Changes Made

### Validation Improvements

* Added inline field-level validation messages
* Added real-time validation feedback while typing
* Added visual error styling for invalid fields

### Error Handling

* Properly parses backend Zod `fieldErrors`
* Displays validation messages for:

  * name
  * email
  * password
  * recruiter email restrictions

### UX Improvements

* Errors clear automatically after correction
* Preserved existing UI structure and styling
* Consistent behavior across student and recruiter forms

## Files Updated

* `client/src/module/auth/RegisterPage.tsx`
* `client/src/module/recruiter/auth/RecruiterRegisterPage.tsx`

## Validation Tested

* Invalid name input
* Invalid email format
* Weak passwords
* Recruiter personal email restrictions
* Successful valid registration flow

No new dependencies added.
Frontend-only isolated fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration forms now include real-time client-side validation with inline error messages for each field
  * Server validation errors are displayed as field-specific feedback instead of general alerts
  * Both standard and recruiter registration forms provide immediate validation feedback as users enter information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->