### PR TITLE
feat: add related jobs section

### DIFF
--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -5,6 +5,7 @@ export const queryKeys = {
     list: (params?: Record<string, string | number | boolean | undefined>) =>
       ["jobs", "list", params] as const,
     detail: (id: string | number) => ["jobs", "detail", id] as const,
+    related: (id: string | number) => ["jobs", "related", id] as const,
   },
 
   // Applications

--- a/client/src/module/student/jobs/JobDetailPage.tsx
+++ b/client/src/module/student/jobs/JobDetailPage.tsx
@@ -63,12 +63,12 @@ export default function JobDetailPage() {
     enabled: !!id && isAuthenticated && user?.role === "STUDENT",
   });
 
-  const { data: relatedJobs = [] } = useQuery({
-    queryKey: queryKeys.jobs.list({ related: id!, tags: job?.tags?.join(",") || "" }),
+  const { data: relatedJobs = [], isLoading: isRelatedJobsLoading } = useQuery({
+    queryKey: queryKeys.jobs.related(id!),
     queryFn: () =>
-      api.get("/jobs", { params: { tags: job!.tags.join(","), limit: 4 } })
-        .then((res) => (res.data.jobs as Job[]).filter((j) => j.id !== Number(id))),
-    enabled: !!job && job.tags.length > 0,
+      api.get(`/jobs/${id}/related`, { params: { limit: 4 } })
+        .then((res) => res.data.jobs as Job[]),
+    enabled: !!id && !!job,
   });
 
   const { data: relatedPosts = [] } = useQuery({
@@ -355,14 +355,30 @@ export default function JobDetailPage() {
           </div>
 
           {/* Related jobs */}
-          {relatedJobs.length > 0 && (
+          {(isRelatedJobsLoading || relatedJobs.length > 0) && (
             <motion.div variants={fadeUp}>
               <Kicker>related / similar roles</Kicker>
               <h2 className="mt-3 text-xl font-bold tracking-tight text-stone-900 dark:text-stone-50 mb-5">
                 Similar positions.
               </h2>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {relatedJobs.slice(0, 4).map((rj) => (
+                {isRelatedJobsLoading &&
+                  Array.from({ length: 4 }).map((_, index) => (
+                    <div
+                      key={index}
+                      className="animate-pulse rounded-md border border-stone-200 bg-white p-5 dark:border-white/10 dark:bg-stone-900"
+                    >
+                      <div className="mb-3 flex items-start gap-3">
+                        <div className="h-10 w-10 rounded-md bg-stone-200 dark:bg-stone-800" />
+                        <div className="flex-1 space-y-2">
+                          <div className="h-3 w-2/3 rounded bg-stone-200 dark:bg-stone-800" />
+                          <div className="h-3 w-1/3 rounded bg-stone-200 dark:bg-stone-800" />
+                        </div>
+                      </div>
+                      <div className="h-3 w-1/2 rounded bg-stone-200 dark:bg-stone-800" />
+                    </div>
+                  ))}
+                {!isRelatedJobsLoading && relatedJobs.slice(0, 4).map((rj) => (
                   <Link
                     key={rj.id}
                     to={inStudentLayout ? `/student/jobs/${rj.id}` : `/jobs/${rj.id}`}

--- a/server/src/module/job/job.controller.ts
+++ b/server/src/module/job/job.controller.ts
@@ -78,8 +78,8 @@ export class JobController {
         return res.status(400).json({ message: "Invalid job ID" });
       }
 
-      const limitParam = Number(req.query["limit"] ?? 4);
-      const limit = Number.isFinite(limitParam) ? limitParam : 4;
+      const rawLimit = Number.parseInt(String(req.query["limit"] ?? "4"), 10);
+      const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(rawLimit, 1), 4) : 4;
       const jobs = await this.jobService.getRelatedJobs(id, limit);
       if (!jobs) {
         return res.status(404).json({ message: "Job not found" });

--- a/server/src/module/job/job.controller.ts
+++ b/server/src/module/job/job.controller.ts
@@ -71,6 +71,27 @@ export class JobController {
     }
   }
 
+  async getRelatedJobs(req: Request, res: Response) {
+    try {
+      const id = parseInt(String(req.params["id"]), 10);
+      if (isNaN(id)) {
+        return res.status(400).json({ message: "Invalid job ID" });
+      }
+
+      const limitParam = Number(req.query["limit"] ?? 4);
+      const limit = Number.isFinite(limitParam) ? limitParam : 4;
+      const jobs = await this.jobService.getRelatedJobs(id, limit);
+      if (!jobs) {
+        return res.status(404).json({ message: "Job not found" });
+      }
+
+      return res.status(200).json({ jobs });
+    } catch (error) {
+      logger.error("Failed to get related jobs", error);
+      return res.status(500).json({ message: "Internal Server Error" });
+    }
+  }
+
   async getRecruiterJobs(req: Request, res: Response) {
     try {
       if (!req.user) {

--- a/server/src/module/job/job.routes.ts
+++ b/server/src/module/job/job.routes.ts
@@ -15,6 +15,7 @@ jobRouter.get("/recruiter/my-jobs", authMiddleware, requireRole("RECRUITER"), (r
 // Public routes
 jobRouter.get("/", (req, res) => jobController.getJobs(req, res));
 jobRouter.get("/landing/:slug", (req, res) => jobController.getLandingPage(req, res));
+jobRouter.get("/:id/related", (req, res) => jobController.getRelatedJobs(req, res));
 jobRouter.get("/:id", (req, res) => jobController.getJobById(req, res));
 
 // Recruiter-only routes

--- a/server/src/module/job/job.service.ts
+++ b/server/src/module/job/job.service.ts
@@ -195,6 +195,44 @@ export class JobService {
     });
   }
 
+  async getRelatedJobs(jobId: number, limit = 4) {
+    const job = await prisma.job.findUnique({
+      where: { id: jobId },
+      select: { id: true, title: true, tags: true },
+    });
+    if (!job) return null;
+
+    const titleKeywords = job.title
+      .split(/[^a-zA-Z0-9+#.]+/)
+      .map((word) => word.trim())
+      .filter((word) => word.length >= 3)
+      .slice(0, 5);
+
+    const matchFilters: Prisma.jobWhereInput[] = [
+      ...(job.tags.length > 0 ? [{ tags: { hasSome: job.tags } }] : []),
+      ...titleKeywords.map((keyword) => ({
+        title: { contains: keyword, mode: "insensitive" as const },
+      })),
+    ];
+
+    if (matchFilters.length === 0) return [];
+
+    return prisma.job.findMany({
+      where: {
+        id: { not: job.id },
+        status: "PUBLISHED",
+        OR: matchFilters,
+        AND: [{ OR: [{ deadline: null }, { deadline: { gte: new Date() } }] }],
+      },
+      take: Math.min(Math.max(limit, 1), 8),
+      orderBy: { createdAt: "desc" },
+      include: {
+        recruiter: { select: { id: true, name: true, company: true } },
+        _count: { select: { applications: true, rounds: true } },
+      },
+    });
+  }
+
   async getRecruiterJobs(recruiterId: number, query: JobQuery) {
     const where: Prisma.jobWhereInput = { recruiterId };
 


### PR DESCRIPTION
## Summary
- Add a `GET /jobs/:id/related` endpoint backed by tag and title-keyword matching.
- Keep related jobs limited, published-only, non-expired, and excluding the current job.
- Update the job detail page to fetch related jobs from the dedicated endpoint.
- Add skeleton cards while related jobs load and keep the section hidden when there are no matches.

Fixes #455

## Verification
- `npx eslint src/module/student/jobs/JobDetailPage.tsx src/lib/query-keys.ts`
- `git diff --check`

## Notes
- Full client typecheck is currently blocked by unrelated JSX parse errors in `src/module/blog/BlogListPage.tsx`.
- Server typecheck is currently blocked by unrelated local Prisma generated-client/request type mismatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Related Jobs" section on job detail pages showing up to 4 related positions based on title and tags.
  * Shows a skeleton grid while related jobs load for a smoother experience.

* **Bug Fixes / Reliability**
  * Backend now provides capped related-job results with safer input handling and consistent error responses to improve reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->