### PR TITLE
Fix/company card routing student layout

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -84,7 +84,7 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
               const active =
                 item.href === "/"
                   ? location.pathname === "/"
-                  : location.pathname.startsWith(item.href);
+                  : location.pathname.startsWith(item.href + "/") || location.pathname === item.href;
               return (
                 <Link key={item.href} to={item.href} className="no-underline">
                   <button

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,5 +1,13 @@
 import { motion, AnimatePresence } from "framer-motion";
-import { Menu, X, Settings, LogOut, LayoutDashboard, Sun, Moon } from "lucide-react";
+import {
+  Menu,
+  X,
+  Settings,
+  LogOut,
+  LayoutDashboard,
+  Sun,
+  Moon,
+} from "lucide-react";
 import { useState } from "react";
 import { Link, useNavigate, useLocation } from "react-router";
 import { useAuthStore } from "../lib/auth.store";
@@ -38,8 +46,14 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
     navigate("/");
   };
 
-  const dashboardLink = user?.role === "ADMIN" ? "/admin" : user?.role === "RECRUITER" ? "/recruiters" : "/student/applications";
-  const profileLink = user?.role === "RECRUITER" ? "/recruiters/profile" : "/student/profile";
+  const dashboardLink =
+    user?.role === "ADMIN"
+      ? "/admin"
+      : user?.role === "RECRUITER"
+        ? "/recruiters"
+        : "/student/applications";
+  const profileLink =
+    user?.role === "RECRUITER" ? "/recruiters/profile" : "/student/profile";
 
   return (
     <motion.nav
@@ -53,7 +67,11 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
         <div className="flex items-center justify-between h-16">
           <Link to="/" className="flex items-center gap-2.5 no-underline">
             <div className="relative">
-              <img src="/logo.png" alt="InternHack" className="h-8 w-8 rounded-md object-contain" />
+              <img
+                src="/logo.png"
+                alt="InternHack"
+                className="h-8 w-8 rounded-md object-contain"
+              />
               <span className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 bg-lime-400" />
             </div>
             <span className="text-base font-bold tracking-tight text-stone-900 dark:text-stone-50">
@@ -63,7 +81,10 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
 
           <div className="hidden lg:flex items-center gap-1">
             {NAV_ITEMS.map((item) => {
-              const active = location.pathname === item.href;
+              const active =
+                item.href === "/"
+                  ? location.pathname === "/"
+                  : location.pathname.startsWith(item.href);
               return (
                 <Link key={item.href} to={item.href} className="no-underline">
                   <button
@@ -71,7 +92,7 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
                       "relative px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-transparent border-0 cursor-pointer",
                       active
                         ? "text-stone-900 dark:text-stone-50"
-                        : "text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50"
+                        : "text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50",
                     )}
                   >
                     {item.label}
@@ -88,9 +109,17 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
             <button
               onClick={toggleTheme}
               className="p-2 text-stone-500 hover:text-stone-900 hover:bg-stone-200/60 dark:text-stone-400 dark:hover:text-stone-50 dark:hover:bg-white/5 rounded-md transition-colors"
-              title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+              title={
+                theme === "dark"
+                  ? "Switch to light mode"
+                  : "Switch to dark mode"
+              }
             >
-              {theme === "dark" ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+              {theme === "dark" ? (
+                <Sun className="w-4 h-4" />
+              ) : (
+                <Moon className="w-4 h-4" />
+              )}
             </button>
 
             {isAuthenticated ? (
@@ -99,7 +128,10 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
                   <button className="h-9 w-9 rounded-md cursor-pointer border border-stone-200 dark:border-white/10 p-0 bg-transparent overflow-hidden">
                     <Avatar className="h-full w-full rounded-none">
                       {user?.profilePic && (
-                        <AvatarImage src={user.profilePic} alt={user?.name ?? ""} />
+                        <AvatarImage
+                          src={user.profilePic}
+                          alt={user?.name ?? ""}
+                        />
                       )}
                       <AvatarFallback className="rounded-none">
                         {user?.name?.charAt(0).toUpperCase() ?? "U"}
@@ -112,15 +144,22 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
                     <div className="flex items-center gap-3">
                       <Avatar className="h-10 w-10 rounded-md">
                         {user?.profilePic && (
-                          <AvatarImage src={user.profilePic} alt={user?.name ?? ""} />
+                          <AvatarImage
+                            src={user.profilePic}
+                            alt={user?.name ?? ""}
+                          />
                         )}
                         <AvatarFallback className="rounded-md">
                           {user?.name?.charAt(0).toUpperCase() ?? "U"}
                         </AvatarFallback>
                       </Avatar>
                       <div className="min-w-0">
-                        <PopoverTitle className="text-sm truncate">{user?.name}</PopoverTitle>
-                        <PopoverDescription className="text-xs truncate">{user?.email}</PopoverDescription>
+                        <PopoverTitle className="text-sm truncate">
+                          {user?.name}
+                        </PopoverTitle>
+                        <PopoverDescription className="text-xs truncate">
+                          {user?.email}
+                        </PopoverDescription>
                       </div>
                     </div>
                   </PopoverHeader>
@@ -168,9 +207,18 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
           <div className="flex lg:hidden items-center gap-2">
             <button
               onClick={toggleTheme}
+              aria-label={
+                theme === "dark"
+                  ? "Switch to light mode"
+                  : "Switch to dark mode"
+              }
               className="p-2 text-stone-500 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-50 rounded-md transition-colors"
             >
-              {theme === "dark" ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+              {theme === "dark" ? (
+                <Sun className="w-4 h-4" />
+              ) : (
+                <Moon className="w-4 h-4" />
+              )}
             </button>
             {isAuthenticated && (
               <Popover modal>
@@ -178,7 +226,10 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
                   <button className="h-9 w-9 rounded-md cursor-pointer border border-stone-200 dark:border-white/10 p-0 bg-transparent overflow-hidden">
                     <Avatar className="h-full w-full rounded-none">
                       {user?.profilePic && (
-                        <AvatarImage src={user.profilePic} alt={user?.name ?? ""} />
+                        <AvatarImage
+                          src={user.profilePic}
+                          alt={user?.name ?? ""}
+                        />
                       )}
                       <AvatarFallback className="rounded-none">
                         {user?.name?.charAt(0).toUpperCase() ?? "U"}
@@ -191,15 +242,22 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
                     <div className="flex items-center gap-3">
                       <Avatar className="h-10 w-10 rounded-md">
                         {user?.profilePic && (
-                          <AvatarImage src={user.profilePic} alt={user?.name ?? ""} />
+                          <AvatarImage
+                            src={user.profilePic}
+                            alt={user?.name ?? ""}
+                          />
                         )}
                         <AvatarFallback className="rounded-md">
                           {user?.name?.charAt(0).toUpperCase() ?? "U"}
                         </AvatarFallback>
                       </Avatar>
                       <div className="min-w-0">
-                        <PopoverTitle className="text-sm truncate">{user?.name}</PopoverTitle>
-                        <PopoverDescription className="text-xs truncate">{user?.email}</PopoverDescription>
+                        <PopoverTitle className="text-sm truncate">
+                          {user?.name}
+                        </PopoverTitle>
+                        <PopoverDescription className="text-xs truncate">
+                          {user?.email}
+                        </PopoverDescription>
                       </div>
                     </div>
                   </PopoverHeader>
@@ -231,9 +289,15 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
             )}
             <button
               onClick={() => setIsOpen(!isOpen)}
+              aria-expanded={isOpen}
+              aria-label={isOpen ? "Close menu" : "Open menu"}
               className="p-2 text-stone-700 hover:bg-stone-200/60 dark:text-stone-300 dark:hover:bg-white/5 rounded-md transition-colors"
             >
-              {isOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+              {isOpen ? (
+                <X className="w-5 h-5" />
+              ) : (
+                <Menu className="w-5 h-5" />
+              )}
             </button>
           </div>
         </div>
@@ -249,29 +313,48 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
             >
               <div className="pt-2 pb-4 space-y-1 border-t border-stone-200 dark:border-white/10">
                 {NAV_ITEMS.map((item) => (
-                  <MobileNavLink key={item.href} href={item.href} onClick={() => setIsOpen(false)}>
+                  <MobileNavLink
+                    key={item.href}
+                    href={item.href}
+                    onClick={() => setIsOpen(false)}
+                  >
                     {item.label}
                   </MobileNavLink>
                 ))}
                 <div className="pt-3 space-y-2">
                   {isAuthenticated ? (
                     <>
-                      <Link to={dashboardLink} onClick={() => setIsOpen(false)}
-                        className="block px-3 py-2 text-sm text-stone-700 dark:text-stone-300 font-medium rounded-md hover:bg-stone-100 dark:hover:bg-white/5 no-underline">
+                      <Link
+                        to={dashboardLink}
+                        onClick={() => setIsOpen(false)}
+                        className="block px-3 py-2 text-sm text-stone-700 dark:text-stone-300 font-medium rounded-md hover:bg-stone-100 dark:hover:bg-white/5 no-underline"
+                      >
                         Dashboard
                       </Link>
-                      <button onClick={() => { handleLogout(); setIsOpen(false); }}
-                        className="w-full px-3 py-2 text-sm text-stone-700 dark:text-stone-300 font-medium text-left rounded-md hover:bg-stone-100 dark:hover:bg-white/5 bg-transparent border-0">
+                      <button
+                        onClick={() => {
+                          handleLogout();
+                          setIsOpen(false);
+                        }}
+                        className="w-full px-3 py-2 text-sm text-stone-700 dark:text-stone-300 font-medium text-left rounded-md hover:bg-stone-100 dark:hover:bg-white/5 bg-transparent border-0"
+                      >
                         Logout
                       </button>
                     </>
                   ) : (
                     <>
-                      <Link to="/login" onClick={() => setIsOpen(false)}
-                        className="block px-3 py-2 text-sm text-stone-700 dark:text-stone-300 font-medium rounded-md hover:bg-stone-100 dark:hover:bg-white/5 no-underline">
+                      <Link
+                        to="/login"
+                        onClick={() => setIsOpen(false)}
+                        className="block px-3 py-2 text-sm text-stone-700 dark:text-stone-300 font-medium rounded-md hover:bg-stone-100 dark:hover:bg-white/5 no-underline"
+                      >
                         Sign In
                       </Link>
-                      <Link to="/register" onClick={() => setIsOpen(false)} className="block no-underline">
+                      <Link
+                        to="/register"
+                        onClick={() => setIsOpen(false)}
+                        className="block no-underline"
+                      >
                         <button className="w-full px-4 py-2.5 bg-lime-400 text-stone-950 text-sm font-bold rounded-md hover:bg-lime-300 transition-colors border-0">
                           Start free
                         </button>

--- a/client/src/module/student/companies/CompanyListPage.tsx
+++ b/client/src/module/student/companies/CompanyListPage.tsx
@@ -182,9 +182,9 @@ function UpgradeBanner({
 }
 
 // ─── Cards ──────────────────────────────────────────────
-const CompanyCard = React.memo(function CompanyCard({ company }: { company: Company }) {
+const CompanyCard = React.memo(function CompanyCard({ company, insideLayout }: { company: Company; insideLayout: boolean }) {
   return (
-    <Link to={`/companies/${company.slug}`} className={cardBase}>
+    <Link to={`${insideLayout ? "/student" : ""}/companies/${company.slug}`} className={cardBase}>
       <div className="flex items-start gap-3 mb-3">
         <CompanyMark label={company.name} src={company.logo} />
         <div className="flex-1 min-w-0">
@@ -247,9 +247,9 @@ const CompanyCard = React.memo(function CompanyCard({ company }: { company: Comp
   );
 });
 
-const YCCard = React.memo(function YCCard({ company }: { company: YCCompany }) {
+const YCCard = React.memo(function YCCard({ company, insideLayout }: { company: YCCompany; insideLayout: boolean }) {
   return (
-    <Link to={`/yc/${company.slug}`} className={cardBase}>
+    <Link to={`${insideLayout ? "/student" : ""}/yc/${company.slug}`} className={cardBase}>
       <div className="flex items-start gap-3 mb-3">
         <CompanyMark label={company.name} src={company.smallLogoUrl} />
         <div className="flex-1 min-w-0">
@@ -1039,7 +1039,8 @@ export default function CompanyListPage() {
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ delay: i * 0.03, duration: 0.3 }}
                     >
-                      <CompanyCard company={company} />
+                     <CompanyCard company={company} insideLayout={isInsideLayout} />
+
                     </motion.div>
                   ))}
                 </div>
@@ -1145,7 +1146,7 @@ export default function CompanyListPage() {
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ delay: i * 0.03, duration: 0.3 }}
                     >
-                      <YCCard company={company} />
+                     <YCCard company={company} insideLayout={isInsideLayout} />
                     </motion.div>
                   ))}
                 </div>


### PR DESCRIPTION
Fixes #128

## Problem
On `/student/companies`, clicking a CompanyCard or YCCard always 
routed to the public page (`/companies/:slug` or `/yc/:slug`), 
throwing students out of the student layout context.

## Root Cause
CompanyCard and YCCard had hardcoded links and were unaware of 
the current layout context, unlike InterviewCompanyCard which 
already handled this correctly via an `insideLayout` prop.

## Fix
Passed `insideLayout` prop to both `CompanyCard` and `YCCard`, 
same pattern already used by `InterviewCompanyCard`. When inside 
the student layout, links are prefixed with `/student`.

- `CompanyCard` → `/student/companies/:slug` inside layout
- `YCCard` → `/student/yc/:slug` inside layout

## Files Changed
- `client/src/module/student/companies/CompanyListPage.tsx`

## Note
Unable to demonstrate via video as no company data is available 
in the dev environment. Happy to record once data is seeded or 
maintainer can verify directly on staging.