### PR TITLE
fix: add staleTime to gov internships list query

### DIFF
--- a/client/src/module/student/jobs/GovInternshipsPage.tsx
+++ b/client/src/module/student/jobs/GovInternshipsPage.tsx
@@ -126,6 +126,7 @@ export default function GovInternshipsPage() {
   }>({
     queryKey: queryKeys.internships.list(queryParams),
     queryFn: () => api.get("/internships", { params: queryParams }).then((r) => r.data),
+    staleTime: 5 * 60 * 1000,
   });
 
   const internships = data?.internships ?? [];


### PR DESCRIPTION
## Summary
The internships list query on /student/internships had no staleTime configured, causing React Query to refetch data on every tab focus, component remount, and back-navigation even though the data rarely changes. The stats query on the same page already had staleTime: 5 * 60 * 1000 set correctly — the list query was simply missed.

## Changes
- Added staleTime: 5 * 60 * 1000 to the internships list useQuery in GovInternshipsPage.tsx
- Consistent with stats query staleTime already present on the same page

## How to test
1. Visit http://localhost:5173/student/internships
2. Wait for cards to load
3. Switch to another browser tab and switch back — no refetch should trigger
4. Navigate away to another page and hit back — no refetch should trigger
5. Open browser devtools Network tab and confirm no GET /internships request fires on tab focus within 5 minutes of initial load

## Screenshots
<img width="1806" height="953" alt="image" src="https://github.com/user-attachments/assets/4dafc2db-9ecd-488d-93a8-8251ce2583ab" />


Closes #397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized caching behavior for government internships data to align with platform standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->