### PR TITLE
Fix: Handle duplicate email and validation errors in newsletter subscription .

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -35,14 +35,14 @@ export function Footer() {
         setError("You're already subscribed!");
       }
     } catch (err: any) {
-      if (err.response?.status === 400) {
-        setError("Please enter a valid email address.");
-      } else if (err.response?.status === 409) {
-        setError("You're already subscribed!");
-      } else {
-        setError("Failed to subscribe. Try again.");
-      }
-    }
+  if (err.response?.status === 400) {
+    setError(err.response?.data?.message || "Please enter a valid email address.");
+  } else if (err.response?.status === 409) {
+    setError(err.response?.data?.message || "You're already subscribed!");
+  } else {
+    setError("Failed to subscribe. Try again.");
+  }
+}
     finally {
       setSubmitting(false);
     }

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -21,16 +21,29 @@ export function Footer() {
 
   const handleSubscribe = async (e: React.FormEvent) => {
     e.preventDefault();
+    e.preventDefault();
     if (!email.trim()) return;
     setSubmitting(true);
     setError("");
     try {
-      await api.post("/newsletter/subscribe", { email: email.trim() });
-      setSubscribed(true);
-      setEmail("");
-    } catch {
-      setError("Failed to subscribe. Try again.");
-    } finally {
+      const res = await api.post("/newsletter/subscribe", { email: email.trim() });
+      
+      if (res.status === 201) {
+        setSubscribed(true);
+        setEmail("");
+      } else if (res.status === 200) {
+        setError("You're already subscribed!");
+      }
+    } catch (err: any) {
+      if (err.response?.status === 400) {
+        setError("Please enter a valid email address.");
+      } else if (err.response?.status === 409) {
+        setError("You're already subscribed!");
+      } else {
+        setError("Failed to subscribe. Try again.");
+      }
+    }
+    finally {
       setSubmitting(false);
     }
   };


### PR DESCRIPTION
## Summary
Handle backend response cases in newsletter subscription form 
that were previously ignored by the frontend.

## Changes
- Handle `201` response: show success message for new subscribers
- Handle `200` response: show "already subscribed" error message
- Handle `400` error: show "valid email required" message from backend
- Handle `409` error: show duplicate email message as extra safety net

## How to test
1. Go to the footer of the landing page
2. Enter a new valid email → should show "subscribed. see you monday."
3. Enter the same email again → should show "You're already subscribed!"
4. Enter invalid email like `abc@` → should show validation error

Fixes #363 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved newsletter subscription flow with clearer, specific messages for invalid emails and duplicate subscriptions; prevents duplicate success notifications and correctly reports when an address is already subscribed.
  * Ensures submit button state is cleared after submission attempts so the UI remains responsive.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->