### PR TITLE
Fix: scroll-to-top button not clear on dark mode.

### DIFF
--- a/client/src/components/common/BackToTopButton.tsx
+++ b/client/src/components/common/BackToTopButton.tsx
@@ -47,6 +47,9 @@ export default function BackToTopButton() {
             hover:scale-110 hover:-translate-y-1
             hover:bg-primary
             active:scale-95
+            dark:bg-white
+            dark:text-black
+            dark:hover:bg-white
           "
         >
           <ChevronUp size={22} />


### PR DESCRIPTION
## Problem
The scroll-to-top button was invisible on dark mode.

## Changes

| Section | Before | After |
|---------|--------|-------|
| Dark bg | 🔴 invisible | ✅ visible (white button) |
| Light bg | ✅ visible | ✅ visible |

## Verification
- Before:
<img width="452" height="329" alt="image" src="https://github.com/user-attachments/assets/56568f34-26f8-4cf9-99a1-f3c606bd1677" />

- After:
<img width="452" height="329" alt="image" src="https://github.com/user-attachments/assets/226d833b-c72e-4bc6-bd25-0a328a820687" />

## Type
- [x] Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added dark mode styling to the back-to-top button, including adjusted background color, text color, and hover state effects for improved visibility in dark theme.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->