### PR TITLE
Feat/ats keyword gap visualization

### DIFF
--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -236,6 +236,7 @@ export interface AtsCategoryScores {
 
 export interface AtsKeywordAnalysis {
   found: string[];
+  partial: string[];
   missing: string[];
 }
 

--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -26,6 +26,8 @@ import {
   Mail,
   Wand2,
   Download,
+  CheckCircle2,
+  XCircle,
 } from "lucide-react";
 import { Button } from "../../../components/ui/button";
 import api from "../../../lib/axios";
@@ -1190,44 +1192,121 @@ export default function AtsScorePage() {
                           transition={{ duration: 0.18 }}
                           className="space-y-5"
                         >
-                          {result.keywordAnalysis.found.length > 0 && (
-                            <div>
-                              <div className={sectionKickerCls + " mb-3"}>
-                                <span className="h-1 w-1 bg-lime-400" />
-                                found · {result.keywordAnalysis.found.length}
+                          {/* ── Summary bar ── */}
+                          {(() => {
+                            const found = result.keywordAnalysis.found.length;
+                            const partial = (result.keywordAnalysis.partial ?? []).length;
+                            const missing = result.keywordAnalysis.missing.length;
+                            const total = found + partial + missing;
+                            if (total === 0) return null;
+                            const pFound = Math.round((found / total) * 100);
+                            const pPartial = Math.round((partial / total) * 100);
+                            const pMissing = 100 - pFound - pPartial;
+                            return (
+                              <div>
+                                <div className="flex items-center justify-between mb-1.5">
+                                  <span className={sectionKickerCls}>
+                                    <span className="h-1 w-1 bg-lime-400" />
+                                    {total} keywords analysed
+                                  </span>
+                                  <div className="flex items-center gap-3 text-[10px] font-mono uppercase tracking-widest text-stone-500">
+                                    <span className="inline-flex items-center gap-1"><span className="w-2 h-2 bg-lime-400 rounded-sm" />{found} present</span>
+                                    <span className="inline-flex items-center gap-1"><span className="w-2 h-2 bg-amber-400 rounded-sm" />{partial} partial</span>
+                                    <span className="inline-flex items-center gap-1"><span className="w-2 h-2 bg-red-400 rounded-sm" />{missing} missing</span>
+                                  </div>
+                                </div>
+                                <div className="flex h-2 rounded-full overflow-hidden gap-0.5">
+                                  {pFound > 0 && (
+                                    <div className="bg-lime-400 rounded-full transition-all" style={{ width: `${String(pFound)}%` }} />
+                                  )}
+                                  {pPartial > 0 && (
+                                    <div className="bg-amber-400 rounded-full transition-all" style={{ width: `${String(pPartial)}%` }} />
+                                  )}
+                                  {pMissing > 0 && (
+                                    <div className="bg-red-400 rounded-full transition-all" style={{ width: `${String(pMissing)}%` }} />
+                                  )}
+                                </div>
                               </div>
-                              <div className="flex flex-wrap gap-1.5">
-                                {result.keywordAnalysis.found.map((kw) => (
+                            );
+                          })()}
+
+                          {/* ── Three columns ── */}
+                          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                            {/* Present */}
+                            <div className="rounded-md border border-lime-200 dark:border-lime-900/50 bg-lime-50 dark:bg-lime-400/5 overflow-hidden">
+                              <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-lime-200 dark:border-lime-900/50">
+                                <span className="inline-flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-widest text-lime-700 dark:text-lime-400">
+                                  <CheckCircle2 className="w-3.5 h-3.5" /> Present
+                                </span>
+                                <span className="text-[10px] font-mono tabular-nums bg-lime-100 dark:bg-lime-400/20 text-lime-700 dark:text-lime-400 px-1.5 py-0.5 rounded-sm">
+                                  {result.keywordAnalysis.found.length}
+                                </span>
+                              </div>
+                              <div className="p-3 flex flex-wrap gap-1.5 min-h-14">
+                                {result.keywordAnalysis.found.length === 0 ? (
+                                  <p className="text-xs text-stone-400 dark:text-stone-600 italic self-center w-full text-center">None detected</p>
+                                ) : result.keywordAnalysis.found.map((kw) => (
                                   <span
                                     key={kw}
-                                    className="px-2.5 py-1 bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 rounded-md text-xs font-medium border border-lime-200 dark:border-lime-400/30"
+                                    className="inline-flex items-center gap-1 px-2 py-0.5 bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 rounded-md text-xs font-medium border border-lime-200 dark:border-lime-400/30"
                                   >
-                                    {kw}
+                                    <span className="text-lime-500 font-bold">✓</span> {kw}
                                   </span>
                                 ))}
                               </div>
                             </div>
-                          )}
-                          {result.keywordAnalysis.missing.length > 0 && (
-                            <div>
-                              <div className={sectionKickerCls + " mb-3"}>
-                                <span className="h-1 w-1 bg-orange-500" />
-                                missing ·{" "}
-                                {result.keywordAnalysis.missing.length}
+
+                            {/* Partial */}
+                            <div className="rounded-md border border-dashed border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-400/5 overflow-hidden">
+                              <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-amber-200 dark:border-amber-900/50">
+                                <span className="inline-flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-widest text-amber-700 dark:text-amber-400">
+                                  <AlertCircle className="w-3.5 h-3.5" /> Partial
+                                </span>
+                                <span className="text-[10px] font-mono tabular-nums bg-amber-100 dark:bg-amber-400/20 text-amber-700 dark:text-amber-400 px-1.5 py-0.5 rounded-sm">
+                                  {(result.keywordAnalysis.partial ?? []).length}
+                                </span>
                               </div>
-                              <div className="flex flex-wrap gap-1.5">
-                                {result.keywordAnalysis.missing.map((kw) => (
+                              <div className="p-3 flex flex-wrap gap-1.5 min-h-14">
+                                {(result.keywordAnalysis.partial ?? []).length === 0 ? (
+                                  <p className="text-xs text-stone-400 dark:text-stone-600 italic self-center w-full text-center">No partial keywords detected</p>
+                                ) : (result.keywordAnalysis.partial ?? []).map((kw) => (
                                   <span
                                     key={kw}
-                                    className="px-2.5 py-1 bg-orange-50 dark:bg-orange-950/20 text-orange-700 dark:text-orange-400 rounded-md text-xs font-medium border border-dashed border-orange-200 dark:border-orange-900/50"
+                                    className="inline-flex items-center gap-1 px-2 py-0.5 bg-amber-50 dark:bg-amber-400/10 text-amber-700 dark:text-amber-400 rounded-md text-xs font-medium border border-dashed border-amber-200 dark:border-amber-400/30"
                                   >
-                                    + {kw}
+                                    <span className="text-amber-500 font-bold">~</span> {kw}
                                   </span>
                                 ))}
                               </div>
                             </div>
-                          )}
+
+                            {/* Missing */}
+                            <div className="rounded-md border border-dashed border-red-200 dark:border-red-900/50 bg-red-50 dark:bg-red-400/5 overflow-hidden">
+                              <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-red-200 dark:border-red-900/50">
+                                <span className="inline-flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-widest text-red-700 dark:text-red-400">
+                                  <XCircle className="w-3.5 h-3.5" /> Missing
+                                </span>
+                                <span className="text-[10px] font-mono tabular-nums bg-red-100 dark:bg-red-400/20 text-red-700 dark:text-red-400 px-1.5 py-0.5 rounded-sm">
+                                  {result.keywordAnalysis.missing.length}
+                                </span>
+                              </div>
+                              <div className="p-3 flex flex-wrap gap-1.5 min-h-14">
+                                {result.keywordAnalysis.missing.length === 0 ? (
+                                  <p className="text-xs text-stone-400 dark:text-stone-600 italic self-center w-full text-center">None — great coverage!</p>
+                                ) : result.keywordAnalysis.missing.map((kw) => (
+                                  <span
+                                    key={kw}
+                                    className="inline-flex items-center gap-1 px-2 py-0.5 bg-red-50 dark:bg-red-400/10 text-red-700 dark:text-red-400 rounded-md text-xs font-medium border border-dashed border-red-200 dark:border-red-400/30"
+                                  >
+                                    <span className="text-red-500 font-bold">+</span> {kw}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                          </div>
+
                           {result.keywordAnalysis.found.length === 0 &&
+                            (result.keywordAnalysis.partial ?? []).length === 0 &&
                             result.keywordAnalysis.missing.length === 0 && (
                               <p className="text-sm text-stone-500 text-center py-8">
                                 No keyword data available for this analysis.

--- a/server/src/module/ats/ats.service.ts
+++ b/server/src/module/ats/ats.service.ts
@@ -306,8 +306,9 @@ Respond with ONLY valid JSON (no markdown formatting, no code blocks, no explana
     "<up to 8 suggestions total>"
   ],
   "keywordAnalysis": {
-    "found": ["<keyword1>", "<keyword2>", "...up to 15 found keywords"],
-    "missing": ["<missing keyword1>", "<missing keyword2>", "...up to 10 missing keywords"]
+    "found": ["<keyword1>", "<keyword2>", "...up to 15 keywords fully present and prominent in the resume"],
+    "partial": ["<keyword1>", "<keyword2>", "...up to 8 keywords mentioned only once or under-represented"],
+    "missing": ["<missing keyword1>", "<missing keyword2>", "...up to 10 keywords from the JD completely absent from the resume"]
   }
 }`;
   }
@@ -385,12 +386,15 @@ Respond with ONLY valid JSON (no markdown formatting, no code blocks, no explana
   }
 
   private validateKeywordAnalysis(raw: unknown): AtsKeywordAnalysis {
-    const defaults: AtsKeywordAnalysis = { found: [], missing: [] };
+    const defaults: AtsKeywordAnalysis = { found: [], partial: [], missing: [] };
     if (!raw || typeof raw !== "object") return defaults;
     const obj = raw as Record<string, unknown>;
     return {
       found: Array.isArray(obj["found"])
         ? obj["found"].filter((s): s is string => typeof s === "string")
+        : [],
+      partial: Array.isArray(obj["partial"])
+        ? obj["partial"].filter((s): s is string => typeof s === "string")
         : [],
       missing: Array.isArray(obj["missing"])
         ? obj["missing"].filter((s): s is string => typeof s === "string")

--- a/server/src/module/ats/ats.types.ts
+++ b/server/src/module/ats/ats.types.ts
@@ -9,6 +9,7 @@ export interface AtsCategoryScores {
 
 export interface AtsKeywordAnalysis {
   found: string[];
+  partial: string[];
   missing: string[];
 }
 


### PR DESCRIPTION
## Summary
Enhanced the ATS resume keyword analysis feature to support partial matches. Replaced the flat chip lists with a detailed, scannable three-column visual breakdown that explicitly highlights completely present, partially matched, and completely missing keywords alongside a proportional visual summary bar.

## Changes
- **AI Integration & Schema:** Updated the Gemini analysis prompt to identify and return partially matched keywords and updated the `AtsKeywordAnalysis` type to support a `partial: string[]` array field.
- **UI Breakdown:** Replaced the flat chip elements with a clean, three-column layout separating keywords into Present, Partial, and Missing categories.
- **Visual Summary Bar:** Added a proportional, colored segment bar highlighting key coverage metrics using Tailwind tokens (Present: solid lime, Partial: dashed amber, Missing: dashed red).
- **Responsiveness:** Managed vertical stacking with responsive count badges on smaller viewport sizes.
- **Backward Compatibility:** Ensured that older saved analyses lacking partial match keys default gracefully to an empty array without crashing the view.

## How to Test
1. Navigate to the ATS / Resume feedback section.
2. Run a keyword gap analysis on a resume against a target job description.
3. Verify that the keyword section renders the three columns correctly.
4. Ensure the summary bar correctly estimates proportional segments based on the counts.
5. Toggle responsive view sizes to confirm column stacking and count badge readability.

Closes #481 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced ATS keyword analysis now detects partial keywords (mentioned once or under-represented) alongside found and missing keywords.
  * Improved results interface displays a three-column layout showing keyword coverage with Present, Partial, and Missing categories.
  * Updated scoring provides more detailed keyword insights with coverage percentages across all three categories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->