### PR TITLE
fix: roadmap filters returning 400 due to limit validation mismatch 

### DIFF
--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -90,12 +90,19 @@ export async function listPublishedRoadmaps(opts: {
   if (opts.level && opts.level !== "ALL_LEVELS") {
     where.level = opts.level as "BEGINNER" | "INTERMEDIATE" | "ADVANCED" | "ALL_LEVELS";
   }
-  if (opts.tag) {
-    andConditions.push({ tags: { has: opts.tag } });
-  }
-  if (opts.category) {
-    andConditions.push({ tags: { has: opts.category } });
-  }
+  // if (opts.tag) {
+  //   andConditions.push({ tags: { has: opts.tag } });
+  // }
+  // if (opts.category) {
+  //   andConditions.push({ tags: { has: opts.category } });
+  // }
+  const tagFilters: string[] = [];
+if (opts.tag) tagFilters.push(opts.tag);
+if (opts.category) tagFilters.push(opts.category);
+
+if (tagFilters.length > 0) {
+  andConditions.push({ tags: { hasSome: tagFilters } });
+}
   if (opts.search) {
     const s = opts.search.trim();
     if (s) {

--- a/server/src/module/roadmap/roadmap.validation.ts
+++ b/server/src/module/roadmap/roadmap.validation.ts
@@ -49,7 +49,8 @@ export const pdfThemeQuery = z.object({
 
 export const listQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
-  limit: z.coerce.number().int().min(1).max(50).default(20),
+  // limit: z.coerce.number().int().min(1).max(50).default(20),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
   level: z.enum(["BEGINNER", "INTERMEDIATE", "ADVANCED", "ALL_LEVELS"]).optional(),
   search: z.string().optional(),
   tag: z.string().optional(),


### PR DESCRIPTION
## Summary
The roadmap filter feature was broken — every request to `/api/roadmaps` 
was returning 400 Bad Request, so filters for level, tag, category and 
search never worked. After reading through the codebase, the root cause 
was a mismatch between what the frontend sends and what the backend 
validation allows. The frontend sends `limit=100` but the validation 
schema had `max(50)`, so every request was rejected before even reaching 
the Prisma query or the database. Fixes #194 

## Changes
- `server/src/module/roadmap/roadmap.validation.ts` — bumped limit max 
  from 50 to 100 to match what the frontend actually sends
- `server/src/module/roadmap/roadmap.service.ts` — replaced separate 
  `has` conditions for tag and category with a single `hasSome`, so 
  filtering by both doesn't require a roadmap to have both values 
  simultaneously in its tags array

## How to test
1. Clone the repo and run `npm run dev` in the server folder
2. Open the roadmaps page in the browser
3. Open the Network tab in browser devtools
4. Click any filter (Level, Tag, or Category)
5. Before this fix: every request returns 400 Bad Request
6. After this fix: requests return 200 with correctly filtered results

## Screenshots (if UI changes)
No UI changes

## Note
While testing locally I noticed the seed script 
(`src/database/seeds/seed.ts`) doesn't seed any roadmap data, even 
though two JSON files exist at `src/module/roadmap/seed/` 
(`ai-engineer.json`, `full-stack.json`). So the roadmaps page will show 
"no results" on a fresh local setup even after this fix. Happy to raise 
a follow-up PR to wire those JSON files into the seed script if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased maximum query results limit from 50 to 100 items per request. Default page size remains 20 items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->