### PR TITLE
fix: resolve PDF preview CSP policy and remove redundant webhook mount

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -102,7 +102,7 @@ app.use(
         styleSrc: ["'self'", "'unsafe-inline'", "https://accounts.google.com", "https://fonts.googleapis.com"],
         imgSrc: ["'self'", "data:", "https:", "blob:"],
         connectSrc: ["'self'", "https://accounts.google.com", "https://generativelanguage.googleapis.com", "https://www.google-analytics.com", "https://analytics.google.com"],
-        frameSrc: ["https://accounts.google.com", "https://checkout.dodopayments.com"],
+        frameSrc: ["https://accounts.google.com", "https://checkout.dodopayments.com", "blob:"],
         fontSrc: ["'self'", "https:", "data:"],
       },
     },
@@ -150,7 +150,6 @@ app.get("/api/health", (_req, res) => {
 });
 
 // Raw body for webhooks (must be BEFORE express.json())
-app.use("/api/payments/webhook", express.raw({ type: "application/json" }));
 app.use("/api/email-inbound/webhook", express.raw({ type: "application/json" }));
 // Raw body for Dodo Payments webhook (must be BEFORE express.json())
 app.use(PAYMENT_WEBHOOK_PATH, express.raw({ type: "application/json" }));


### PR DESCRIPTION
### Description
This Pull Request resolves the production bugs and architecture issues identified in #389:

1. **Fixed PDF Preview (CSP Violation):** Added `"blob:"` to the `frameSrc` directive in the Helmet Content Security Policy configuration within `server/src/index.ts`. This allows the generated blob URLs to render successfully inside the resume preview iframe instead of being blocked by the browser.
2. **Removed Redundant Webhook Mount:** Cleaned up the duplicate raw body parsing middleware configuration for the Dodo Payments webhook. The handler was being mounted twice on the same route (via hardcoded string and the `PAYMENT_WEBHOOK_PATH` constant). Removed the redundant hardcoded string line to prevent duplicate middleware execution.

### Related Issue
Resolves #389

### Verification
- Both backend type-checks (`npx tsc --noEmit`) and frontend builds have been verified locally and pass successfully with 0 compilation errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated Content Security Policy to support additional iframe protocols
  * Reorganized webhook request processing pipeline

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->