### PR TITLE
feat: send weekly roadmap progress digests

### DIFF
--- a/server/src/cron/roadmap-weekly-digest.ts
+++ b/server/src/cron/roadmap-weekly-digest.ts
@@ -110,23 +110,34 @@ export async function sendWeeklyRoadmapDigests(): Promise<void> {
   for (const digest of byUser.values()) {
     if (digest.roadmaps.length === 0) continue;
 
-    await sendEmail({
-      to: digest.user.email,
-      subject: `${digest.user.name.split(" ")[0] || "Student"}, your weekly roadmap progress`,
-      html: roadmapWeeklyDigestEmailHtml({
-        name: digest.user.name,
-        roadmaps: digest.roadmaps,
-      }),
-    });
+    try {
+      await sendEmail({
+        to: digest.user.email,
+        subject: `${digest.user.name.split(" ")[0] || "Student"}, your weekly roadmap progress`,
+        html: roadmapWeeklyDigestEmailHtml({
+          name: digest.user.name,
+          roadmaps: digest.roadmaps,
+        }),
+      });
+    } catch (err) {
+      console.error(
+        `[RoadmapDigest] Failed to send digest to user ${digest.user.id} (${digest.user.email}):`,
+        err,
+      );
+    }
   }
 }
 
 export function startWeeklyRoadmapDigestCron(schedule = "0 9 * * 1"): void {
   if (cronJob) return;
-  cronJob = cron.schedule(schedule, () => {
-    void sendWeeklyRoadmapDigests().catch((err) => {
-      console.error("[RoadmapDigest] Weekly digest failed:", err);
-    });
-  });
+  cronJob = cron.schedule(
+    schedule,
+    () => {
+      void sendWeeklyRoadmapDigests().catch((err) => {
+        console.error("[RoadmapDigest] Weekly digest failed:", err);
+      });
+    },
+    { timezone: "Etc/UTC" },
+  );
   console.log(`[RoadmapDigest] Weekly digest scheduled with cron "${schedule}"`);
 }

--- a/server/src/cron/roadmap-weekly-digest.ts
+++ b/server/src/cron/roadmap-weekly-digest.ts
@@ -120,10 +120,7 @@ export async function sendWeeklyRoadmapDigests(): Promise<void> {
         }),
       });
     } catch (err) {
-      console.error(
-        `[RoadmapDigest] Failed to send digest to user ${digest.user.id} (${digest.user.email}):`,
-        err,
-      );
+      console.error(`[RoadmapDigest] Failed to send digest to user ${digest.user.id}:`, err);
     }
   }
 }

