### PR TITLE
feat(client): migrate external jobs pages to React Query and stone/li…

### DIFF
--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -139,6 +139,15 @@ export const queryKeys = {
     stats: () => ["internships", "stats"] as const,
   },
 
+  // Scraped / external job aggregator
+  scrapedJobs: {
+    all: ["scraped-jobs"] as const,
+    sources: () => ["scraped-jobs", "sources"] as const,
+    list: (params?: Record<string, string | number | undefined>) =>
+      ["scraped-jobs", "list", params] as const,
+    detail: (id: string | number) => ["scraped-jobs", "detail", id] as const,
+  },
+
   // Professors
   professors: {
     list: (params?: Record<string, string | number>) =>

--- a/client/src/module/scraped-jobs/ScrapedJobDetailPage.tsx
+++ b/client/src/module/scraped-jobs/ScrapedJobDetailPage.tsx
@@ -1,37 +1,125 @@
-import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router";
 import { motion } from "framer-motion";
-import { ArrowLeft, MapPin, DollarSign, Building2, ExternalLink, Globe, Clock } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import {
+  ArrowLeft,
+  MapPin,
+  DollarSign,
+  Building2,
+  ExternalLink,
+  Globe,
+  Clock,
+  ArrowUpRight,
+} from "lucide-react";
 import { Navbar } from "../../components/Navbar";
 import { SEO } from "../../components/SEO";
+import { LoadingScreen } from "../../components/LoadingScreen";
+import { Button } from "../../components/ui/button";
+import { queryKeys } from "../../lib/query-keys";
 import api from "../../lib/axios";
 import type { ScrapedJob } from "../../lib/types";
+import { getSourceBadgeColor } from "./scraped-jobs.utils";
+
+function Kicker({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500">
+      <span className="h-1.5 w-1.5 bg-lime-400" />
+      {children}
+    </div>
+  );
+}
+
+function CompanyMark({ label }: { label: string }) {
+  return (
+    <div className="w-14 h-14 rounded-md bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-white/10 flex items-center justify-center shrink-0 text-stone-900 dark:text-stone-50 text-xl font-bold">
+      {label?.charAt(0)?.toUpperCase() || "?"}
+    </div>
+  );
+}
 
 export default function ScrapedJobDetailPage() {
   const { id } = useParams();
-  const [job, setJob] = useState<ScrapedJob | null>(null);
-  const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    api.get(`/scraped-jobs/${id}`).then((res) => {
-      setJob(res.data.job);
-      setLoading(false);
-    }).catch(() => setLoading(false));
-  }, [id]);
+  const { data: job, isLoading, isError, refetch } = useQuery({
+    queryKey: queryKeys.scrapedJobs.detail(id!),
+    queryFn: async () => {
+      try {
+        const res = await api.get(`/scraped-jobs/${id}`);
+        return res.data.job as ScrapedJob;
+      } catch (err) {
+        if (axios.isAxiosError(err) && err.response?.status === 404) {
+          return null;
+        }
+        throw err;
+      }
+    },
+    enabled: !!id,
+    retry: false,
+  });
 
-  if (loading) return <div className="min-h-screen bg-gray-50 dark:bg-gray-950"><Navbar /><div className="flex items-center justify-center h-64 pt-24 text-gray-500">Loading...</div></div>;
-  if (!job) return <div className="min-h-screen bg-gray-50 dark:bg-gray-950"><Navbar /><div className="text-center pt-24 text-gray-500">Job not found</div></div>;
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-stone-50 dark:bg-stone-950">
+        <Navbar />
+        <LoadingScreen />
+      </div>
+    );
+  }
 
