### PR TITLE
fix: forward tag filter to scraped jobs on browse page

### DIFF
--- a/client/src/module/student/jobs/JobBrowsePage.tsx
+++ b/client/src/module/student/jobs/JobBrowsePage.tsx
@@ -145,6 +145,7 @@ export default function JobBrowsePage() {
       });
       if (debouncedSearch) params.set("search", debouncedSearch);
       if (debouncedLocation) params.set("location", debouncedLocation);
+      if (selectedTags.length) params.set("tags", selectedTags.join(","));
       const res = await api.get(`/scraped-jobs?${params}`);
       return res.data as { jobs: ScrapedJob[]; pagination: Pagination };
     },


### PR DESCRIPTION
Scraped jobs query now sends tags in the request params, matching internal and external job queries. Fixes #124.

## Summary
- Forwards `tags` query param to `GET /scraped-jobs` on the jobs browse page, matching internal and external queries.

Fixes #124

## Test plan
- [ ] Select skill tags on browse page; scraped section filters
- [ ] Clear tags; scraped section shows full results
- [ ] Internal/external sections still filter correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job browsing now correctly filters results by selected tags. Previously, tag filters were not applied when viewing job listings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->