### PR TITLE
feat: add GitHub stats widget to profiles

### DIFF
--- a/client/src/module/student/profile/GitHubStatsCard.tsx
+++ b/client/src/module/student/profile/GitHubStatsCard.tsx
@@ -1,0 +1,150 @@
+import { useQuery } from "@tanstack/react-query";
+import { BookOpen, ExternalLink, Github, Loader2, Star, Code2 } from "lucide-react";
+import api from "../../../lib/axios";
+
+interface GitHubStats {
+  username: string;
+  profileUrl: string;
+  publicRepos: number;
+  totalStars: number;
+  topLanguages: { name: string; count: number }[];
+}
+
+function getGitHubUsername(url?: string | null) {
+  const value = url?.trim();
+  if (!value) return "";
+
+  try {
+    const parsed = new URL(value.startsWith("http") ? value : `https://${value}`);
+    if (!parsed.hostname.toLowerCase().includes("github.com")) return "";
+    return parsed.pathname.split("/").filter(Boolean)[0] ?? "";
+  } catch {
+    return value.replace(/^github\.com\//i, "").split("/")[0] ?? "";
+  }
+}
+
+function formatCount(value: number) {
+  return new Intl.NumberFormat("en", { notation: value >= 1000 ? "compact" : "standard" }).format(value);
+}
+
+export default function GitHubStatsCard({
+  githubUrl,
+  compact = false,
+}: {
+  githubUrl?: string | null;
+  compact?: boolean;
+}) {
+  const username = getGitHubUsername(githubUrl);
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["github-stats", username],
+    queryFn: () =>
+      api
+        .get<{ stats: GitHubStats }>("/auth/github-stats", { params: { username } })
+        .then((res) => res.data.stats),
+    enabled: !!username,
+    staleTime: 60 * 60 * 1000,
+  });
+
+  if (!username) {
+    return (
+      <div className={`${compact ? "rounded-2xl" : "rounded-md"} border border-dashed border-stone-300 dark:border-white/15 bg-white dark:bg-stone-900 p-5`}>
+        <div className="flex items-start gap-3">
+          <div className="w-9 h-9 rounded-md bg-stone-100 dark:bg-stone-800 flex items-center justify-center shrink-0">
+            <Github className="w-4 h-4 text-stone-500" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-stone-900 dark:text-stone-50">GitHub stats</h3>
+            <p className="text-xs text-stone-500 mt-1">Link a GitHub profile to show repos, stars, and top languages.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className={`${compact ? "rounded-2xl" : "rounded-md"} border border-stone-200 dark:border-white/10 bg-white dark:bg-stone-900 p-5`}>
+        <div className="flex items-center gap-2 text-sm text-stone-500">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          Loading GitHub stats...
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className={`${compact ? "rounded-2xl" : "rounded-md"} border border-red-200 dark:border-red-900/40 bg-red-50/60 dark:bg-red-950/20 p-5`}>
+        <div className="flex items-start gap-3">
+          <Github className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
+          <div>
+            <h3 className="text-sm font-semibold text-red-700 dark:text-red-300">GitHub stats unavailable</h3>
+            <p className="text-xs text-red-600/80 dark:text-red-300/80 mt-1">Check that the linked GitHub profile is public and valid.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${compact ? "rounded-2xl border-gray-100 dark:border-gray-800" : "rounded-md border-stone-200 dark:border-white/10"} bg-white dark:bg-stone-900 border p-5`}>
+      <div className="flex items-start justify-between gap-3 mb-4">
+        <div className="min-w-0">
+          <p className="inline-flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500">
+            <Github className="w-3.5 h-3.5" />
+            GitHub stats
+          </p>
+          <h3 className="mt-1 text-sm font-bold text-stone-900 dark:text-stone-50 truncate">@{data.username}</h3>
+        </div>
+        <a
+          href={data.profileUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-stone-200 dark:border-white/10 text-[11px] font-semibold text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-50 hover:border-stone-400 dark:hover:border-white/30 transition-colors shrink-0"
+        >
+          Profile
+          <ExternalLink className="w-3 h-3" />
+        </a>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-md bg-stone-50 dark:bg-stone-950/60 border border-stone-100 dark:border-white/10 p-3">
+          <div className="flex items-center gap-2 text-stone-500 mb-2">
+            <BookOpen className="w-3.5 h-3.5" />
+            <span className="text-[10px] font-mono uppercase tracking-widest">Repos</span>
+          </div>
+          <p className="text-xl font-bold text-stone-900 dark:text-stone-50 tabular-nums">{formatCount(data.publicRepos)}</p>
+        </div>
+        <div className="rounded-md bg-stone-50 dark:bg-stone-950/60 border border-stone-100 dark:border-white/10 p-3">
+          <div className="flex items-center gap-2 text-stone-500 mb-2">
+            <Star className="w-3.5 h-3.5" />
+            <span className="text-[10px] font-mono uppercase tracking-widest">Stars</span>
+          </div>
+          <p className="text-xl font-bold text-stone-900 dark:text-stone-50 tabular-nums">{formatCount(data.totalStars)}</p>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-2">
+          <Code2 className="w-3.5 h-3.5" />
+          Top languages
+        </div>
+        {data.topLanguages.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {data.topLanguages.map((language) => (
+              <span
+                key={language.name}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-lime-50 dark:bg-lime-950/25 text-lime-700 dark:text-lime-300 text-xs font-medium border border-lime-100 dark:border-lime-900/40"
+              >
+                {language.name}
+                <span className="text-[10px] opacity-70">{language.count}</span>
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p className="text-xs text-stone-500">No repository language data found yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/module/student/profile/GitHubStatsCard.tsx
+++ b/client/src/module/student/profile/GitHubStatsCard.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { BookOpen, ExternalLink, Github, Loader2, Star, Code2 } from "lucide-react";
 import api from "../../../lib/axios";
+import { Button } from "../../../components/ui/button";
 
 interface GitHubStats {
   username: string;
@@ -96,15 +97,12 @@ export default function GitHubStatsCard({
           </p>
           <h3 className="mt-1 text-sm font-bold text-stone-900 dark:text-stone-50 truncate">@{data.username}</h3>
         </div>
-        <a
-          href={data.profileUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-stone-200 dark:border-white/10 text-[11px] font-semibold text-stone-600 dark:text-stone-300 hover:text-stone-900 dark:hover:text-stone-50 hover:border-stone-400 dark:hover:border-white/30 transition-colors shrink-0"
-        >
-          Profile
-          <ExternalLink className="w-3 h-3" />
-        </a>
+        <Button asChild variant="foreground" mode="link" size="sm" className="shrink-0">
+          <a href={data.profileUrl} target="_blank" rel="noopener noreferrer">
+            Profile
+            <ExternalLink className="w-3 h-3" />
+          </a>
+        </Button>
       </div>
 
       <div className="grid grid-cols-2 gap-3">

--- a/client/src/module/student/profile/PublicProfilePage.tsx
+++ b/client/src/module/student/profile/PublicProfilePage.tsx
@@ -12,6 +12,7 @@ import { SEO } from "../../../components/SEO";
 import { Button } from "../../../components/ui/button";
 import { BadgesSection } from "../badges/BadgesSection";
 import ContributionGraphs from "../../../components/ContributionGraphs";
+import GitHubStatsCard from "./GitHubStatsCard";
 import type { ProjectItem, AchievementItem, VerifiedSkill } from "../../../lib/types";
 
 interface PublicProfile {
@@ -265,6 +266,10 @@ export default function PublicProfilePage() {
           <motion.div custom={4} variants={fadeInUp} initial="hidden" animate="visible"
             className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-5">
             <BadgesSection studentId={profile.id} />
+          </motion.div>
+
+          <motion.div custom={5} variants={fadeInUp} initial="hidden" animate="visible">
+            <GitHubStatsCard githubUrl={profile.githubUrl} compact />
           </motion.div>
         </div>
 

--- a/client/src/module/student/profile/StudentProfilePage.tsx
+++ b/client/src/module/student/profile/StudentProfilePage.tsx
@@ -16,6 +16,7 @@ import { LoadingScreen } from "../../../components/LoadingScreen";
 import toast from "@/components/ui/toast";
 import ImageCropModal from "../../../components/ImageCropModal";
 import GitHubImportModal from "./GitHubImportModal";
+import GitHubStatsCard from "./GitHubStatsCard";
 import { BadgesSection } from "../badges/BadgesSection";
 import ContributionGraphs from "../../../components/ContributionGraphs";
 
@@ -820,6 +821,10 @@ export default function StudentProfilePage() {
               <BadgesSection studentId={user.id} />
             </motion.div>
           )}
+
+          <motion.div custom={3} variants={fadeInUp} initial="hidden" animate="visible">
+            <GitHubStatsCard githubUrl={form.githubUrl} />
+          </motion.div>
         </aside>
 
         {/* ─── Right: Editable sections ─── */}

--- a/server/src/config/usage-limits.ts
+++ b/server/src/config/usage-limits.ts
@@ -10,6 +10,7 @@ export const DAILY_LIMITS: Record<UsageAction, Record<PlanTier, number>> = {
   MOCK_INTERVIEW:  { FREE: 0,  PREMIUM: 999999 },
   AI_JOB_CHAT:     { FREE: 2,  PREMIUM: 50 },
   CODE_RUN:        { FREE: 0,  PREMIUM: 50 },
+  GITHUB_STATS:    { FREE: 20, PREMIUM: 999999 },
 };
 
 export function getPlanTier(

--- a/server/src/database/prisma/migrations/20260525000000_add_github_stats_usage_action/migration.sql
+++ b/server/src/database/prisma/migrations/20260525000000_add_github_stats_usage_action/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "UsageAction" ADD VALUE 'GITHUB_STATS';

--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -1252,6 +1252,7 @@ enum UsageAction {
   MOCK_INTERVIEW
   AI_JOB_CHAT
   CODE_RUN
+  GITHUB_STATS
 }
 
 enum EmailCampaignStatus {

--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -163,6 +163,33 @@ export class AuthController {
     }
   }
 
+  async getGitHubStats(req: Request, res: Response) {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ message: "Authentication required" });
+      }
+
+      const username = typeof req.query["username"] === "string" ? req.query["username"] : "";
+      if (!username.trim()) {
+        return res.status(400).json({ message: "GitHub username is required" });
+      }
+
+      const stats = await this.authService.getGitHubStats(username);
+      return res.status(200).json({ stats });
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === "GitHub user not found") {
+          return res.status(404).json({ message: error.message });
+        }
+        if (error.message === "GitHub username is required") {
+          return res.status(400).json({ message: error.message });
+        }
+      }
+      console.error(error);
+      return res.status(500).json({ message: "Failed to fetch GitHub stats" });
+    }
+  }
+
   async verifyEmail(req: Request, res: Response) {
     const { email, otp } = req.body as { email?: string; otp?: string };
     if (!email || !otp) {

--- a/server/src/module/auth/auth.routes.ts
+++ b/server/src/module/auth/auth.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { AuthController } from "./auth.controller.js";
 import { AuthService } from "./auth.service.js";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
+import { usageLimit } from "../../middleware/usage-limit.middleware.js";
 import rateLimit from "express-rate-limit";
 
 const createOtpRateLimit = (max: number, message: string) => rateLimit({
@@ -31,5 +32,5 @@ authRouter.post("/logout", (req, res) => authController.logout(req, res));
 authRouter.get("/me", authMiddleware, (req, res) => authController.getProfile(req, res));
 authRouter.put("/me", authMiddleware, (req, res) => authController.updateProfile(req, res));
 authRouter.post("/import-github", authMiddleware, (req, res) => authController.importGitHub(req, res));
-authRouter.get("/github-stats", authMiddleware, (req, res) => authController.getGitHubStats(req, res));
+authRouter.get("/github-stats", authMiddleware, usageLimit("GITHUB_STATS"), (req, res) => authController.getGitHubStats(req, res));
 authRouter.get("/profile/:id", authMiddleware, (req, res) => authController.getPublicProfile(req, res));

--- a/server/src/module/auth/auth.routes.ts
+++ b/server/src/module/auth/auth.routes.ts
@@ -31,4 +31,5 @@ authRouter.post("/logout", (req, res) => authController.logout(req, res));
 authRouter.get("/me", authMiddleware, (req, res) => authController.getProfile(req, res));
 authRouter.put("/me", authMiddleware, (req, res) => authController.updateProfile(req, res));
 authRouter.post("/import-github", authMiddleware, (req, res) => authController.importGitHub(req, res));
+authRouter.get("/github-stats", authMiddleware, (req, res) => authController.getGitHubStats(req, res));
 authRouter.get("/profile/:id", authMiddleware, (req, res) => authController.getPublicProfile(req, res));

--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -55,6 +55,7 @@ interface GoogleAuthInput {
 }
 
 const GITHUB_STATS_CACHE_TTL = 60 * 60 * 1000;
+const GITHUB_STATS_MAX_REPO_PAGES = 100;
 
 type GitHubStats = {
   username: string;
@@ -87,8 +88,9 @@ function parseGitHubUsername(input: string) {
 
 async function fetchAllGitHubStatsRepos(username: string, headers: Record<string, string>): Promise<GitHubStatsRepo[]> {
   const repos: GitHubStatsRepo[] = [];
+  let hasNextPage = false;
 
-  for (let page = 1; ; page += 1) {
+  for (let page = 1; page <= GITHUB_STATS_MAX_REPO_PAGES; page += 1) {
     const reposRes = await fetch(
       `https://api.github.com/users/${encodeURIComponent(username)}/repos?per_page=100&type=owner&sort=updated&page=${page}`,
       { headers },
@@ -100,7 +102,12 @@ async function fetchAllGitHubStatsRepos(username: string, headers: Record<string
     const pageRepos = (await reposRes.json()) as GitHubStatsRepo[];
     repos.push(...pageRepos);
     const linkHeader = reposRes.headers.get("link") ?? "";
-    if (!linkHeader.includes('rel="next"')) break;
+    hasNextPage = linkHeader.includes('rel="next"');
+    if (!hasNextPage) break;
+  }
+
+  if (hasNextPage) {
+    throw new Error("Exceeded max GitHub repository pages while fetching stats");
   }
 
   return repos;

--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -54,6 +54,31 @@ interface GoogleAuthInput {
   role?: UserRole;
 }
 
+const GITHUB_STATS_CACHE_TTL = 60 * 60 * 1000;
+
+type GitHubStats = {
+  username: string;
+  profileUrl: string;
+  publicRepos: number;
+  totalStars: number;
+  topLanguages: { name: string; count: number }[];
+};
+
+const githubStatsCache = new Map<string, { data: GitHubStats; expiresAt: number }>();
+
+function parseGitHubUsername(input: string) {
+  const value = input.trim();
+  if (!value) return "";
+
+  try {
+    const parsed = new URL(value.startsWith("http") ? value : `https://${value}`);
+    if (!parsed.hostname.toLowerCase().includes("github.com")) return value.replace(/^@/, "");
+    return parsed.pathname.split("/").filter(Boolean)[0]?.replace(/^@/, "") ?? "";
+  } catch {
+    return value.replace(/^github\.com\//i, "").split("/")[0]?.replace(/^@/, "") ?? "";
+  }
+}
+
 export class AuthService {
   private googleClient: OAuth2Client;
 
@@ -665,5 +690,75 @@ export class AuthService {
       languages,
       projects,
     };
+  }
+
+  async getGitHubStats(input: string): Promise<GitHubStats> {
+    const username = parseGitHubUsername(input);
+    if (!username) {
+      throw new Error("GitHub username is required");
+    }
+
+    const cacheKey = username.toLowerCase();
+    const cached = githubStatsCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.data;
+    }
+
+    const headers = { "User-Agent": "InternHack-App" };
+    const [userRes, reposRes] = await Promise.all([
+      fetch(`https://api.github.com/users/${encodeURIComponent(username)}`, { headers }),
+      fetch(`https://api.github.com/users/${encodeURIComponent(username)}/repos?per_page=100&type=owner&sort=updated`, { headers }),
+    ]);
+
+    if (!userRes.ok) {
+      if (userRes.status === 404) throw new Error("GitHub user not found");
+      throw new Error(`GitHub API error: ${userRes.status}`);
+    }
+    if (!reposRes.ok) {
+      throw new Error(`GitHub API error: ${reposRes.status}`);
+    }
+
+    const profile = (await userRes.json()) as {
+      login: string;
+      html_url: string;
+      public_repos: number;
+    };
+    const repos = (await reposRes.json()) as {
+      stargazers_count: number;
+      language: string | null;
+      fork: boolean;
+    }[];
+
+    const ownRepos = repos.filter((repo) => !repo.fork);
+    const languageCounts = new Map<string, number>();
+    let totalStars = 0;
+
+    for (const repo of ownRepos) {
+      totalStars += repo.stargazers_count ?? 0;
+      if (repo.language) {
+        languageCounts.set(repo.language, (languageCounts.get(repo.language) ?? 0) + 1);
+      }
+    }
+
+    const data: GitHubStats = {
+      username: profile.login,
+      profileUrl: profile.html_url,
+      publicRepos: profile.public_repos ?? ownRepos.length,
+      totalStars,
+      topLanguages: [...languageCounts.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .slice(0, 3)
+        .map(([name, count]) => ({ name, count })),
+    };
+
+    githubStatsCache.set(cacheKey, { data, expiresAt: Date.now() + GITHUB_STATS_CACHE_TTL });
+    if (githubStatsCache.size > 200) {
+      const now = Date.now();
+      for (const [key, entry] of githubStatsCache) {
+        if (entry.expiresAt <= now) githubStatsCache.delete(key);
+      }
+    }
+
+    return data;
   }
 }

--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -64,6 +64,12 @@ type GitHubStats = {
   topLanguages: { name: string; count: number }[];
 };
 
+type GitHubStatsRepo = {
+  stargazers_count: number;
+  language: string | null;
+  fork: boolean;
+};
+
 const githubStatsCache = new Map<string, { data: GitHubStats; expiresAt: number }>();
 
 function parseGitHubUsername(input: string) {
@@ -77,6 +83,27 @@ function parseGitHubUsername(input: string) {
   } catch {
     return value.replace(/^github\.com\//i, "").split("/")[0]?.replace(/^@/, "") ?? "";
   }
+}
+
+async function fetchAllGitHubStatsRepos(username: string, headers: Record<string, string>): Promise<GitHubStatsRepo[]> {
+  const repos: GitHubStatsRepo[] = [];
+
+  for (let page = 1; ; page += 1) {
+    const reposRes = await fetch(
+      `https://api.github.com/users/${encodeURIComponent(username)}/repos?per_page=100&type=owner&sort=updated&page=${page}`,
+      { headers },
+    );
+    if (!reposRes.ok) {
+      throw new Error(`GitHub API error: ${reposRes.status}`);
+    }
+
+    const pageRepos = (await reposRes.json()) as GitHubStatsRepo[];
+    repos.push(...pageRepos);
+    const linkHeader = reposRes.headers.get("link") ?? "";
+    if (!linkHeader.includes('rel="next"')) break;
+  }
+
+  return repos;
 }
 
 export class AuthService {
@@ -705,29 +732,20 @@ export class AuthService {
     }
 
     const headers = { "User-Agent": "InternHack-App" };
-    const [userRes, reposRes] = await Promise.all([
+    const [userRes, repos] = await Promise.all([
       fetch(`https://api.github.com/users/${encodeURIComponent(username)}`, { headers }),
-      fetch(`https://api.github.com/users/${encodeURIComponent(username)}/repos?per_page=100&type=owner&sort=updated`, { headers }),
+      fetchAllGitHubStatsRepos(username, headers),
     ]);
 
     if (!userRes.ok) {
       if (userRes.status === 404) throw new Error("GitHub user not found");
       throw new Error(`GitHub API error: ${userRes.status}`);
     }
-    if (!reposRes.ok) {
-      throw new Error(`GitHub API error: ${reposRes.status}`);
-    }
-
     const profile = (await userRes.json()) as {
       login: string;
       html_url: string;
       public_repos: number;
     };
-    const repos = (await reposRes.json()) as {
-      stargazers_count: number;
-      language: string | null;
-      fork: boolean;
-    }[];
 
     const ownRepos = repos.filter((repo) => !repo.fork);
     const languageCounts = new Map<string, number>();


### PR DESCRIPTION
## Summary
- add a cached backend GitHub stats endpoint for linked profiles
- add a reusable GitHub stats card with loading, error, and empty states
- show repos, total stars, top languages, and profile link on student and public profiles

Fixes #498

## Verification
- git diff --check
- npx eslint src/module/student/profile/GitHubStatsCard.tsx
- npx tsc --noEmit --jsx react-jsx --moduleResolution bundler --module ESNext --target ES2022 --types node --types vite/client --skipLibCheck src/module/student/profile/GitHubStatsCard.tsx

## Notes
- Full client typecheck is currently blocked by an existing JSX parse issue in src/module/blog/BlogListPage.tsx.
- Full server typecheck is currently blocked by the local Prisma client not matching the repository schema/generated models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub statistics card to student and public profiles showing repo count, total stars, and top languages, with loading, empty, and error states and prompts to link a GitHub profile.
  * New backend endpoint to fetch GitHub stats for linked profiles.

* **Chores**
  * Results are cached for faster responses and the stats endpoint is rate-limited to prevent abuse.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->