### PR TITLE
fix: unblock camera for proctored skill tests (Permissions-Policy)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   build-and-deploy:
+    if: github.repository == 'Sachinchaurasiya360/InternHack'
     runs-on: ubuntu-latest
 
     steps:

--- a/client/src/hooks/useFaceDetection.ts
+++ b/client/src/hooks/useFaceDetection.ts
@@ -64,9 +64,21 @@ export function useFaceDetection(config: FaceDetectionConfig) {
       });
       streamRef.current = stream;
     } catch (err: any) {
-      const msg = err?.name === "NotAllowedError"
-        ? "Camera permission denied"
-        : "Camera not available";
+      let msg: string;
+      if (err?.name === "NotAllowedError") {
+        const isPolicy =
+          err?.message?.toLowerCase().includes("permissions policy") ||
+          err?.message?.toLowerCase().includes("feature policy");
+        msg = isPolicy
+          ? "Camera blocked by site security policy. Please contact support."
+          : "Camera permission denied. Please allow camera access in your browser settings and try again.";
+      } else if (err?.name === "NotFoundError") {
+        msg = "No camera found. Please connect a camera and try again.";
+      } else if (err?.name === "NotReadableError") {
+        msg = "Camera is in use by another application. Please close it and try again.";
+      } else {
+        msg = "Camera not available. Please check your device and try again.";
+      }
       setError(msg);
       setIsLoading(false);
       onErrorRef.current(msg);

--- a/client/src/module/student/skill-verification/SkillTestPage.tsx
+++ b/client/src/module/student/skill-verification/SkillTestPage.tsx
@@ -358,10 +358,23 @@ export default function SkillTestPage() {
         // Stop the preview stream - proctoring camera component will start its own
         stream.getTracks().forEach((t) => t.stop());
         streamRef.current = null;
-      } catch {
-        setCameraError(
-          "Camera access denied. Please allow camera permissions and try again.",
-        );
+      } catch (err: any) {
+        let msg: string;
+        if (err?.name === "NotAllowedError") {
+          const isPolicy =
+            err?.message?.toLowerCase().includes("permissions policy") ||
+            err?.message?.toLowerCase().includes("feature policy");
+          msg = isPolicy
+            ? "Camera is blocked by a site security policy. This is a known issue — please contact support."
+            : "Camera permission denied. Please allow camera access in your browser settings and try again.";
+        } else if (err?.name === "NotFoundError") {
+          msg = "No camera detected. Please connect a camera and try again.";
+        } else if (err?.name === "NotReadableError") {
+          msg = "Camera is in use by another app. Please close it and try again.";
+        } else {
+          msg = "Camera not available. Please check your device and try again.";
+        }
+        setCameraError(msg);
       }
     };
 

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -24,7 +24,7 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()" },
+        { "key": "Permissions-Policy", "value": "camera=(self), microphone=(self), geolocation=(), interest-cohort=()" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" }
       ]
     },


### PR DESCRIPTION
## Problem

Camera access fails on proctored skill tests with:

```
[Violation] Permissions policy violation: camera is not allowed in this document.
```

Users see "Camera access denied" but it's not a user permission issue — the browser never even shows a permission prompt.

## Root Cause

`client/vercel.json` line 27 sets:

```
Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
```

`camera=()` blocks camera access at the **document level** for all origins, including self. This overrides any user permission and causes `getUserMedia()` to fail immediately.

## Changes

| File | What |
|---|---|
| `client/vercel.json` | `camera=()` → `camera=(self)`, `microphone=()` → `microphone=(self)` |
| `client/src/hooks/useFaceDetection.ts` | Granular error messages (policy block vs user denial vs no device vs in-use) |
| `client/src/module/student/skill-verification/SkillTestPage.tsx` | Same improved error handling in camera gate UI |

## Security Note

`camera=(self)` allows camera **only** for the site's own origin — third-party embeds still cannot access it. `geolocation=()` and `interest-cohort=()` remain fully blocked.

## Testing

After deploy, verify:
1. Open `/test/:testId` → click "Enable Camera & Continue" → camera prompt should appear
2. Check response headers: `Permissions-Policy: camera=(self), microphone=(self), ...`
3. Block camera in browser settings → should show "Camera permission denied" (not "policy blocked")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera permission flow with clearer, specific messages for permission denied, site/security policy blocks, no camera found, and camera-in-use situations.

* **Chores**
  * Permissions policy updated to explicitly allow camera and microphone.
  * Deployment workflow restricted to run only for the primary repository to avoid unintended builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->