### PR TITLE
fix: session invalidation, atomic progress upsert, ATS IDOR bypass (#…

### DIFF
--- a/server/src/module/ats/ats.service.ts
+++ b/server/src/module/ats/ats.service.ts
@@ -31,9 +31,7 @@ export class AtsService {
     });
     if (!user) throw new Error("User not found");
 
-    const isOwned =
-      user.resumes.includes(input.resumeUrl) ||
-      getS3KeyFromUrl(input.resumeUrl) !== null; // allow any S3 URL they uploaded via the upload endpoint
+    const isOwned = user.resumes.includes(input.resumeUrl);
     if (!isOwned) {
       throw new Error("Resume does not belong to this user");
     }
@@ -99,9 +97,7 @@ export class AtsService {
     });
     if (!user) throw new Error("User not found");
 
-    const isOwned =
-      user.resumes.includes(input.resumeUrl) ||
-      getS3KeyFromUrl(input.resumeUrl) !== null;
+    const isOwned = user.resumes.includes(input.resumeUrl);
     if (!isOwned) {
       throw new Error("Resume does not belong to this user");
     }

--- a/server/src/module/ats/ats.service.ts
+++ b/server/src/module/ats/ats.service.ts
@@ -23,7 +23,13 @@ const __dirname = path.dirname(__filename);
 const SCORE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 export class AtsService {
+  private normalizeResumeUrl(resumeUrl: string): string {
+    return resumeUrl.split("?")[0] ?? resumeUrl;
+  }
+
   async scoreResume(studentId: number, input: ScoreResumeInput) {
+    const resumeUrl = this.normalizeResumeUrl(input.resumeUrl);
+
     // IDOR check: verify the resume belongs to this student
     const user = await prisma.user.findUnique({
       where: { id: studentId },
@@ -31,7 +37,7 @@ export class AtsService {
     });
     if (!user) throw new Error("User not found");
 
-    const isOwned = user.resumes.includes(input.resumeUrl);
+    const isOwned = user.resumes.includes(resumeUrl);
     if (!isOwned) {
       throw new Error("Resume does not belong to this user");
     }
@@ -41,7 +47,7 @@ export class AtsService {
     const cached = await prisma.atsScore.findFirst({
       where: {
         studentId,
-        resumeUrl: input.resumeUrl,
+        resumeUrl,
         jobTitle: input.jobTitle ?? null,
         jobDescription: input.jobDescription ?? null,
         createdAt: { gte: new Date(Date.now() - SCORE_CACHE_TTL_MS) },
@@ -50,7 +56,7 @@ export class AtsService {
     });
     if (cached) return cached;
 
-    const resumeText = await this.extractPdfText(input.resumeUrl);
+    const resumeText = await this.extractPdfText(resumeUrl);
 
     if (!resumeText || resumeText.trim().length < 50) {
       throw new Error(
@@ -68,7 +74,7 @@ export class AtsService {
     const atsScore = await prisma.atsScore.create({
       data: {
         studentId,
-        resumeUrl: input.resumeUrl,
+        resumeUrl,
         jobTitle: input.jobTitle ?? null,
         jobDescription: input.jobDescription ?? null,
         overallScore: result.overallScore,
@@ -91,18 +97,20 @@ export class AtsService {
   }
 
   async applySuggestions(studentId: number, input: ApplySuggestionsInput) {
+    const resumeUrl = this.normalizeResumeUrl(input.resumeUrl);
+
     const user = await prisma.user.findUnique({
       where: { id: studentId },
       select: { resumes: true },
     });
     if (!user) throw new Error("User not found");
 
-    const isOwned = user.resumes.includes(input.resumeUrl);
+    const isOwned = user.resumes.includes(resumeUrl);
     if (!isOwned) {
       throw new Error("Resume does not belong to this user");
     }
 
-    const resumeText = await this.extractPdfText(input.resumeUrl);
+    const resumeText = await this.extractPdfText(resumeUrl);
 
     if (!resumeText || resumeText.trim().length < 50) {
       throw new Error(

--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -585,13 +585,10 @@ export class AuthService {
         password: hashedPassword,
         resetPasswordOtp: null,
         resetOtpExpiresAt: null,
+        tokenVersion: { increment: 1 },
       },
     });
-    // Revoke existing sessions by bumping tokenVersion and clearing cache
-    await prisma.user.update({
-      where: { id: user.id },
-      data: { tokenVersion: { increment: 1 } },
-    });
+    // Revoke existing sessions only after the atomic password + version update succeeds.
     invalidateVersionCache(user.id);
   }
 

--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -587,6 +587,12 @@ export class AuthService {
         resetOtpExpiresAt: null,
       },
     });
+    // Revoke existing sessions by bumping tokenVersion and clearing cache
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { tokenVersion: { increment: 1 } },
+    });
+    invalidateVersionCache(user.id);
   }
 
   async importGitHub(username: string) {

--- a/server/src/module/interview-progress/interview-progress.service.ts
+++ b/server/src/module/interview-progress/interview-progress.service.ts
@@ -37,28 +37,15 @@ export class InterviewProgressService {
     questionId: string,
     action: ProgressAction
   ) {
-    const existingProgress =
-      await prisma.userInterviewProgress.findUnique({
-        where: {
-          userId,
-        },
-      });
+    // Read current state; default to empty arrays if no row exists yet
+    const existing = await prisma.userInterviewProgress.findUnique({
+      where: { userId },
+    });
 
-    const progress =
-      existingProgress ??
-      (await prisma.userInterviewProgress.create({
-        data: {
-          userId,
-          completedIds: [],
-          bookmarkedIds: [],
-        },
-      }));
-
-    let completedIds = [...progress.completedIds];
-    let bookmarkedIds = [...progress.bookmarkedIds];
-
-    let lastVisitedId = progress.lastVisitedId;
-    let lastVisitedAt = progress.lastVisitedAt;
+    let completedIds = [...(existing?.completedIds ?? [])];
+    let bookmarkedIds = [...(existing?.bookmarkedIds ?? [])];
+    let lastVisitedId = existing?.lastVisitedId ?? null;
+    let lastVisitedAt = existing?.lastVisitedAt ?? null;
 
     if (action === "complete") {
       completedIds = [...new Set([...completedIds, questionId])];
@@ -85,11 +72,17 @@ export class InterviewProgressService {
       lastVisitedAt = new Date();
     }
 
-    return prisma.userInterviewProgress.update({
-      where: {
+    // Single atomic upsert — safe under concurrent requests
+    return prisma.userInterviewProgress.upsert({
+      where: { userId },
+      create: {
         userId,
+        completedIds,
+        bookmarkedIds,
+        lastVisitedId,
+        lastVisitedAt,
       },
-      data: {
+      update: {
         completedIds,
         bookmarkedIds,
         lastVisitedId,

--- a/server/src/module/interview-progress/interview-progress.service.ts
+++ b/server/src/module/interview-progress/interview-progress.service.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../database/db.js";
 
 type ProgressAction =
@@ -8,6 +9,43 @@ type ProgressAction =
   | "visit";
 
 export class InterviewProgressService {
+  private serializeProgress(progress: {
+    completedIds: string[];
+    bookmarkedIds: string[];
+    lastVisitedId: string | null;
+    lastVisitedAt: Date | null;
+  }) {
+    return {
+      completedIds: progress.completedIds,
+      bookmarkedIds: progress.bookmarkedIds,
+      lastVisitedId: progress.lastVisitedId,
+      lastVisitedAt: progress.lastVisitedAt,
+    };
+  }
+
+  private async runSerializable<T>(
+    operation: (tx: Prisma.TransactionClient) => Promise<T>
+  ): Promise<T> {
+    const maxAttempts = 3;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        return await prisma.$transaction(operation, {
+          isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+        });
+      } catch (error) {
+        const canRetry =
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === "P2034" &&
+          attempt < maxAttempts;
+
+        if (!canRetry) throw error;
+      }
+    }
+
+    throw new Error("Could not save interview progress");
+  }
+
   async getProgress(userId: number) {
     const progress = await prisma.userInterviewProgress.findUnique({
       where: {
@@ -24,12 +62,7 @@ export class InterviewProgressService {
       };
     }
 
-    return {
-      completedIds: progress.completedIds,
-      bookmarkedIds: progress.bookmarkedIds,
-      lastVisitedId: progress.lastVisitedId,
-      lastVisitedAt: progress.lastVisitedAt,
-    };
+    return this.serializeProgress(progress);
   }
 
   async updateProgress(
@@ -37,57 +70,55 @@ export class InterviewProgressService {
     questionId: string,
     action: ProgressAction
   ) {
-    // Read current state; default to empty arrays if no row exists yet
-    const existing = await prisma.userInterviewProgress.findUnique({
-      where: { userId },
+    const progress = await this.runSerializable(async (tx) => {
+      const existing = await tx.userInterviewProgress.findUnique({
+        where: { userId },
+      });
+
+      let completedIds = [...(existing?.completedIds ?? [])];
+      let bookmarkedIds = [...(existing?.bookmarkedIds ?? [])];
+      let lastVisitedId = existing?.lastVisitedId ?? null;
+      let lastVisitedAt = existing?.lastVisitedAt ?? null;
+
+      if (action === "complete") {
+        completedIds = [...new Set([...completedIds, questionId])];
+      }
+
+      if (action === "uncomplete") {
+        completedIds = completedIds.filter((id) => id !== questionId);
+      }
+
+      if (action === "bookmark") {
+        bookmarkedIds = [...new Set([...bookmarkedIds, questionId])];
+      }
+
+      if (action === "unbookmark") {
+        bookmarkedIds = bookmarkedIds.filter((id) => id !== questionId);
+      }
+
+      if (action === "visit") {
+        lastVisitedId = questionId;
+        lastVisitedAt = new Date();
+      }
+
+      return tx.userInterviewProgress.upsert({
+        where: { userId },
+        create: {
+          userId,
+          completedIds,
+          bookmarkedIds,
+          lastVisitedId,
+          lastVisitedAt,
+        },
+        update: {
+          completedIds,
+          bookmarkedIds,
+          lastVisitedId,
+          lastVisitedAt,
+        },
+      });
     });
 
-    let completedIds = [...(existing?.completedIds ?? [])];
-    let bookmarkedIds = [...(existing?.bookmarkedIds ?? [])];
-    let lastVisitedId = existing?.lastVisitedId ?? null;
-    let lastVisitedAt = existing?.lastVisitedAt ?? null;
-
-    if (action === "complete") {
-      completedIds = [...new Set([...completedIds, questionId])];
-    }
-
-    if (action === "uncomplete") {
-      completedIds = completedIds.filter(
-        (id) => id !== questionId
-      );
-    }
-
-    if (action === "bookmark") {
-      bookmarkedIds = [...new Set([...bookmarkedIds, questionId])];
-    }
-
-    if (action === "unbookmark") {
-      bookmarkedIds = bookmarkedIds.filter(
-        (id) => id !== questionId
-      );
-    }
-
-    if (action === "visit") {
-      lastVisitedId = questionId;
-      lastVisitedAt = new Date();
-    }
-
-    // Single atomic upsert — safe under concurrent requests
-    return prisma.userInterviewProgress.upsert({
-      where: { userId },
-      create: {
-        userId,
-        completedIds,
-        bookmarkedIds,
-        lastVisitedId,
-        lastVisitedAt,
-      },
-      update: {
-        completedIds,
-        bookmarkedIds,
-        lastVisitedId,
-        lastVisitedAt,
-      },
-    });
+    return this.serializeProgress(progress);
   }
 }


### PR DESCRIPTION

- auth.service: increment tokenVersion + invalidate cache after resetPassword so stolen tokens are revoked immediately on password change
- interview-progress.service: replace find+create+update with prisma.upsert to eliminate race condition on concurrent requests (was throwing P2002)
- ats.service: remove permissive S3 URL fallback in IDOR ownership check; only resumes in user.resumes[] are accepted

Fixes #379


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened resume ownership validation and now consistently normalizes resume URLs to reduce accidental exposure.

* **Bug Fixes**
  * Password reset now revokes all active sessions, logging users out of other devices.

* **Improvements**
  * Interview progress updates are now persisted atomically with improved consistency and retry handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->