--- a/server/src/cron/roadmap-weekly-digest.ts
+++ b/server/src/cron/roadmap-weekly-digest.ts
@@ -1,0 +1,132 @@
+import cron from "node-cron";
+import { prisma } from "../database/db.js";
+import { sendEmail } from "../utils/email.utils.js";
+import { roadmapWeeklyDigestEmailHtml } from "../utils/email-templates.js";
+
+let cronJob: cron.ScheduledTask | null = null;
+
+type DigestRoadmap = {
+  title: string;
+  slug: string;
+  percentComplete: number;
+  completedThisWeek: number;
+  nextTopicTitle: string | null;
+  nextTopicSlug: string | null;
+};
+
+type DigestEnrollment = {
+  userId: number;
+  user: { id: number; name: string; email: string };
+  topicProgress: { topicId: number; status: string; completedAt: Date | null }[];
+  roadmap: {
+    title: string;
+    slug: string;
+    sections: {
+      topics: {
+        id: number;
+        slug: string;
+        title: string;
+        orderIndex: number;
+        section: { orderIndex: number };
+      }[];
+    }[];
+  };
+};
+
+function buildDigestRoadmap(enrollment: DigestEnrollment): DigestRoadmap | null {
+  const topics = enrollment.roadmap.sections
+    .flatMap((section) => section.topics)
+    .sort((a, b) => a.section.orderIndex - b.section.orderIndex || a.orderIndex - b.orderIndex);
+  const totalTopics = topics.length;
+  if (totalTopics === 0) return null;
+
+  const progressByTopicId = new Map(enrollment.topicProgress.map((progress) => [progress.topicId, progress]));
+  const completed = topics.filter((topic) => progressByTopicId.get(topic.id)?.status === "COMPLETED");
+  if (completed.length >= totalTopics) return null;
+
+  const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const completedThisWeek = enrollment.topicProgress.filter(
+    (progress) => progress.status === "COMPLETED" && progress.completedAt && progress.completedAt >= weekAgo,
+  ).length;
+  const nextTopic = topics.find((topic) => progressByTopicId.get(topic.id)?.status !== "COMPLETED") ?? null;
+
+  return {
+    title: enrollment.roadmap.title,
+    slug: enrollment.roadmap.slug,
+    percentComplete: Math.round((completed.length / totalTopics) * 100),
+    completedThisWeek,
+    nextTopicTitle: nextTopic?.title ?? null,
+    nextTopicSlug: nextTopic?.slug ?? null,
+  };
+}
+
+async function getActiveDigestEnrollments(): Promise<DigestEnrollment[]> {
+  const enrollments = await prisma.roadmapEnrollment.findMany({
+    where: {
+      status: "ACTIVE",
+      user: {
+        isActive: true,
+        unsubscribeDigest: false,
+      },
+    },
+    include: {
+      user: { select: { id: true, name: true, email: true } },
+      topicProgress: true,
+      roadmap: {
+        include: {
+          sections: {
+            include: {
+              topics: {
+                select: {
+                  id: true,
+                  slug: true,
+                  title: true,
+                  orderIndex: true,
+                  section: { select: { orderIndex: true } },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+  return enrollments as unknown as DigestEnrollment[];
+}
+
+export async function sendWeeklyRoadmapDigests(): Promise<void> {
+  const enrollments = await getActiveDigestEnrollments();
+  const byUser = new Map<number, { user: { id: number; name: string; email: string }; roadmaps: DigestRoadmap[] }>();
+
+  for (const enrollment of enrollments) {
+    const digestRoadmap = buildDigestRoadmap(enrollment);
+    if (!digestRoadmap) continue;
+
+    const current = byUser.get(enrollment.userId) ?? { user: enrollment.user, roadmaps: [] };
+    current.roadmaps.push(digestRoadmap);
+    byUser.set(enrollment.userId, current);
+  }
+
+  for (const digest of byUser.values()) {
+    if (digest.roadmaps.length === 0) continue;
+
+    await sendEmail({
+      to: digest.user.email,
+      subject: `${digest.user.name.split(" ")[0] || "Student"}, your weekly roadmap progress`,
+      html: roadmapWeeklyDigestEmailHtml({
+        name: digest.user.name,
+        roadmaps: digest.roadmaps,
+      }),
+    });
+  }
+}
+
+export function startWeeklyRoadmapDigestCron(schedule = "0 9 * * 1"): void {
+  if (cronJob) return;
+  cronJob = cron.schedule(schedule, () => {
+    void sendWeeklyRoadmapDigests().catch((err) => {
+      console.error("[RoadmapDigest] Weekly digest failed:", err);
+    });
+  });
+  console.log(`[RoadmapDigest] Weekly digest scheduled with cron "${schedule}"`);
+}

--- a/server/src/database/prisma/migrations/20260524000000_add_unsubscribe_digest/migration.sql
+++ b/server/src/database/prisma/migrations/20260524000000_add_unsubscribe_digest/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "unsubscribeDigest" BOOLEAN NOT NULL DEFAULT false;

--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -43,6 +43,7 @@ model user {
   projects              Json                        @default("[]")
   achievements          Json                        @default("[]")
   leetcodeUrl           String?
+  unsubscribeDigest     Boolean                     @default(false)
   tokenVersion          Int                         @default(0)
   adminActivityLogs     adminActivityLog[]          @relation("AdminActivityLogs")
   adminProfile          adminProfile?               @relation("AdminProfile")

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -69,6 +69,7 @@ import { startFollowUpCron } from "./cron/scheduled-emails.js";
 import { startAIPipelineCrons } from "./cron/internhack-ai.cron.js";
 import { startSubscriptionExpiryCron } from "./cron/subscription-expiry.js";
 import { startScheduledEmailWorker } from "./cron/scheduled-email-worker.js";
+import { startWeeklyRoadmapDigestCron } from "./cron/roadmap-weekly-digest.js";
 
 // ── Validate required environment variables ──
 const REQUIRED_ENV = ["DATABASE_URL", "JWT_SECRET"] as const;
@@ -323,4 +324,7 @@ app.listen(PORT, async () => {
 
   // Start the scheduled-email worker (drains roadmap day-10, future digests)
   startScheduledEmailWorker();
+
+  // Start weekly roadmap progress digests (Monday 9 AM)
+  startWeeklyRoadmapDigestCron();
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -325,6 +325,13 @@ app.listen(PORT, async () => {
   // Start the scheduled-email worker (drains roadmap day-10, future digests)
   startScheduledEmailWorker();
 
-  // Start weekly roadmap progress digests (Monday 9 AM)
-  startWeeklyRoadmapDigestCron();
+  // Start weekly roadmap progress digests from one owner only in production.
+  const runWeeklyDigestCron =
+    process.env["RUN_WEEKLY_ROADMAP_DIGEST_CRON"] === "true" ||
+    (process.env["NODE_ENV"] !== "production" && process.env["RUN_WEEKLY_ROADMAP_DIGEST_CRON"] !== "false");
+  if (runWeeklyDigestCron) {
+    startWeeklyRoadmapDigestCron();
+  } else {
+    console.log("[RoadmapDigest] Weekly digest cron disabled on this process");
+  }
 });

--- a/server/src/utils/email-templates.ts
+++ b/server/src/utils/email-templates.ts
@@ -1097,6 +1097,83 @@ export function roadmapDay10EmailHtml(args: {
 </html>`;
 }
 
+export function roadmapWeeklyDigestEmailHtml(args: {
+  name: string;
+  roadmaps: {
+    title: string;
+    slug: string;
+    percentComplete: number;
+    completedThisWeek: number;
+    nextTopicTitle: string | null;
+    nextTopicSlug: string | null;
+  }[];
+}): string {
+  const firstName = args.name.split(" ")[0] || args.name;
+  const dashboardUrl = "https://www.internhack.xyz/dashboard/roadmaps";
+  const rows = args.roadmaps.map((roadmap) => {
+    const resumeUrl = roadmap.nextTopicSlug
+      ? `https://www.internhack.xyz/learn/roadmaps/${roadmap.slug}/${roadmap.nextTopicSlug}`
+      : `https://www.internhack.xyz/learn/roadmaps/${roadmap.slug}`;
+    const nudge = roadmap.completedThisWeek === 0
+      ? "No topics completed this week. A 20-minute restart still counts."
+      : `${roadmap.completedThisWeek} topic${roadmap.completedThisWeek === 1 ? "" : "s"} completed this week.`;
+
+    return `
+      <tr><td style="padding:16px;background-color:#fafafa;border:1px solid #e4e4e7;border-radius:10px;">
+        <p style="margin:0 0 4px;font-size:15px;font-weight:700;color:#18181b;">${roadmap.title}</p>
+        <p style="margin:0 0 12px;font-size:12px;color:#71717a;">${nudge}</p>
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:12px;">
+          <tr><td style="height:8px;background-color:#e4e4e7;border-radius:999px;overflow:hidden;">
+            <div style="height:8px;width:${Math.max(0, Math.min(100, roadmap.percentComplete))}%;background-color:#a3e635;"></div>
+          </td></tr>
+        </table>
+        <p style="margin:0 0 10px;font-size:12px;color:#52525b;">
+          <strong style="color:#18181b;">${roadmap.percentComplete}% complete</strong>
+          ${roadmap.nextTopicTitle ? ` - Next: ${roadmap.nextTopicTitle}` : ""}
+        </p>
+        <a href="${resumeUrl}" style="display:inline-block;padding:10px 14px;background-color:#18181b;color:#ffffff;text-decoration:none;border-radius:6px;font-size:12px;font-weight:700;">
+          Resume roadmap
+        </a>
+      </td></tr>
+      <tr><td style="height:10px;"></td></tr>`;
+  }).join("");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /></head>
+<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:'Segoe UI',Arial,Helvetica,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;margin:0 auto;">
+    <tr><td style="background-color:#0a0a0a;padding:28px 24px;text-align:center;">
+      <h1 style="margin:0;font-size:26px;font-weight:800;color:#ffffff;letter-spacing:-0.5px;">InternHack</h1>
+      <p style="margin:6px 0 0;font-size:11px;font-family:'Courier New',Courier,monospace;letter-spacing:2px;color:#a3e635;text-transform:uppercase;">weekly roadmap digest</p>
+    </td></tr>
+    <tr><td style="background-color:#ffffff;padding:32px 24px;">
+      <h2 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#18181b;">Hey ${firstName}, your weekly roadmap check-in is here.</h2>
+      <p style="margin:0 0 20px;font-size:15px;line-height:1.7;color:#52525b;">
+        Here is where your active roadmap progress stands, plus the next topic to pick up.
+      </p>
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:22px;">
+        ${rows}
+      </table>
+      <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto 14px;">
+        <tr><td style="background-color:#0a0a0a;border-radius:8px;">
+          <a href="${dashboardUrl}" style="display:inline-block;padding:14px 36px;font-size:15px;font-weight:700;color:#ffffff;text-decoration:none;">
+            Open roadmap dashboard
+          </a>
+        </td></tr>
+      </table>
+      <p style="margin:18px 0 0;font-size:12px;color:#a1a1aa;text-align:center;">
+        You can turn off roadmap digests from your account preferences.
+      </p>
+    </td></tr>
+    <tr><td style="background-color:#fafafa;padding:20px 24px;text-align:center;border-top:1px solid #e4e4e7;">
+      <p style="margin:0;font-size:11px;color:#a1a1aa;">&copy; ${new Date().getFullYear()} InternHack. All rights reserved.</p>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}
+
 type ApplicationStatusEmailStatus = "IN_PROGRESS" | "SHORTLISTED" | "REJECTED" | "HIRED";
 
 const STATUS_COPY: Record<

--- a/server/src/utils/email-templates.ts
+++ b/server/src/utils/email-templates.ts
@@ -1108,9 +1108,11 @@ export function roadmapWeeklyDigestEmailHtml(args: {
     nextTopicSlug: string | null;
   }[];
 }): string {
-  const firstName = args.name.split(" ")[0] || args.name;
+  const firstName = escapeHtml(args.name.split(" ")[0] || args.name || "there");
   const dashboardUrl = "https://www.internhack.xyz/dashboard/roadmaps";
   const rows = args.roadmaps.map((roadmap) => {
+    const title = escapeHtml(roadmap.title);
+    const nextTopicTitle = roadmap.nextTopicTitle ? escapeHtml(roadmap.nextTopicTitle) : "";
     const resumeUrl = roadmap.nextTopicSlug
       ? `https://www.internhack.xyz/learn/roadmaps/${roadmap.slug}/${roadmap.nextTopicSlug}`
       : `https://www.internhack.xyz/learn/roadmaps/${roadmap.slug}`;
@@ -1120,7 +1122,7 @@ export function roadmapWeeklyDigestEmailHtml(args: {
 
     return `
       <tr><td style="padding:16px;background-color:#fafafa;border:1px solid #e4e4e7;border-radius:10px;">
-        <p style="margin:0 0 4px;font-size:15px;font-weight:700;color:#18181b;">${roadmap.title}</p>
+        <p style="margin:0 0 4px;font-size:15px;font-weight:700;color:#18181b;">${title}</p>
         <p style="margin:0 0 12px;font-size:12px;color:#71717a;">${nudge}</p>
         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:12px;">
           <tr><td style="height:8px;background-color:#e4e4e7;border-radius:999px;overflow:hidden;">
@@ -1129,7 +1131,7 @@ export function roadmapWeeklyDigestEmailHtml(args: {
         </table>
         <p style="margin:0 0 10px;font-size:12px;color:#52525b;">
           <strong style="color:#18181b;">${roadmap.percentComplete}% complete</strong>
-          ${roadmap.nextTopicTitle ? ` - Next: ${roadmap.nextTopicTitle}` : ""}
+          ${nextTopicTitle ? ` - Next: ${nextTopicTitle}` : ""}
         </p>
         <a href="${resumeUrl}" style="display:inline-block;padding:10px 14px;background-color:#18181b;color:#ffffff;text-decoration:none;border-radius:6px;font-size:12px;font-weight:700;">
           Resume roadmap


### PR DESCRIPTION
## Summary
- add a Monday 9 AM weekly roadmap digest cron
- send one digest per active student with progress percent, topics completed this week, next topic, and resume links
- add unsubscribeDigest to User and respect it when selecting recipients
- add the weekly digest email template and database migration

Fixes #500

## Verification
- git diff --check
- npx tsc --noEmit --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2022 --types node src/cron/roadmap-weekly-digest.ts src/utils/email-templates.ts (blocked by existing local Prisma client/schema mismatch in src/database/db.ts and missing generated roadmapEnrollment model types)

## Notes
- The implementation uses the existing EnrollmentStatus value ACTIVE, which is the schema equivalent of the issue's IN_PROGRESS wording.
- Students with all active enrolled roadmaps completed are skipped because no digest rows are generated for completed roadmaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly roadmap digest emails delivered each Monday (UTC) with progress %, items completed this week, next recommended topic, and a resume link per roadmap; emails are personalized and use a polished HTML layout.

* **Chores**
  * Added a user preference to opt out of roadmap digests (off by default).

* **Behavior**
  * Digest job runs on a scheduled cron at startup and can be enabled or disabled via configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->