### PR TITLE
fix: scroll scraped jobs pagination to top

### DIFF
--- a/client/src/module/scraped-jobs/ScrapedJobsPage.tsx
+++ b/client/src/module/scraped-jobs/ScrapedJobsPage.tsx
@@ -89,6 +89,10 @@ export default function ScrapedJobsPage() {
   const sources = sourcesData ?? [];
 
   useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [page]);
+
+  useEffect(() => {
     if (sourcesError && !sourcesErrorShown.current) {
       sourcesErrorShown.current = true;
       toast.error("Failed to load job sources");


### PR DESCRIPTION
## Summary
- Scroll the external jobs page back to the top whenever the pagination page changes.
- Keeps the existing PaginationControls API and data fetching flow unchanged.

## Root Cause
Changing pages updated the result cards while preserving the previous scroll position, so users could remain at the bottom of the page after new results loaded.

## Changed Files
- `client/src/module/scraped-jobs/ScrapedJobsPage.tsx`

## Tests
- `npx eslint src/module/scraped-jobs/ScrapedJobsPage.tsx`
- `git diff --check`
- `npm run typecheck` fails due pre-existing JSX parse errors in `src/module/blog/BlogListPage.tsx` at lines 132, 154, 262, 284, 322, and 323.

Closes #459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added smooth scrolling to the top when navigating between pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->