### PR TITLE
fix: scroll to top on pagination in gov internships page

### DIFF
--- a/client/src/module/student/jobs/GovInternshipsPage.tsx
+++ b/client/src/module/student/jobs/GovInternshipsPage.tsx
@@ -204,11 +204,10 @@ export default function GovInternshipsPage() {
         <div className="mb-8 flex flex-wrap items-center gap-2">
           <button
             onClick={() => { setCategory(""); setPage(1); }}
-            className={`px-3 py-1.5 text-xs font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${
-              !category
-                ? "bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 border-stone-900 dark:border-stone-50"
-                : "bg-transparent text-stone-600 dark:text-stone-400 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30"
-            }`}
+            className={`px-3 py-1.5 text-xs font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${!category
+              ? "bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 border-stone-900 dark:border-stone-50"
+              : "bg-transparent text-stone-600 dark:text-stone-400 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30"
+              }`}
           >
             All ({stats?.total ?? "..."})
           </button>
@@ -216,11 +215,10 @@ export default function GovInternshipsPage() {
             <button
               key={c.name}
               onClick={() => { setCategory(c.name); setPage(1); }}
-              className={`px-3 py-1.5 text-xs font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${
-                category === c.name
-                  ? "bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 border-stone-900 dark:border-stone-50"
-                  : "bg-transparent text-stone-600 dark:text-stone-400 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30"
-              }`}
+              className={`px-3 py-1.5 text-xs font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${category === c.name
+                ? "bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 border-stone-900 dark:border-stone-50"
+                : "bg-transparent text-stone-600 dark:text-stone-400 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30"
+                }`}
             >
               {c.name} ({c.count})
             </button>
@@ -277,7 +275,10 @@ export default function GovInternshipsPage() {
             {pagination && pagination.totalPages > 1 && (
               <div className="flex items-center justify-center gap-3 mt-10">
                 <button
-                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  onClick={() => {
+                    setPage((p) => Math.max(1, p - 1));
+                    window.scrollTo({ top: 0, behavior: "smooth" });
+                  }}
                   disabled={page <= 1}
                   className="flex items-center gap-1.5 px-4 py-2 rounded-md text-xs font-mono uppercase tracking-widest text-stone-600 dark:text-stone-400 border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30 hover:text-stone-900 dark:hover:text-stone-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors bg-transparent cursor-pointer"
                 >
@@ -287,7 +288,10 @@ export default function GovInternshipsPage() {
                   {pagination.page} / {pagination.totalPages}
                 </span>
                 <button
-                  onClick={() => setPage((p) => Math.min(pagination.totalPages, p + 1))}
+                  onClick={() => {
+                    setPage((p) => Math.min(pagination.totalPages, p + 1));
+                    window.scrollTo({ top: 0, behavior: "smooth" });
+                  }}
                   disabled={page >= pagination.totalPages}
                   className="flex items-center gap-1.5 px-4 py-2 rounded-md text-xs font-mono uppercase tracking-widest text-stone-600 dark:text-stone-400 border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30 hover:text-stone-900 dark:hover:text-stone-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors bg-transparent cursor-pointer"
                 >


### PR DESCRIPTION
## Summary
Gov internship cards on /student/internships did not scroll back to the top when navigating between pages. Clicking Next or Prev loaded new results correctly but left the user stranded at the bottom of the page, forcing a manual scroll up to see the new cards.

## Changes
- Added window.scrollTo({ top: 0, behavior: "smooth" }) to Prev button onClick handler in GovInternshipsPage.tsx
- Added window.scrollTo({ top: 0, behavior: "smooth" }) to Next button onClick handler in GovInternshipsPage.tsx

## How to test
1. Visit http://localhost:5173/student/internships
2. Scroll down to the pagination controls
3. Click Next — page should change AND viewport should smoothly scroll back to top
4. Click Prev — same behavior
5. Confirm new cards are visible immediately at top of page without manual scroll

## Screenshots
<img width="1866" height="939" alt="image" src="https://github.com/user-attachments/assets/dc443bfa-adff-4e2d-84c7-fe017bd1327b" />


Closes #396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Government internships page now automatically scrolls to the top with smooth animation when navigating between pages.

* **Style**
  * Updated visual styling for category filter buttons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->