-  const getSourceBadgeColor = (src: string) => {
-    switch (src) {
-      case "remotive": return "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400";
-      case "arbeitnow": return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400";
-      default: return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
-    }
-  };
+  if (isError) {
+    return (
+      <div className="min-h-screen bg-stone-50 dark:bg-stone-950">
+        <SEO title="External Job" noIndex />
+        <Navbar />
+        <div className="max-w-4xl mx-auto px-6 pt-24 pb-12 text-center">
+          <Kicker>error / network</Kicker>
+          <h1 className="mt-4 text-2xl font-bold tracking-tight text-stone-900 dark:text-stone-50">
+            Could not load this job
+          </h1>
+          <p className="mt-3 text-sm text-stone-500 mb-6">Check your connection and try again.</p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <Button variant="mono" onClick={() => refetch()}>
+              Retry
+            </Button>
+            <Link
+              to="/external-jobs"
+              className="inline-flex items-center gap-1.5 text-xs font-mono uppercase tracking-widest text-stone-900 dark:text-stone-50 hover:text-lime-500 no-underline"
+            >
+              Back to external jobs <ArrowUpRight className="w-3.5 h-3.5" />
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!job) {
+    return (
+      <div className="min-h-screen bg-stone-50 dark:bg-stone-950">
+        <SEO title="Job Not Found" noIndex />
+        <Navbar />
+        <div className="max-w-4xl mx-auto px-6 pt-24 pb-12 text-center">
+          <Kicker>error / 404</Kicker>
+          <h1 className="mt-4 text-3xl font-bold tracking-tight text-stone-900 dark:text-stone-50">
+            Job not found.
+          </h1>
+          <p className="mt-3 text-sm text-stone-500 mb-6">
+            This listing may have expired or been removed.
+          </p>
+          <Link
+            to="/external-jobs"
+            className="inline-flex items-center gap-1.5 text-xs font-mono uppercase tracking-widest text-stone-900 dark:text-stone-50 hover:text-lime-500 no-underline"
+          >
+            Browse external jobs <ArrowUpRight className="w-3.5 h-3.5" />
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <div className="min-h-screen bg-stone-50 dark:bg-stone-950 text-stone-900 dark:text-stone-50">
       <SEO
         title={`${job.title} at ${job.company}`}
         description={`${job.title} at ${job.company} in ${job.location}. Found on ${job.source}. Apply now on InternHack.`}
@@ -39,66 +127,106 @@ export default function ScrapedJobDetailPage() {
       />
       <Navbar />
       <div className="max-w-4xl mx-auto px-6 pt-24 pb-12">
-        <Link to="/external-jobs" className="flex items-center gap-2 text-sm text-gray-500 hover:text-black dark:hover:text-white mb-6 no-underline">
+        <Link
+          to="/external-jobs"
+          className="inline-flex items-center gap-2 text-sm text-stone-500 hover:text-stone-900 dark:hover:text-stone-50 mb-6 no-underline"
+        >
           <ArrowLeft className="w-4 h-4" /> Back to External Jobs
         </Link>
 
         <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
-          {/* Header */}
-          <div className="bg-white dark:bg-gray-900 p-8 rounded-xl border border-gray-100 dark:border-gray-800 shadow-sm mb-6">
-            <div className="flex items-start justify-between">
-              <div className="flex-1">
-                <div className="flex items-center gap-3 mb-2">
-                  <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{job.title}</h1>
-                  <span className={`text-xs px-2.5 py-1 rounded-full font-medium ${getSourceBadgeColor(job.source)}`}>
-                    {job.source}
-                  </span>
-                </div>
-                <div className="flex items-center gap-4 text-sm text-gray-500 mb-4">
-                  <span className="flex items-center gap-1"><Building2 className="w-4 h-4" />{job.company}</span>
-                  <span className="flex items-center gap-1"><MapPin className="w-4 h-4" />{job.location}</span>
-                  {job.salary && <span className="flex items-center gap-1"><DollarSign className="w-4 h-4" />{job.salary}</span>}
-                </div>
-                <div className="flex items-center gap-3 text-sm text-gray-400 dark:text-gray-500">
-                  <span className="flex items-center gap-1">
-                    <Clock className="w-4 h-4" />Scraped {new Date(job.scrapedAt).toLocaleDateString()}
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <Globe className="w-4 h-4" />Last seen {new Date(job.lastSeenAt).toLocaleDateString()}
-                  </span>
+          <div className="bg-white dark:bg-stone-900 p-8 rounded-md border border-stone-200 dark:border-white/10 mb-6">
+            <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+              <div className="flex gap-4 flex-1 min-w-0">
+                <CompanyMark label={job.company || "?"} />
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-center gap-3 mb-2">
+                    <h1 className="text-2xl font-bold tracking-tight text-stone-900 dark:text-stone-50">
+                      {job.title}
+                    </h1>
+                    <span
+                      className={`text-xs px-2.5 py-1 rounded font-medium ${getSourceBadgeColor(job.source)}`}
+                    >
+                      {job.source}
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-4 text-sm text-stone-500 mb-4">
+                    <span className="flex items-center gap-1">
+                      <Building2 className="w-4 h-4" />
+                      {job.company}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <MapPin className="w-4 h-4" />
+                      {job.location}
+                    </span>
+                    {job.salary && (
+                      <span className="flex items-center gap-1">
+                        <DollarSign className="w-4 h-4" />
+                        {job.salary}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3 text-sm text-stone-400">
+                    <span className="flex items-center gap-1">
+                      <Clock className="w-4 h-4" />
+                      Scraped {new Date(job.scrapedAt).toLocaleDateString()}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <Globe className="w-4 h-4" />
+                      Last seen {new Date(job.lastSeenAt).toLocaleDateString()}
+                    </span>
+                  </div>
                 </div>
               </div>
-              <a href={job.applicationUrl} target="_blank" rel="noopener noreferrer"
-                className="flex items-center gap-2 px-6 py-3 bg-black text-white font-semibold rounded-xl hover:bg-gray-800 transition-colors no-underline text-sm shrink-0 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200">
-                <ExternalLink className="w-4 h-4" />
-                Apply Externally
-              </a>
+              <Button variant="mono" size="lg" asChild className="shrink-0 rounded-md">
+                <a href={job.applicationUrl} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="w-4 h-4" />
+                  Apply Externally
+                </a>
+              </Button>
             </div>
 
             {job.tags.length > 0 && (
               <div className="flex flex-wrap gap-2 mt-4">
                 {job.tags.map((tag) => (
-                  <span key={tag} className="px-3 py-1 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 rounded-full text-xs">{tag}</span>
+                  <span
+                    key={tag}
+                    className="px-3 py-1 bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 rounded text-xs font-mono uppercase tracking-wider"
+                  >
+                    {tag}
+                  </span>
                 ))}
               </div>
             )}
           </div>
 
-          {/* Description */}
-          <div className="bg-white dark:bg-gray-900 p-8 rounded-xl border border-gray-100 dark:border-gray-800 shadow-sm mb-6">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Job Description</h2>
-            <div className="text-gray-600 dark:text-gray-400 whitespace-pre-wrap leading-relaxed">{job.description}</div>
+          <div className="bg-white dark:bg-stone-900 p-8 rounded-md border border-stone-200 dark:border-white/10 mb-6">
+            <h2 className="text-lg font-semibold text-stone-900 dark:text-stone-50 mb-4">
+              Job Description
+            </h2>
+            <div className="text-stone-600 dark:text-stone-400 whitespace-pre-wrap leading-relaxed">
+              {job.description}
+            </div>
           </div>
 
-          {/* Source Info */}
-          <div className="bg-white dark:bg-gray-900 p-6 rounded-xl border border-gray-100 dark:border-gray-800 shadow-sm">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Source Information</h2>
-            <div className="text-sm text-gray-500 space-y-1">
-              <p>Source: <span className="font-medium text-gray-700 dark:text-gray-300">{job.source}</span></p>
+          <div className="bg-white dark:bg-stone-900 p-6 rounded-md border border-stone-200 dark:border-white/10">
+            <h2 className="text-lg font-semibold text-stone-900 dark:text-stone-50 mb-2">
+              Source Information
+            </h2>
+            <div className="text-sm text-stone-500 space-y-1">
+              <p>
+                Source:{" "}
+                <span className="font-medium text-stone-700 dark:text-stone-300">{job.source}</span>
+              </p>
               {job.sourceUrl && (
                 <p>
                   Original listing:{" "}
-                  <a href={job.sourceUrl} target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">
+                  <a
+                    href={job.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-lime-600 dark:text-lime-400 hover:underline"
+                  >
                     View on {job.source}
                   </a>
                 </p>
@@ -108,13 +236,13 @@ export default function ScrapedJobDetailPage() {
             </div>
           </div>
 
-          {/* Bottom CTA */}
           <div className="mt-6 text-center">
-            <a href={job.applicationUrl} target="_blank" rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-8 py-3 bg-black text-white font-semibold rounded-xl hover:bg-gray-800 transition-colors no-underline text-sm dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200">
-              <ExternalLink className="w-4 h-4" />
-              Apply on {job.source}
-            </a>
+            <Button variant="mono" size="lg" asChild className="rounded-md">
+              <a href={job.applicationUrl} target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="w-4 h-4" />
+                Apply on {job.source}
+              </a>
+            </Button>
           </div>
         </motion.div>
       </div>

--- a/client/src/module/scraped-jobs/ScrapedJobsPage.tsx
+++ b/client/src/module/scraped-jobs/ScrapedJobsPage.tsx
@@ -1,64 +1,123 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
 import { motion } from "framer-motion";
-import { Search, MapPin, DollarSign, Building2, ExternalLink, Globe, Filter } from "lucide-react";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import {
+  Search,
+  MapPin,
+  DollarSign,
+  ChevronDown,
+  Globe,
+  Filter,
+  ArrowUpRight,
+} from "lucide-react";
 import { LocationDropdown } from "../../components/ui/LocationDropdown";
+import { PaginationControls } from "../../components/ui/PaginationControls";
 import { Navbar } from "../../components/Navbar";
 import { SEO } from "../../components/SEO";
 import { canonicalUrl } from "../../lib/seo.utils";
+import { queryKeys } from "../../lib/query-keys";
 import api from "../../lib/axios";
 import type { ScrapedJob, ScrapedJobSource, Pagination } from "../../lib/types";
 import { Button } from "../../components/ui/button";
+import toast from "@/components/ui/toast";
+import { getSourceBadgeColor, getSourceLabel } from "./scraped-jobs.utils";
+
+const cardBase =
+  "group relative flex flex-col bg-white dark:bg-stone-900 p-6 rounded-md border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30 transition-colors h-full no-underline";
+
+function CompanyMark({ label }: { label: string }) {
+  return (
+    <div className="w-10 h-10 rounded-md bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-white/10 flex items-center justify-center shrink-0 text-stone-900 dark:text-stone-50 text-sm font-bold">
+      {label?.charAt(0)?.toUpperCase() || "?"}
+    </div>
+  );
+}
+
+function Kicker({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-2">
+      <span className="h-1.5 w-1.5 bg-lime-400" />
+      {children}
+    </div>
+  );
+}
 
 export default function ScrapedJobsPage() {
-  const [jobs, setJobs] = useState<ScrapedJob[]>([]);
-  const [sources, setSources] = useState<ScrapedJobSource[]>([]);
-  const [pagination, setPagination] = useState<Pagination | null>(null);
-  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [location, setLocation] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [debouncedLocation, setDebouncedLocation] = useState("");
   const [source, setSource] = useState("");
   const [page, setPage] = useState(1);
-
-  const fetchJobs = () => {
-    setLoading(true);
-    const params = new URLSearchParams({ page: String(page), limit: "12" });
-    if (search) params.set("search", search);
-    if (location) params.set("location", location);
-    if (source) params.set("source", source);
-
-    api.get(`/scraped-jobs?${params}`).then((res) => {
-      setJobs(res.data.jobs);
-      setPagination(res.data.pagination);
-      setLoading(false);
-    }).catch(() => setLoading(false));
-  };
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const sourcesErrorShown = useRef(false);
 
   useEffect(() => {
-    api.get("/scraped-jobs/sources").then((res) => {
-      setSources(res.data.sources);
-    }).catch(() => {});
-  }, []);
+    timerRef.current = setTimeout(() => {
+      setDebouncedSearch(search);
+      setDebouncedLocation(location);
+      setPage(1);
+    }, 400);
+    return () => clearTimeout(timerRef.current);
+  }, [search, location]);
 
-  useEffect(() => { fetchJobs(); }, [page]);
+  const flushSearch = () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setDebouncedSearch(search);
+    setDebouncedLocation(location);
+    setPage(1);
+  };
 
-  const getSourceBadgeColor = (src: string) => {
-    switch (src) {
-      case "remotive": return "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400";
-      case "arbeitnow": return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400";
-      case "adzuna": return "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400";
-      case "linkedin": return "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400";
-      default: return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
+  const {
+    data: sourcesData,
+    isError: sourcesError,
+    isLoading: sourcesLoading,
+  } = useQuery({
+    queryKey: queryKeys.scrapedJobs.sources(),
+    queryFn: async () => {
+      const res = await api.get("/scraped-jobs/sources");
+      return res.data.sources as ScrapedJobSource[];
+    },
+    staleTime: 30 * 60 * 1000,
+  });
+
+  const sources = sourcesData ?? [];
+
+  useEffect(() => {
+    if (sourcesError && !sourcesErrorShown.current) {
+      sourcesErrorShown.current = true;
+      toast.error("Failed to load job sources");
     }
-  };
+    if (!sourcesError) {
+      sourcesErrorShown.current = false;
+    }
+  }, [sourcesError]);
 
-  const getSourceLabel = (src: string) => {
-    const found = sources.find((s) => s.id === src);
-    return found ? found.name : src;
-  };
+  const { data, isLoading, isFetching, isError, refetch } = useQuery({
+    queryKey: queryKeys.scrapedJobs.list({
+      page,
+      search: debouncedSearch,
+      location: debouncedLocation,
+      source,
+    }),
+    queryFn: async () => {
+      const params = new URLSearchParams({ page: String(page), limit: "12" });
+      if (debouncedSearch) params.set("search", debouncedSearch);
+      if (debouncedLocation) params.set("location", debouncedLocation);
+      if (source) params.set("source", source);
+      const res = await api.get(`/scraped-jobs?${params}`);
+      return res.data as { jobs: ScrapedJob[]; pagination: Pagination };
+    },
+    placeholderData: keepPreviousData,
+    retry: 1,
+  });
+
+  const jobs = data?.jobs ?? [];
+  const pagination = data?.pagination;
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <div className="min-h-screen bg-stone-50 dark:bg-stone-950 text-stone-900 dark:text-stone-50">
       <SEO
         title="External Job Listings"
         description="Browse aggregated job listings from top job boards. Find remote and on-site opportunities from Remotive, Arbeitnow, Adzuna, and more."
@@ -67,102 +126,163 @@ export default function ScrapedJobsPage() {
       />
       <Navbar />
       <div className="max-w-7xl mx-auto px-6 pt-24 pb-12">
+        <Kicker>job aggregator</Kicker>
         <div className="flex items-center gap-3 mb-2">
-          <Globe className="w-8 h-8 text-gray-700 dark:text-gray-300" />
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">External Job Listings</h1>
+          <Globe className="w-8 h-8 text-stone-600 dark:text-stone-400" />
+          <h1 className="text-3xl font-bold tracking-tight text-stone-900 dark:text-stone-50">
+            External Job Listings
+          </h1>
         </div>
-        <p className="text-gray-500 mb-8">Jobs scraped from top job boards across the web, updated every 6 hours</p>
+        <p className="text-stone-500 mb-8">
+          Jobs scraped from top job boards across the web, updated every 6 hours
+        </p>
 
-        {/* Search & Filters */}
         <div className="flex flex-wrap items-center gap-3 mb-8">
           <div className="flex-1 min-w-0 relative">
-            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 dark:text-gray-500" />
-            <input type="text" value={search} onChange={(e) => setSearch(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && fetchJobs()}
-              className="w-full pl-12 pr-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl focus:outline-none focus:ring-2 focus:ring-black/20 dark:focus:ring-white/20 text-sm dark:bg-gray-800 dark:text-white"
-              placeholder="Search by title, company, or keywords..." />
+            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-stone-400" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && flushSearch()}
+              className="w-full pl-12 pr-4 py-3 border border-stone-200 dark:border-white/10 rounded-md bg-white dark:bg-stone-900 text-sm text-stone-900 dark:text-stone-50 placeholder-stone-400 focus:outline-none focus:border-lime-400 focus:ring-2 focus:ring-lime-400/20"
+              placeholder="Search by title, company, or keywords..."
+            />
           </div>
           <LocationDropdown
             id="job-location-filter"
             value={location}
-            onChange={(val) => { setLocation(val); setPage(1); }}
-            onSearch={() => { setPage(1); fetchJobs(); }}
+            onChange={setLocation}
+            onSearch={flushSearch}
             placeholder="Location"
             className="w-full sm:w-52"
           />
           <div className="relative">
-            <Filter className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-gray-500" />
-            <select value={source} onChange={(e) => { setSource(e.target.value); setPage(1); }}
-              className="pl-10 pr-8 py-3 border border-gray-300 dark:border-gray-600 rounded-xl focus:outline-none focus:ring-2 focus:ring-black/20 dark:focus:ring-white/20 text-sm appearance-none bg-white dark:bg-gray-800 dark:text-white w-full sm:w-44">
-              <option value="">All Sources</option>
+            <Filter className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400 pointer-events-none" />
+            <select
+              value={source}
+              onChange={(e) => {
+                setSource(e.target.value);
+                setPage(1);
+              }}
+              disabled={sourcesLoading && !sources.length}
+              className="pl-10 pr-8 py-3 border border-stone-200 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 focus:ring-2 focus:ring-lime-400/20 text-sm appearance-none bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-50 w-full sm:w-44 disabled:opacity-60"
+            >
+              <option value="">
+                {sourcesError ? "Sources unavailable" : "All Sources"}
+              </option>
               {sources.map((s) => (
-                <option key={s.id} value={s.id}>{s.name}</option>
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
               ))}
             </select>
+            <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400 pointer-events-none" />
           </div>
-          <Button
-            variant="mono"
-            size="lg"
-            onClick={() => { setPage(1); fetchJobs(); }}
-            className="rounded-xl"
-          >
+          <Button variant="mono" size="lg" onClick={flushSearch} className="rounded-md">
             Search
           </Button>
         </div>
 
-        {loading ? (
-          <div className="text-center py-16 text-gray-500">Loading external jobs...</div>
+        {isError ? (
+          <div className="text-center py-16 bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md">
+            <p className="text-stone-600 dark:text-stone-400 mb-4">
+              Failed to load external jobs. Please try again.
+            </p>
+            <Button variant="mono" onClick={() => refetch()}>
+              Retry
+            </Button>
+          </div>
+        ) : isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="w-8 h-8 border-2 border-stone-300 dark:border-stone-700 border-t-lime-400 rounded-full animate-spin" />
+          </div>
         ) : jobs.length === 0 ? (
           <div className="text-center py-16">
-            <Globe className="w-12 h-12 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
-            <p className="text-gray-500 mb-2">No external jobs found</p>
-            <p className="text-sm text-gray-400 dark:text-gray-500">Try different search criteria or check back later</p>
+            <Globe className="w-12 h-12 text-stone-300 dark:text-stone-600 mx-auto mb-4" />
+            <p className="text-stone-600 dark:text-stone-400 mb-2">No external jobs found</p>
+            <p className="text-sm text-stone-500">Try different search criteria or check back later</p>
           </div>
         ) : (
           <>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {jobs.map((job, i) => (
-                <motion.div key={job.id} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.03 }}>
-                  <Link to={`/external-jobs/${String(job.id)}`}
-                    className="block bg-white dark:bg-gray-900 p-6 rounded-xl border border-gray-100 dark:border-gray-800 shadow-sm hover:shadow-md transition-shadow no-underline h-full">
-                    <div className="flex items-start justify-between mb-3">
-                      <h3 className="text-lg font-semibold text-gray-900 dark:text-white line-clamp-1 flex-1">{job.title}</h3>
-                      <span className={`text-[10px] px-2 py-0.5 rounded-full font-medium shrink-0 ml-2 ${getSourceBadgeColor(job.source)}`}>
-                        {getSourceLabel(job.source)}
+            <div className="relative">
+              {isFetching && !isLoading && (
+                <div className="absolute inset-0 bg-stone-50/70 dark:bg-stone-950/70 z-10 flex items-center justify-center rounded-md">
+                  <div className="w-6 h-6 border-2 border-stone-300 dark:border-stone-700 border-t-lime-400 rounded-full animate-spin" />
+                </div>
+              )}
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {jobs.map((job, i) => (
+                  <motion.div
+                    key={job.id}
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: i * 0.03 }}
+                  >
+                    <Link to={`/external-jobs/${String(job.id)}`} className={cardBase}>
+                      <span
+                        className={`absolute top-4 right-4 text-[10px] px-2 py-0.5 rounded font-medium shrink-0 ${getSourceBadgeColor(job.source)}`}
+                      >
+                        {getSourceLabel(job.source, sources)}
                       </span>
-                    </div>
-                    <div className="flex items-center gap-2 mb-2">
-                      <Building2 className="w-4 h-4 text-gray-400 dark:text-gray-500" />
-                      <span className="text-sm text-gray-600 dark:text-gray-400">{job.company}</span>
-                    </div>
-                    <p className="text-sm text-gray-500 line-clamp-2 mb-4">{job.description}</p>
-                    <div className="flex flex-wrap gap-3 text-xs text-gray-500">
-                      <span className="flex items-center gap-1"><MapPin className="w-3 h-3" />{job.location}</span>
-                      {job.salary && (
-                        <span className="flex items-center gap-1"><DollarSign className="w-3 h-3" />{job.salary}</span>
-                      )}
-                      <span className="flex items-center gap-1">
-                        <ExternalLink className="w-3 h-3" />External
-                      </span>
-                    </div>
-                    {job.tags.length > 0 && (
-                      <div className="flex flex-wrap gap-1.5 mt-3">
-                        {job.tags.slice(0, 4).map((tag) => (
-                          <span key={tag} className="px-2 py-0.5 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 rounded text-xs">{tag}</span>
-                        ))}
+                      <div className="flex items-start gap-3 mb-3 pr-16">
+                        <CompanyMark label={job.company || "?"} />
+                        <div className="flex-1 min-w-0">
+                          <h3 className="text-base font-bold tracking-tight text-stone-900 dark:text-stone-50 line-clamp-1">
+                            {job.title}
+                          </h3>
+                          <span className="text-xs font-mono uppercase tracking-widest text-stone-500 mt-0.5 block truncate">
+                            {job.company}
+                          </span>
+                        </div>
                       </div>
-                    )}
-                  </Link>
-                </motion.div>
-              ))}
+                      <p className="text-sm text-stone-600 dark:text-stone-400 line-clamp-2 mb-4 leading-relaxed">
+                        {job.description}
+                      </p>
+                      <div className="flex flex-wrap gap-3 text-xs text-stone-500 mb-3">
+                        <span className="flex items-center gap-1">
+                          <MapPin className="w-3 h-3" />
+                          {job.location}
+                        </span>
+                        {job.salary && (
+                          <span className="flex items-center gap-1">
+                            <DollarSign className="w-3 h-3" />
+                            {job.salary}
+                          </span>
+                        )}
+                      </div>
+                      {job.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-1.5 mb-4">
+                          {job.tags.slice(0, 4).map((tag) => (
+                            <span
+                              key={tag}
+                              className="px-2 py-0.5 bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-400 rounded text-[10px] font-mono uppercase tracking-wider"
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                      <div className="mt-auto flex items-center justify-between pt-3 border-t border-stone-100 dark:border-white/5">
+                        <span className="text-[11px] font-mono uppercase tracking-widest text-stone-500">
+                          view role
+                        </span>
+                        <ArrowUpRight className="w-4 h-4 text-stone-400 group-hover:text-lime-500 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-all" />
+                      </div>
+                    </Link>
+                  </motion.div>
+                ))}
+              </div>
             </div>
 
             {pagination && pagination.totalPages > 1 && (
-              <div className="flex items-center justify-center gap-2 mt-8">
-                <Button variant="outline" onClick={() => setPage(Math.max(1, page - 1))} disabled={page === 1}>Previous</Button>
-                <span className="text-sm text-gray-500">Page {page} of {pagination.totalPages}</span>
-                <Button variant="outline" onClick={() => setPage(Math.min(pagination.totalPages, page + 1))} disabled={page === pagination.totalPages}>Next</Button>
-              </div>
+              <PaginationControls
+                className="mt-8"
+                currentPage={page}
+                totalPages={pagination.totalPages}
+                onPageChange={setPage}
+                showingInfo={{ total: pagination.total, limit: pagination.limit }}
+              />
             )}
           </>
         )}

--- a/client/src/module/scraped-jobs/ScrapedJobsPage.tsx
+++ b/client/src/module/scraped-jobs/ScrapedJobsPage.tsx
@@ -62,10 +62,14 @@ export default function ScrapedJobsPage() {
     return () => clearTimeout(timerRef.current);
   }, [search, location]);
 
-  const flushSearch = () => {
+  const commitFilters = () => {
     if (timerRef.current) clearTimeout(timerRef.current);
     setDebouncedSearch(search);
     setDebouncedLocation(location);
+  };
+
+  const flushSearch = () => {
+    commitFilters();
     setPage(1);
   };
 
@@ -162,6 +166,7 @@ export default function ScrapedJobsPage() {
             <select
               value={source}
               onChange={(e) => {
+                commitFilters();
                 setSource(e.target.value);
                 setPage(1);
               }}

--- a/client/src/module/scraped-jobs/scraped-jobs.utils.ts
+++ b/client/src/module/scraped-jobs/scraped-jobs.utils.ts
@@ -1,0 +1,21 @@
+import type { ScrapedJobSource } from "../../lib/types";
+
+export function getSourceBadgeColor(src: string): string {
+  switch (src) {
+    case "remotive":
+      return "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400";
+    case "arbeitnow":
+      return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400";
+    case "adzuna":
+      return "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400";
+    case "linkedin":
+      return "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400";
+    default:
+      return "bg-stone-100 text-stone-700 dark:bg-stone-800 dark:text-stone-300";
+  }
+}
+
+export function getSourceLabel(src: string, sources: ScrapedJobSource[]): string {
+  const found = sources.find((s) => s.id === src);
+  return found ? found.name : src;
+}


### PR DESCRIPTION
Suggested title: feat(client): migrate external jobs pages to React Query

Summary
Migrate /external-jobs list and detail from useEffect + manual fetch to React Query with queryKeys.scrapedJobs
Add error states with retry on list/detail; toast when sources fail to load
Restyle with student stone/lime tokens; add scraped-jobs.utils.ts for source badges
Test plan

 /external-jobs — jobs load; search, filters, pagination work

 API failure — error UI and Retry work

 Job detail — load, 404, and network error states

 Dark mode matches job browse styling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced job detail pages with improved loading states, error handling, and 404 screens
  * Added debounced search and location filtering for faster job list browsing
  * Implemented refined pagination controls for job listings
  * Improved source information display with company marks and badges

* **Improvements**
  * Better error recovery with retry functionality
  * Optimized data fetching for improved performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->