### PR TITLE
refactor : replace manual useState/useEffect fetching with useQuery in companyDetailPage

### DIFF
--- a/client/src/module/student/companies/CompanyDetailPage.tsx
+++ b/client/src/module/student/companies/CompanyDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { useParams, Link, useLocation } from "react-router";
 import { queryKeys } from "../../../lib/query-keys";
 import { motion } from "framer-motion";
@@ -88,7 +88,12 @@ export default function CompanyDetailPage() {
   const [showReviewForm, setShowReviewForm] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
 
-  const { data: company, isLoading: companyLoading } = useQuery<Company>({
+  const { 
+    data: company, 
+    isLoading: companyLoading,
+    isError: companyIsError,
+    error: companyError 
+  } = useQuery<Company>({
     queryKey: queryKeys.companies.detail(slug!),
     queryFn: () => api.get(`/companies/${slug}`).then((r) => r.data.company),
     enabled: !!slug,
@@ -97,11 +102,14 @@ export default function CompanyDetailPage() {
   const {
     data: reviewsData,
     isLoading: reviewsLoading,
+    isError: reviewsIsError,
+    error: reviewsError,
     refetch: refetchReviews,
   } = useQuery<{ reviews: CompanyReview[] }>({
     queryKey: [...queryKeys.companies.reviews(slug!), sortBy],
     queryFn: () => api.get(`/companies/${slug}/reviews?sort=${sortBy}`).then((r) => r.data),
     enabled: !!slug,
+    placeholderData: keepPreviousData,
   });
 
   const reviews = reviewsData?.reviews || [];
@@ -123,7 +131,38 @@ export default function CompanyDetailPage() {
     );
   }
 
-  if (!company) {
+  if (companyIsError || reviewsIsError) {
+    const errorMsg = companyIsError 
+      ? (companyError as any)?.response?.data?.message || companyError?.message || "Failed to load company"
+      : (reviewsError as any)?.response?.data?.message || reviewsError?.message || "Failed to load reviews";
+      
+    const errorContent = (
+      <div className="max-w-6xl mx-auto px-6 pt-24 text-center">
+        <Kicker>error / api</Kicker>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight text-red-500">
+          Something went wrong
+        </h1>
+        <p className="mt-2 text-stone-500">{errorMsg}</p>
+        <Link
+          to={backPath}
+          className="mt-4 inline-flex items-center gap-1.5 text-xs font-mono uppercase tracking-widest text-stone-500 hover:text-stone-900 dark:hover:text-stone-50 no-underline"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" /> Back to companies
+        </Link>
+      </div>
+    );
+    
+    if (isInsideLayout) return errorContent;
+    return (
+      <div className="min-h-screen bg-stone-50 dark:bg-stone-950">
+        <Navbar />
+        {errorContent}
+        <Footer />
+      </div>
+    );
+  }
+
+  if (!companyIsError && !company) {
     const notFound = (
       <div className="max-w-6xl mx-auto px-6 pt-24 text-center">
         <Kicker>error / 404</Kicker>

--- a/client/src/module/student/companies/CompanyDetailPage.tsx
+++ b/client/src/module/student/companies/CompanyDetailPage.tsx
@@ -1,5 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useParams, Link, useLocation } from "react-router";
+import { queryKeys } from "../../../lib/query-keys";
 import { motion } from "framer-motion";
 import {
   MapPin,
@@ -82,35 +84,32 @@ export default function CompanyDetailPage() {
   const { user, isAuthenticated } = useAuthStore();
   const location = useLocation();
   const isInsideLayout = location.pathname.startsWith("/student/");
-  const [company, setCompany] = useState<Company | null>(null);
-  const [reviews, setReviews] = useState<CompanyReview[]>([]);
   const [sortBy, setSortBy] = useState("latest");
-  const [loading, setLoading] = useState(true);
   const [showReviewForm, setShowReviewForm] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
 
-  useEffect(() => {
-    if (!slug) return;
-    setLoading(true);
-    Promise.all([
-      api.get(`/companies/${slug}`),
-      api.get(`/companies/${slug}/reviews?sort=${sortBy}`),
-    ])
-      .then(([companyRes, reviewsRes]) => {
-        setCompany(companyRes.data.company);
-        setReviews(reviewsRes.data.reviews);
-      })
-      .catch(() => setCompany(null))
-      .finally(() => setLoading(false));
-  }, [slug, sortBy]);
+  const { data: company, isLoading: companyLoading } = useQuery<Company>({
+    queryKey: queryKeys.companies.detail(slug!),
+    queryFn: () => api.get(`/companies/${slug}`).then((r) => r.data.company),
+    enabled: !!slug,
+  });
+
+  const {
+    data: reviewsData,
+    isLoading: reviewsLoading,
+    refetch: refetchReviews,
+  } = useQuery<{ reviews: CompanyReview[] }>({
+    queryKey: [...queryKeys.companies.reviews(slug!), sortBy],
+    queryFn: () => api.get(`/companies/${slug}/reviews?sort=${sortBy}`).then((r) => r.data),
+    enabled: !!slug,
+  });
+
+  const reviews = reviewsData?.reviews || [];
+  const loading = companyLoading || reviewsLoading;
 
   const refreshReviews = () => {
-    if (!slug) return;
     setShowReviewForm(false);
-    api
-      .get(`/companies/${slug}/reviews?sort=${sortBy}`)
-      .then((res) => setReviews(res.data.reviews))
-      .catch(() => {});
+    refetchReviews();
   };
 
   const backPath = isInsideLayout ? "/student/companies" : "/companies";


### PR DESCRIPTION
### Summary

Refactors the data-fetching architecture in `CompanyDetailPage.tsx` by replacing manual async loops `useState` and `useEffect` with React Query `useQuery` hooks. 

This fixes redundant boilerplate code, adds instant client-side caching, and enables automatic background data revalidation when students navigate back to previously viewed companies.

###  Changes Made

- **Removed Manual State:** Eliminated `company`, `reviews`, and `loading` states managed by `useState`.
- **Removed Side-Effects:** Cleared out the `useEffect` block that handled sequential `Promise.all` network requests on component mount.
- **Implemented TanStack Query:** - Added a `useQuery` hook for company detail metadata using standard project query keys.
  - Added a reactive `useQuery` hook for reviews tracking the `sortBy` state variable natively.
- **State Optimization:** Created derived states for backward compatibility, completely shielding the lower JSX rendering code from requiring any modifications.
- **Refactored Refresh Actions:** Updated the manual API calls in `refreshReviews` to utilize the native `refetch()` functionality provided by React Query.

###  Reference Implementation Checked
- Checked patterns against `JobBrowsePage` and `YCCompanyDetailPage` to maintain layout syntax, naming schemes, and config parameters uniformly.

**Closes** #131 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data loading and management for the company details page to enhance performance and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->