### PR TITLE
fix: restore demo section so Watch 90s demo button scrolls correctly

### DIFF
--- a/client/src/components/DemoVideoSection.tsx
+++ b/client/src/components/DemoVideoSection.tsx
@@ -1,10 +1,12 @@
 import { motion } from "framer-motion";
+import { Play, ArrowRight } from "lucide-react";
+import { Link } from "react-router";
 
 export function DemoVideoSection() {
   return (
     <section
       id="demo"
-      className="relative py-24 md:py-32 bg-stone-50 dark:bg-stone-950 border-t border-stone-200 dark:border-white/10"
+      className="relative py-24 md:py-32 bg-stone-50 dark:bg-stone-950 border-t border-stone-200 dark:border-white/10 scroll-mt-16"
     >
       <div className="max-w-6xl mx-auto px-6">
         <motion.div
@@ -25,8 +27,8 @@ export function DemoVideoSection() {
             </span>
           </h2>
           <p className="mt-6 text-base md:text-lg text-stone-600 dark:text-stone-400 max-w-xl mx-auto leading-relaxed">
-            Watch a full resume go from upload to ATS score to applied, start to
-            finish, in a single uninterrupted take.
+            Watch a full resume go from upload to ATS score to applied — start
+            to finish, in a single uninterrupted take.
           </p>
         </motion.div>
 
@@ -38,6 +40,7 @@ export function DemoVideoSection() {
           className="relative max-w-5xl mx-auto"
         >
           <div className="relative rounded-2xl border border-stone-200 dark:border-white/10 bg-white dark:bg-stone-900 overflow-hidden shadow-2xl shadow-stone-900/10 dark:shadow-black/60">
+            {/* Mock browser chrome bar */}
             <div className="flex items-center gap-2.5 px-5 py-3 border-b border-stone-200 dark:border-white/10 bg-stone-50 dark:bg-white/5">
               <div className="flex gap-1.5">
                 <span className="h-2.5 w-2.5 rounded-sm bg-stone-300 dark:bg-white/20" />
@@ -45,23 +48,73 @@ export function DemoVideoSection() {
                 <span className="h-2.5 w-2.5 rounded-sm bg-stone-300 dark:bg-white/20" />
               </div>
               <span className="ml-2 text-xs font-mono text-stone-500">
-                internhack.xyz / demo.mp4
+                internhack.xyz / demo
               </span>
               <span className="ml-auto flex items-center gap-1.5 text-xs font-mono text-stone-500">
-                <span className="h-1.5 w-1.5 bg-lime-400" />
-                90 sec
+                <span className="h-1.5 w-1.5 rounded-full bg-lime-400 animate-pulse" />
+                coming soon
               </span>
             </div>
-            <div className="relative aspect-video bg-stone-950">
-              <iframe
-                className="absolute inset-0 w-full h-full"
-                src="https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0&modestbranding=1"
-                title="InternHack product demo"
-                allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowFullScreen
+
+            {/* Demo placeholder — video not yet available */}
+            <div className="relative aspect-video bg-stone-950 flex flex-col items-center justify-center gap-6 px-6 text-center">
+              {/* Subtle grid background */}
+              <div
+                aria-hidden
+                className="absolute inset-0 opacity-10"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(rgba(255,255,255,0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.06) 1px, transparent 1px)",
+                  backgroundSize: "40px 40px",
+                }}
               />
+
+              {/* Play button icon */}
+              <motion.div
+                whileHover={{ scale: 1.08 }}
+                transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                className="relative z-10 flex items-center justify-center w-20 h-20 rounded-2xl bg-lime-400/10 border border-lime-400/30 cursor-default"
+              >
+                <Play className="w-8 h-8 text-lime-400 fill-lime-400 ml-1" />
+              </motion.div>
+
+              {/* Message */}
+              <div className="relative z-10 space-y-2">
+                <p className="text-lg font-semibold text-stone-200">
+                  Demo video coming soon
+                </p>
+                <p className="text-sm text-stone-500 max-w-sm mx-auto">
+                  Our 90-second product walkthrough is being recorded.
+                  In the meantime, try the live platform — no signup needed for the ATS scorer.
+                </p>
+              </div>
+
+              {/* CTA to live feature */}
+              <Link to="/ats-score" className="relative z-10 no-underline">
+                <motion.div
+                  whileHover={{ scale: 1.03 }}
+                  transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                  className="inline-flex items-center gap-2 px-5 py-2.5 bg-lime-400 text-stone-950 rounded-lg text-sm font-bold hover:bg-lime-300 transition-colors"
+                >
+                  Try ATS scorer live
+                  <ArrowRight className="w-4 h-4" />
+                </motion.div>
+              </Link>
             </div>
           </div>
+
+          {/* Caption below player */}
+          <p className="mt-4 text-center text-xs font-mono text-stone-500">
+            Full demo video drops soon · live product available at{" "}
+            <a
+              href="https://www.internhack.xyz"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-lime-600 dark:text-lime-400 hover:underline"
+            >
+              internhack.xyz
+            </a>
+          </p>
         </motion.div>
       </div>
     </section>

--- a/client/src/module/LandingPage/landingPage.tsx
+++ b/client/src/module/LandingPage/landingPage.tsx
@@ -8,6 +8,7 @@ import { PricingSection } from "../../components/PricingSection"
 import { TestimonialsSection } from "../../components/TestimonialsSection"
 import { CTASection } from "../../components/CTASection"
 import { FAQSection, FAQ_ITEMS } from "../../components/FAQSection"
+import { DemoVideoSection } from "../../components/DemoVideoSection"
 import { SEO } from "../../components/SEO"
 import { canonicalUrl } from "../../lib/seo.utils"
 import { faqSchema, websiteSchema, platformOrganizationSchema } from "../../lib/structured-data"
@@ -26,7 +27,7 @@ export default function LandingPage(){
             />
             <Navbar/>
             <HeroGeometric/>
-            {/* <DemoVideoSection/> */}
+            <DemoVideoSection/>
             <AudienceSection/>
             <FeaturesSection/>
             <HowItWorksSection/>


### PR DESCRIPTION
## Summary
Fixes the broken "Watch 90s demo" button on the homepage.

## Changes
- Uncommented DemoVideoSection in landingPage.tsx
- Replaced rickroll placeholder with a "coming soon" state
- Added scroll-mt-16 for correct anchor offset
- Added live CTA fallback linking to /ats-score

## How to test
1. Open homepage
2. Click "Watch 90s demo" in the hero or CTA section
3. Page should now smoothly scroll to the demo section

## Screenshots
<img width="1521" height="908" alt="image" src="https://github.com/user-attachments/assets/017d29e9-eb23-4a31-b6d2-0b883ac454eb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added demo video section to the landing page with a "coming soon" placeholder and updated messaging.
  * Integrated call-to-action linking to ATS score feature.
  * Updated demo section styling and layout for improved scroll behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->