### PR TITLE
fix(prisma): resolve schema validation error P1012 by removing duplicate models

### DIFF
--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -86,7 +86,6 @@ model user {
   generatedResumes      generatedResume[]           @relation("UserGeneratedResumes")
   leetcodeImports       leetcodeImportLog[]          @relation("UserLeetcodeImports")
   generatedCoverLetters generatedCoverLetter[]       @relation("StudentCoverLetters")
-  interviewProgress     userInterviewProgress?       @relation("UserInterviewProgress")
 
   @@index([role])
   @@index([role, isActive])
@@ -549,8 +548,8 @@ model gsocOrganization {
 }
 
 model ycCompany {
-  id              Int       @id @default(autoincrement())
-  ycId            Int       @unique
+  id              Int      @id @default(autoincrement())
+  ycId            Int      @unique
   name            String
   slug            String
   oneLiner        String?
@@ -564,19 +563,19 @@ model ycCompany {
   teamSize        Int?
   industry        String?
   subindustry     String?
-  tags            String[]  @default([])
-  industries      String[]  @default([])
-  regions         String[]  @default([])
+  tags            String[] @default([])
+  industries      String[] @default([])
+  regions         String[] @default([])
   stage           String?
-  isHiring        Boolean   @default(false)
-  topCompany      Boolean   @default(false)
+  isHiring        Boolean  @default(false)
+  topCompany      Boolean  @default(false)
   ycUrl           String?
   launchedAt      DateTime?
   founders        Json?
   socialLinks     Json?
   scrapedAt       DateTime?
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   @@index([batchShort])
   @@index([industry])
@@ -714,18 +713,6 @@ model studentSqlProgress {
 
   @@unique([studentId, exerciseId])
   @@index([studentId])
-}
-
-model userInterviewProgress {
-  id            String   @id @default(cuid())
-  userId        Int      @unique
-  user          user     @relation("UserInterviewProgress", fields: [userId], references: [id], onDelete: Cascade)
-  completedIds  String[] @default([])
-  bookmarkedIds String[] @default([])
-  lastVisitedId String?
-  lastVisitedAt DateTime?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
 }
 
 model aptitudeCategory {


### PR DESCRIPTION
### Overview
This PR resolves a critical local setup and build blocker where `npx prisma generate` fails due to schema validation error `P1012`.

### Changes
- Removed the duplicate `interviewProgress` relational field from the `user` model inside `base.prisma`.
- Purged the redundant duplicate definition of `model userInterviewProgress` from the bottom of the schema file.

### Verification
Tested locally on `localhost:3000`. `npx prisma generate` now compiles flawlessly, and database tables sync smoothly via `prisma db push`.

Closes #368
/gssoc-page-status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized interview progress tracking system to better support data organization and consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->