### PR TITLE
fix: add one-click "Clear filters" to Jobs, Companies, DSA, and Aptitude pages

### DIFF
--- a/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
+++ b/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
-import { motion } from "framer-motion";
-import { CheckCircle2, Building2, ArrowUpRight, Brain, BookOpen, MessageSquare, Search } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import { CheckCircle2, Building2, ArrowUpRight, Brain, BookOpen, MessageSquare, Search, X } from "lucide-react";
 import api from "../../../lib/axios";
 import { queryKeys } from "../../../lib/query-keys";
 import type { AptitudeCategory, AptitudeProgress } from "../../../lib/types";
@@ -28,6 +28,15 @@ export default function AptitudeCategoriesPage() {
     enabled: !!user,
   });
 
+  // True when the user has deviated from the defaults.
+  const hasFilters = activeTab !== "all" || topicSearch.trim() !== "";
+
+  // Reset both filter axes in one shot.
+  const clearFilters = () => {
+    setTopicSearch("");
+    setActiveTab("all");
+  };
+
   const totalQuestions = categories?.reduce((s, c) => s + c.questionCount, 0) ?? 0;
   const totalAnswered = categories?.reduce((s, c) => s + c.answeredCount, 0) ?? 0;
   const overallPct = totalQuestions > 0 ? Math.round((totalAnswered / totalQuestions) * 100) : 0;
@@ -37,9 +46,9 @@ export default function AptitudeCategoriesPage() {
     categories?.flatMap((cat) =>
       cat.topics.map((t) => ({ ...t, categorySlug: cat.slug, categoryName: cat.name })),
     ) ?? [];
-  const filteredTopics = (activeTab === "all" ? allTopics : allTopics.filter((t) => t.categorySlug === activeTab)).filter(
-    (t) => !topicSearch || t.name.toLowerCase().includes(topicSearch.toLowerCase()),
-  );
+  const filteredTopics = (
+    activeTab === "all" ? allTopics : allTopics.filter((t) => t.categorySlug === activeTab)
+  ).filter((t) => !topicSearch || t.name.toLowerCase().includes(topicSearch.toLowerCase()));
 
   if (isLoading) return <LoadingScreen />;
 
@@ -122,12 +131,7 @@ export default function AptitudeCategoriesPage() {
         </motion.div>
 
         {/* Companies strip */}
-        <motion.div
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.05 }}
-          className="mb-6"
-        >
+        <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.05 }} className="mb-6">
           <Link
             to="/learn/aptitude/companies"
             className="group flex items-center gap-4 px-5 py-4 bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md hover:border-stone-400 dark:hover:border-white/30 transition-colors no-underline"
@@ -145,7 +149,7 @@ export default function AptitudeCategoriesPage() {
           </Link>
         </motion.div>
 
-        {/* Overall progress + category breakdown */}
+        {/* Overall progress */}
         {user && progress && categories && (
           <motion.div
             initial={{ opacity: 0, y: 10 }}
@@ -163,9 +167,7 @@ export default function AptitudeCategoriesPage() {
                 labelClassName="text-[11px] font-mono font-bold tabular-nums text-stone-900 dark:text-stone-50"
               />
               <div className="flex-1 min-w-0">
-                <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
-                  overall progress
-                </span>
+                <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500">overall progress</span>
                 <p className="mt-1 text-lg font-bold tracking-tight text-stone-900 dark:text-stone-50 tabular-nums">
                   {totalAnswered.toLocaleString()} / {totalQuestions.toLocaleString()}
                 </p>
@@ -182,49 +184,71 @@ export default function AptitudeCategoriesPage() {
           </motion.div>
         )}
 
-        {/* Tabs + Search */}
+        {/* Search + category tabs + unified clear */}
         <motion.div
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.1 }}
           className="mb-8 space-y-4"
         >
-          <div className="relative">
-            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" />
-            <input
-              type="text"
-              placeholder="Search topics..."
-              value={topicSearch}
-              onChange={(e) => setTopicSearch(e.target.value)}
-              className="w-full pl-11 pr-4 py-3 bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors text-sm text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600"
-            />
+          {/* Search row — clear button sits here at the top of the filter block */}
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" />
+              <input
+                type="text"
+                placeholder="Search topics..."
+                value={topicSearch}
+                onChange={(e) => setTopicSearch(e.target.value)}
+                className="w-full pl-11 pr-4 py-3 bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors text-sm text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600"
+              />
+            </div>
+
+            {/* Clear filters — animated, visible only when a filter is active */}
+            <AnimatePresence>
+              {hasFilters && (
+                <motion.button
+                  type="button"
+                  initial={{ opacity: 0, scale: 0.92 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.92 }}
+                  transition={{ duration: 0.15 }}
+                  onClick={clearFilters}
+                  className="inline-flex items-center gap-1.5 px-4 py-3 rounded-md text-xs font-mono uppercase tracking-widest text-stone-500 hover:text-red-500 border border-stone-300 dark:border-white/10 bg-white dark:bg-stone-900 hover:border-red-300 dark:hover:border-red-800 transition-colors cursor-pointer whitespace-nowrap"
+                >
+                  <X className="w-3.5 h-3.5" /> Clear filters
+                </motion.button>
+              )}
+            </AnimatePresence>
           </div>
 
+          {/* Category tab pills */}
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mr-1">
               category /
             </span>
-            {[{ key: "all", label: "All" }, ...(categories?.map((c) => ({ key: c.slug, label: c.name })) ?? [])].map(
-              (tab, i) => {
-                const active = activeTab === tab.key;
-                return (
-                  <motion.button
-                    key={tab.key}
-                    initial={{ opacity: 0, y: 6 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: i * 0.02, duration: 0.2 }}
-                    onClick={() => setActiveTab(tab.key)}
-                    className={`px-3 py-1.5 rounded-md text-xs font-medium border transition-colors cursor-pointer ${
-                      active
-                        ? "bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 border-stone-900 dark:border-stone-50"
-                        : "bg-transparent text-stone-600 dark:text-stone-400 border-stone-300 dark:border-white/10 hover:border-stone-500 dark:hover:border-white/30 hover:text-stone-900 dark:hover:text-stone-50"
-                    }`}
-                  >
-                    {tab.label}
-                  </motion.button>
-                );
-              },
-            )}
+            {[
+              { key: "all", label: "All" },
+              ...(categories?.map((c) => ({ key: c.slug, label: c.name })) ?? []),
+            ].map((tab, i) => {
+              const active = activeTab === tab.key;
+              return (
+                <motion.button
+                  key={tab.key}
+                  initial={{ opacity: 0, y: 6 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: i * 0.02, duration: 0.2 }}
+                  onClick={() => setActiveTab(tab.key)}
+                  className={`px-3 py-1.5 rounded-md text-xs font-medium border transition-colors cursor-pointer ${
+                    active
+                      ? "bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 border-stone-900 dark:border-stone-50"
+                      : "bg-transparent text-stone-600 dark:text-stone-400 border-stone-300 dark:border-white/10 hover:border-stone-500 dark:hover:border-white/30 hover:text-stone-900 dark:hover:text-stone-50"
+                  }`}
+                >
+                  {tab.label}
+                </motion.button>
+              );
+            })}
           </div>
         </motion.div>
 
@@ -252,6 +276,16 @@ export default function AptitudeCategoriesPage() {
             <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mt-2">
               try a different keyword or category
             </p>
+            {/* Empty-state clear button — avoids scroll back to top */}
+            {hasFilters && (
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="mt-4 inline-flex items-center gap-2 px-4 py-2.5 rounded-md text-xs font-bold bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 hover:bg-stone-800 dark:hover:bg-stone-200 transition-colors border-0 cursor-pointer"
+              >
+                <X className="w-3.5 h-3.5" /> Clear filters
+              </button>
+            )}
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">

--- a/client/src/module/student/companies/CompanyListPage.tsx
+++ b/client/src/module/student/companies/CompanyListPage.tsx
@@ -443,7 +443,7 @@ const ProfessorCard = React.memo(function ProfessorCard({ professor }: { profess
   );
 });
 
-// ─── Dropdown (hover-driven select) ───────────────────────
+// ─── Dropdown ─────────────────────────────────────────────
 interface DropdownOption {
   value: string;
   label: string;
@@ -514,6 +514,23 @@ function EditorialDropdown({
 // ─── Tab type ─────────────────────────────────────────────
 type Tab = "all" | "interviews" | "yc" | "professors";
 
+// ─── Inline clear button ───────────────────────────────────
+// Shared animated "× clear" pill used inside each tab's filter row.
+function ClearButton({ onClick }: { onClick: () => void }) {
+  return (
+    <motion.button
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.9 }}
+      transition={{ duration: 0.15 }}
+      onClick={onClick}
+      className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-mono uppercase tracking-widest text-stone-500 hover:text-red-500 transition-colors border border-stone-300 dark:border-white/10 bg-white dark:bg-stone-900 hover:border-red-300 dark:hover:border-red-800 cursor-pointer"
+    >
+      <X className="w-3 h-3" /> Clear filters
+    </motion.button>
+  );
+}
+
 export default function CompanyListPage() {
   const isInsideLayout = useLocation().pathname.startsWith("/student/");
   const [searchParams, setSearchParams] = useSearchParams();
@@ -525,7 +542,6 @@ export default function CompanyListPage() {
   const [cityLimited, setCityLimited] = useState(false);
   const [totalUnlimited, setTotalUnlimited] = useState(0);
 
-  // Active tab
   const [activeTab, setActiveTab] = useState<Tab>("all");
 
   // YC filters
@@ -549,26 +565,17 @@ export default function CompanyListPage() {
   const [interviewPage, setInterviewPage] = useState(1);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setYcSearch(ycSearchInput);
-      setYcPage(1);
-    }, 400);
+    const timer = setTimeout(() => { setYcSearch(ycSearchInput); setYcPage(1); }, 400);
     return () => clearTimeout(timer);
   }, [ycSearchInput]);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setProfSearch(profSearchInput);
-      setProfPage(1);
-    }, 400);
+    const timer = setTimeout(() => { setProfSearch(profSearchInput); setProfPage(1); }, 400);
     return () => clearTimeout(timer);
   }, [profSearchInput]);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setInterviewSearch(interviewSearchInput);
-      setInterviewPage(1);
-    }, 400);
+    const timer = setTimeout(() => { setInterviewSearch(interviewSearchInput); setInterviewPage(1); }, 400);
     return () => clearTimeout(timer);
   }, [interviewSearchInput]);
 
@@ -582,18 +589,33 @@ export default function CompanyListPage() {
 
   const updateParam = (key: string, value: string) => {
     const params = new URLSearchParams(searchParams);
-    if (value) {
-      params.set(key, value);
-    } else {
-      params.delete(key);
-    }
+    if (value) { params.set(key, value); } else { params.delete(key); }
     if (key !== "page") params.delete("page");
     setSearchParams(params);
   };
 
-  const clearFilters = () => {
-    setSearchParams({});
+  // ── Per-tab clear helpers ─────────────────────────────────
+  const clearAllCompanyFilters = () => setSearchParams({});
+
+  const clearYcFilters = () => {
+    setYcSearchInput(""); setYcSearch(""); setYcBatch("");
+    setYcIndustry(""); setYcHiring(false); setYcPage(1);
   };
+
+  const clearProfFilters = () => {
+    setProfSearchInput(""); setProfSearch(""); setProfCollege("");
+    setProfDepartment(""); setProfPage(1);
+  };
+
+  const clearInterviewFilters = () => {
+    setInterviewSearchInput(""); setInterviewSearch(""); setInterviewPage(1);
+  };
+
+  // ── Active-filter guards (drive button visibility) ────────
+  const hasCompanyFilters = !!(selectedCity || industry || size || hiring || minRating || search);
+  const hasYcFilters = !!(ycSearch || ycBatch || ycIndustry || ycHiring);
+  const hasProfFilters = !!(profSearch || profCollege || profDepartment);
+  const hasInterviewFilters = !!interviewSearch;
 
   const fetchCompanies = useCallback(async () => {
     setLoading(true);
@@ -618,19 +640,11 @@ export default function CompanyListPage() {
     }
   }, [selectedCity, search, industry, size, hiring, minRating, page]);
 
-  useEffect(() => {
-    fetchCompanies();
-  }, [fetchCompanies]);
+  useEffect(() => { fetchCompanies(); }, [fetchCompanies]);
 
   useEffect(() => {
-    api
-      .get("/companies/cities")
-      .then((res) => setCities(res.data.cities))
-      .catch(() => {});
+    api.get("/companies/cities").then((res) => setCities(res.data.cities)).catch(() => {});
   }, []);
-
-  const hasActiveFilters =
-    selectedCity || industry || size || hiring || minRating || search;
 
   // ── YC queries ──
   const { data: ycStats } = useQuery<YCStats>({
@@ -682,22 +696,14 @@ export default function CompanyListPage() {
   const professors = profData?.professors ?? [];
   const profPagination = profData?.pagination ?? null;
 
-  // ── Interview experience queries ──
-  const interviewQueryParams: Record<string, string | number> = {
-    page: interviewPage,
-    limit: 24,
-  };
+  // ── Interview queries ──
+  const interviewQueryParams: Record<string, string | number> = { page: interviewPage, limit: 24 };
   if (interviewSearch) interviewQueryParams["search"] = interviewSearch;
 
   const { data: interviewData, isLoading: interviewLoading } =
     useQuery<InterviewCompanyListResponse>({
       queryKey: queryKeys.interviews.companies(interviewQueryParams),
-      queryFn: () =>
-        listInterviewCompanies({
-          page: interviewPage,
-          limit: 24,
-          search: interviewSearch || undefined,
-        }),
+      queryFn: () => listInterviewCompanies({ page: interviewPage, limit: 24, search: interviewSearch || undefined }),
       enabled: activeTab === "interviews",
       staleTime: 5 * 60 * 1000,
     });
@@ -723,13 +729,11 @@ export default function CompanyListPage() {
 
       {!isInsideLayout && <Navbar />}
 
-      {/* Grid line background */}
       <div
         aria-hidden
         className="absolute inset-0 pointer-events-none opacity-[0.04] dark:opacity-[0.05]"
         style={{
-          backgroundImage:
-            "linear-gradient(to right, rgba(120,113,108,0.25) 1px, transparent 1px)",
+          backgroundImage: "linear-gradient(to right, rgba(120,113,108,0.25) 1px, transparent 1px)",
           backgroundSize: "120px 100%",
         }}
       />
@@ -763,39 +767,19 @@ export default function CompanyListPage() {
           </div>
           <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-[10px] font-mono uppercase tracking-widest text-stone-500">
             {typeof pagination?.total === "number" && (
-              <span>
-                companies{" "}
-                <span className="text-stone-900 dark:text-stone-50 text-sm font-bold tabular-nums ml-1">
-                  {pagination.total}
-                </span>
-              </span>
+              <span>companies <span className="text-stone-900 dark:text-stone-50 text-sm font-bold tabular-nums ml-1">{pagination.total}</span></span>
             )}
             {typeof ycStats?.total === "number" && (
-              <span>
-                yc{" "}
-                <span className="text-stone-900 dark:text-stone-50 text-sm font-bold tabular-nums ml-1">
-                  {ycStats.total}
-                </span>
-              </span>
+              <span>yc <span className="text-stone-900 dark:text-stone-50 text-sm font-bold tabular-nums ml-1">{ycStats.total}</span></span>
             )}
             {typeof profStats?.total === "number" && (
-              <span>
-                profs{" "}
-                <span className="text-stone-900 dark:text-stone-50 text-sm font-bold tabular-nums ml-1">
-                  {profStats.total}
-                </span>
-              </span>
+              <span>profs <span className="text-stone-900 dark:text-stone-50 text-sm font-bold tabular-nums ml-1">{profStats.total}</span></span>
             )}
           </div>
         </motion.div>
 
         {/* Contribute strip */}
-        <motion.div
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.05 }}
-          className="mb-8"
-        >
+        <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.05 }} className="mb-8">
           <Link
             to={isInsideLayout ? "/student/companies/add" : "/companies/add"}
             className="group flex items-center gap-4 px-5 py-4 bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md hover:border-stone-400 dark:hover:border-white/30 transition-colors no-underline"
@@ -804,18 +788,14 @@ export default function CompanyListPage() {
               <Plus className="w-4 h-4 text-stone-600 dark:text-stone-400" />
             </div>
             <div className="flex-1 min-w-0">
-              <p className="text-sm font-bold text-stone-900 dark:text-stone-50">
-                Add a company to the directory
-              </p>
-              <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mt-0.5">
-                help the community / earn contributor points
-              </p>
+              <p className="text-sm font-bold text-stone-900 dark:text-stone-50">Add a company to the directory</p>
+              <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mt-0.5">help the community / earn contributor points</p>
             </div>
             <ArrowUpRight className="w-4 h-4 text-stone-400 group-hover:text-lime-500 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-all shrink-0" />
           </Link>
         </motion.div>
 
-        {/* Tabs (underline style) */}
+        {/* Tabs */}
         <motion.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
@@ -836,23 +816,10 @@ export default function CompanyListPage() {
                       : "border-transparent text-stone-500 hover:text-stone-900 dark:hover:text-stone-50"
                   )}
                 >
-                  <span
-                    className={
-                      active ? "text-stone-900 dark:text-stone-50" : "text-stone-400"
-                    }
-                  >
-                    {t.icon}
-                  </span>
+                  <span className={active ? "text-stone-900 dark:text-stone-50" : "text-stone-400"}>{t.icon}</span>
                   {t.label}
                   {typeof t.count !== "undefined" && (
-                    <span
-                      className={cn(
-                        "text-[10px] font-mono tabular-nums",
-                        active ? "text-stone-400" : "text-stone-400"
-                      )}
-                    >
-                      {t.count ?? "..."}
-                    </span>
+                    <span className="text-[10px] font-mono tabular-nums text-stone-400">{t.count ?? "..."}</span>
                   )}
                 </button>
               );
@@ -863,13 +830,10 @@ export default function CompanyListPage() {
         {/* ── TAB: All Companies ───────────────────────── */}
         {activeTab === "all" && (
           <>
-            {/* City filter row */}
             {cities.length > 0 && (
               <div className="mb-6">
                 <div className="flex items-center gap-2 overflow-x-auto pb-2">
-                  <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mr-1 shrink-0">
-                    city /
-                  </span>
+                  <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mr-1 shrink-0">city /</span>
                   <button
                     onClick={() => updateParam("city", "")}
                     className={cn(
@@ -893,14 +857,7 @@ export default function CompanyListPage() {
                       )}
                     >
                       {c.city}{" "}
-                      <span
-                        className={cn(
-                          "font-mono text-[10px] ml-1",
-                          selectedCity === c.city
-                            ? "text-stone-300 dark:text-stone-500"
-                            : "text-stone-400"
-                        )}
-                      >
+                      <span className={cn("font-mono text-[10px] ml-1", selectedCity === c.city ? "text-stone-300 dark:text-stone-500" : "text-stone-400")}>
                         {c.count}
                       </span>
                     </button>
@@ -909,7 +866,7 @@ export default function CompanyListPage() {
               </div>
             )}
 
-            {/* Search + filter toggle */}
+            {/* Search + filter toggle + unified clear */}
             <div className="flex flex-col sm:flex-row gap-2 mb-4">
               <div className="flex-1 relative">
                 <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" />
@@ -933,19 +890,9 @@ export default function CompanyListPage() {
                 <Filter className="w-4 h-4" />
                 Filters
               </button>
+              {/* Unified clear — replaces the old plain-text button */}
               <AnimatePresence>
-                {hasActiveFilters && (
-                  <motion.button
-                    initial={{ opacity: 0, scale: 0.9 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    exit={{ opacity: 0, scale: 0.9 }}
-                    transition={{ duration: 0.15 }}
-                    onClick={clearFilters}
-                    className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-mono uppercase tracking-widest text-stone-500 hover:text-red-500 transition-colors border-0 bg-transparent cursor-pointer"
-                  >
-                    <X className="w-3 h-3" /> clear
-                  </motion.button>
-                )}
+                {hasCompanyFilters && <ClearButton onClick={clearAllCompanyFilters} />}
               </AnimatePresence>
             </div>
 
@@ -961,9 +908,7 @@ export default function CompanyListPage() {
                 >
                   <div className="bg-white dark:bg-stone-900 p-5 rounded-md border border-stone-200 dark:border-white/10 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
                     <div>
-                      <label className="block text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-2">
-                        industry
-                      </label>
+                      <label className="block text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-2">industry</label>
                       <input
                         type="text"
                         value={industry}
@@ -973,9 +918,7 @@ export default function CompanyListPage() {
                       />
                     </div>
                     <div>
-                      <label className="block text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-2">
-                        company size
-                      </label>
+                      <label className="block text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-2">company size</label>
                       <select
                         value={size}
                         onChange={(e) => updateParam("size", e.target.value)}
@@ -990,9 +933,7 @@ export default function CompanyListPage() {
                       </select>
                     </div>
                     <div>
-                      <label className="block text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-2">
-                        hiring status
-                      </label>
+                      <label className="block text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-2">hiring status</label>
                       <select
                         value={hiring}
                         onChange={(e) => updateParam("hiring", e.target.value)}
@@ -1003,9 +944,7 @@ export default function CompanyListPage() {
                       </select>
                     </div>
                     <div>
-                      <label className="block text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-2">
-                        min rating
-                      </label>
+                      <label className="block text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-2">min rating</label>
                       <select
                         value={minRating}
                         onChange={(e) => updateParam("minRating", e.target.value)}
@@ -1022,27 +961,16 @@ export default function CompanyListPage() {
               )}
             </AnimatePresence>
 
-            {/* Results */}
             {loading ? (
               <LoadingScreen compact />
             ) : companies.length === 0 ? (
-              <EmptyState
-                icon={<Building2 className="w-5 h-5" />}
-                title="No companies found"
-                hint="try different search criteria"
-              />
+              <EmptyState icon={<Building2 className="w-5 h-5" />} title="No companies found" hint="try different search criteria" />
             ) : (
               <>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                   {companies.map((company, i) => (
-                    <motion.div
-                      key={company.id}
-                      initial={{ opacity: 0, y: 12 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: i * 0.03, duration: 0.3 }}
-                    >
-                     <CompanyCard company={company} insideLayout={isInsideLayout} />
-
+                    <motion.div key={company.id} initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.03, duration: 0.3 }}>
+                      <CompanyCard company={company} insideLayout={isInsideLayout} />
                     </motion.div>
                   ))}
                 </div>
@@ -1055,11 +983,7 @@ export default function CompanyListPage() {
                 )}
 
                 {pagination && (
-                  <PaginationControls
-                    currentPage={pagination.page}
-                    totalPages={pagination.totalPages}
-                    onPageChange={(p) => updateParam("page", String(p))}
-                  />
+                  <PaginationControls currentPage={pagination.page} totalPages={pagination.totalPages} onPageChange={(p) => updateParam("page", String(p))} />
                 )}
               </>
             )}
@@ -1081,45 +1005,18 @@ export default function CompanyListPage() {
                 />
               </div>
               <EditorialDropdown
-                icon={<Rocket className="w-3.5 h-3.5" />}
-                label="batch"
-                value={ycBatch}
-                onChange={(v) => {
-                  setYcBatch(v);
-                  setYcPage(1);
-                }}
-                options={[
-                  { value: "", label: "All" },
-                  ...(ycStats?.batches ?? []).map((b) => ({
-                    value: b.name,
-                    label: b.name,
-                    count: b.count,
-                  })),
-                ]}
+                icon={<Rocket className="w-3.5 h-3.5" />} label="batch" value={ycBatch}
+                onChange={(v) => { setYcBatch(v); setYcPage(1); }}
+                options={[{ value: "", label: "All" }, ...(ycStats?.batches ?? []).map((b) => ({ value: b.name, label: b.name, count: b.count }))]}
               />
               <EditorialDropdown
-                icon={<Filter className="w-3.5 h-3.5" />}
-                label="industry"
-                value={ycIndustry}
-                onChange={(v) => {
-                  setYcIndustry(v);
-                  setYcPage(1);
-                }}
-                options={[
-                  { value: "", label: "All" },
-                  ...(ycStats?.industries ?? []).slice(0, 30).map((ind) => ({
-                    value: ind.name,
-                    label: ind.name,
-                    count: ind.count,
-                  })),
-                ]}
+                icon={<Filter className="w-3.5 h-3.5" />} label="industry" value={ycIndustry}
+                onChange={(v) => { setYcIndustry(v); setYcPage(1); }}
+                options={[{ value: "", label: "All" }, ...(ycStats?.industries ?? []).slice(0, 30).map((ind) => ({ value: ind.name, label: ind.name, count: ind.count }))]}
               />
               <button
                 type="button"
-                onClick={() => {
-                  setYcHiring((prev) => !prev);
-                  setYcPage(1);
-                }}
+                onClick={() => { setYcHiring((prev) => !prev); setYcPage(1); }}
                 className={cn(
                   "inline-flex items-center gap-2 h-10 px-3 rounded-md text-xs font-mono uppercase tracking-widest border transition-colors cursor-pointer shrink-0",
                   ycHiring
@@ -1130,51 +1027,27 @@ export default function CompanyListPage() {
                 <span className={cn("h-1.5 w-1.5 rounded-none", ycHiring ? "bg-stone-900" : "bg-lime-500")} />
                 hiring
               </button>
-              {(ycSearch || ycBatch || ycIndustry || ycHiring) && (
-                <button
-                  onClick={() => {
-                    setYcSearchInput("");
-                    setYcSearch("");
-                    setYcBatch("");
-                    setYcIndustry("");
-                    setYcHiring(false);
-                    setYcPage(1);
-                  }}
-                  className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-mono uppercase tracking-widest text-stone-500 hover:text-red-500 transition-colors border-0 bg-transparent cursor-pointer"
-                >
-                  <X className="w-3 h-3" /> clear
-                </button>
-              )}
+              {/* Unified clear for YC tab */}
+              <AnimatePresence>
+                {hasYcFilters && <ClearButton onClick={clearYcFilters} />}
+              </AnimatePresence>
             </div>
 
             {ycLoading ? (
               <Spinner />
             ) : ycCompanies.length === 0 ? (
-              <EmptyState
-                icon={<Rocket className="w-5 h-5" />}
-                title="No YC companies found"
-                hint="try different search criteria"
-              />
+              <EmptyState icon={<Rocket className="w-5 h-5" />} title="No YC companies found" hint="try different search criteria" />
             ) : (
               <>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                   {ycCompanies.map((company, i) => (
-                    <motion.div
-                      key={company.id}
-                      initial={{ opacity: 0, y: 12 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: i * 0.03, duration: 0.3 }}
-                    >
-                     <YCCard company={company} insideLayout={isInsideLayout} />
+                    <motion.div key={company.id} initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.03, duration: 0.3 }}>
+                      <YCCard company={company} insideLayout={isInsideLayout} />
                     </motion.div>
                   ))}
                 </div>
                 {ycPagination && (
-                  <PaginationControls
-                    currentPage={ycPage}
-                    totalPages={ycPagination.totalPages}
-                    onPageChange={setYcPage}
-                  />
+                  <PaginationControls currentPage={ycPage} totalPages={ycPagination.totalPages} onPageChange={setYcPage} />
                 )}
               </>
             )}
@@ -1196,73 +1069,30 @@ export default function CompanyListPage() {
                 />
               </div>
               <EditorialDropdown
-                icon={<GraduationCap className="w-3.5 h-3.5" />}
-                label="college"
-                value={profCollege}
-                onChange={(v) => {
-                  setProfCollege(v);
-                  setProfPage(1);
-                }}
-                options={[
-                  { value: "", label: "All" },
-                  ...(profStats?.colleges ?? []).map((c) => ({
-                    value: c.name,
-                    label: c.name,
-                    count: c.count,
-                  })),
-                ]}
+                icon={<GraduationCap className="w-3.5 h-3.5" />} label="college" value={profCollege}
+                onChange={(v) => { setProfCollege(v); setProfPage(1); }}
+                options={[{ value: "", label: "All" }, ...(profStats?.colleges ?? []).map((c) => ({ value: c.name, label: c.name, count: c.count }))]}
               />
               <EditorialDropdown
-                icon={<BookOpen className="w-3.5 h-3.5" />}
-                label="dept"
-                value={profDepartment}
-                onChange={(v) => {
-                  setProfDepartment(v);
-                  setProfPage(1);
-                }}
-                options={[
-                  { value: "", label: "All" },
-                  ...(profStats?.departments ?? []).map((d) => ({
-                    value: d.name,
-                    label: d.name,
-                    count: d.count,
-                  })),
-                ]}
+                icon={<BookOpen className="w-3.5 h-3.5" />} label="dept" value={profDepartment}
+                onChange={(v) => { setProfDepartment(v); setProfPage(1); }}
+                options={[{ value: "", label: "All" }, ...(profStats?.departments ?? []).map((d) => ({ value: d.name, label: d.name, count: d.count }))]}
               />
-              {(profSearch || profCollege || profDepartment) && (
-                <button
-                  onClick={() => {
-                    setProfSearchInput("");
-                    setProfSearch("");
-                    setProfCollege("");
-                    setProfDepartment("");
-                    setProfPage(1);
-                  }}
-                  className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-mono uppercase tracking-widest text-stone-500 hover:text-red-500 transition-colors border-0 bg-transparent cursor-pointer"
-                >
-                  <X className="w-3 h-3" /> clear
-                </button>
-              )}
+              {/* Unified clear for Professors tab */}
+              <AnimatePresence>
+                {hasProfFilters && <ClearButton onClick={clearProfFilters} />}
+              </AnimatePresence>
             </div>
 
             {profLoading ? (
               <Spinner />
             ) : professors.length === 0 ? (
-              <EmptyState
-                icon={<GraduationCap className="w-5 h-5" />}
-                title="No professors found"
-                hint="try different search criteria"
-              />
+              <EmptyState icon={<GraduationCap className="w-5 h-5" />} title="No professors found" hint="try different search criteria" />
             ) : (
               <>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                   {professors.map((prof, i) => (
-                    <motion.div
-                      key={prof.id}
-                      initial={{ opacity: 0, y: 12 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: i * 0.03, duration: 0.3 }}
-                    >
+                    <motion.div key={prof.id} initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.03, duration: 0.3 }}>
                       <ProfessorCard professor={prof} />
                     </motion.div>
                   ))}
@@ -1276,11 +1106,7 @@ export default function CompanyListPage() {
                 )}
 
                 {profPagination && (
-                  <PaginationControls
-                    currentPage={profPage}
-                    totalPages={profPagination.totalPages}
-                    onPageChange={setProfPage}
-                  />
+                  <PaginationControls currentPage={profPage} totalPages={profPagination.totalPages} onPageChange={setProfPage} />
                 )}
               </>
             )}
@@ -1290,12 +1116,9 @@ export default function CompanyListPage() {
         {/* ── TAB: Interview Experiences ───────────────── */}
         {activeTab === "interviews" && (
           <>
-            {/* Intro strip with "Share yours" CTA */}
             <div className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-5 bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md">
               <div className="min-w-0">
-                <p className="text-sm font-bold text-stone-900 dark:text-stone-50">
-                  Real interviews, real reviews
-                </p>
+                <p className="text-sm font-bold text-stone-900 dark:text-stone-50">Real interviews, real reviews</p>
                 <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mt-1">
                   rounds, questions, ratings, work culture / earn a contributor badge when you share
                 </p>
@@ -1309,7 +1132,6 @@ export default function CompanyListPage() {
               </Link>
             </div>
 
-            {/* Search */}
             <div className="flex flex-col sm:flex-row gap-2 mb-6">
               <div className="flex-1 relative">
                 <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" />
@@ -1321,55 +1143,32 @@ export default function CompanyListPage() {
                   className="w-full pl-11 pr-4 py-3 bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors text-sm text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600"
                 />
               </div>
-              {interviewSearch && (
-                <button
-                  onClick={() => {
-                    setInterviewSearchInput("");
-                    setInterviewSearch("");
-                    setInterviewPage(1);
-                  }}
-                  className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-mono uppercase tracking-widest text-stone-500 hover:text-red-500 transition-colors border-0 bg-transparent cursor-pointer"
-                >
-                  <X className="w-3 h-3" /> clear
-                </button>
-              )}
+              {/* Unified clear for Interviews tab */}
+              <AnimatePresence>
+                {hasInterviewFilters && <ClearButton onClick={clearInterviewFilters} />}
+              </AnimatePresence>
             </div>
 
             {interviewLoading ? (
               <Spinner />
             ) : interviewCompanies.length === 0 ? (
-              <EmptyState
-                icon={<MessageCircle className="w-5 h-5" />}
-                title="No interview experiences yet"
-                hint="be the first to share, earn a badge"
-              />
+              <EmptyState icon={<MessageCircle className="w-5 h-5" />} title="No interview experiences yet" hint="be the first to share, earn a badge" />
             ) : (
               <>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                   {interviewCompanies.map((company, i) => (
-                    <motion.div
-                      key={company.id}
-                      initial={{ opacity: 0, y: 12 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: i * 0.03, duration: 0.3 }}
-                    >
+                    <motion.div key={company.id} initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.03, duration: 0.3 }}>
                       <InterviewCompanyCard company={company} insideLayout={isInsideLayout} />
                     </motion.div>
                   ))}
                 </div>
-
                 {interviewPagination && interviewPagination.totalPages > 1 && (
-                  <PaginationControls
-                    currentPage={interviewPage}
-                    totalPages={interviewPagination.totalPages}
-                    onPageChange={setInterviewPage}
-                  />
+                  <PaginationControls currentPage={interviewPage} totalPages={interviewPagination.totalPages} onPageChange={setInterviewPage} />
                 )}
               </>
             )}
           </>
         )}
-
       </div>
       {!isInsideLayout && <Footer />}
     </div>

--- a/client/src/module/student/dsa/DsaTopicsPage.tsx
+++ b/client/src/module/student/dsa/DsaTopicsPage.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import { Link } from "react-router";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import {
   CheckCircle2, Building2, Puzzle, Bookmark, ArrowRight,
-  Lock, Search, BookOpen, TrendingUp, Target, Download,
+  Lock, Search, BookOpen, TrendingUp, Target, Download, X,
 } from "lucide-react";
 import { PaginationControls } from "../../../components/ui/PaginationControls";
 import api from "../../../lib/axios";
@@ -68,6 +68,17 @@ export default function DsaTopicsPage() {
     }, 300);
     return () => clearTimeout(t);
   }, [topicSearch]);
+
+  // True when the user has deviated from the default "show all" state.
+  const hasFilters = activeTab !== "all" || topicSearch.trim() !== "";
+
+  // Reset all filter state back to defaults in one click.
+  const clearFilters = () => {
+    setTopicSearch("");
+    setDebouncedSearch("");
+    setActiveTab("all");
+    setPage(1);
+  };
 
   const difficultyParam =
     activeTab === "easy" ? "Easy" :
@@ -259,12 +270,8 @@ export default function DsaTopicsPage() {
                   className="flex flex-col gap-2 p-3 sm:p-4 bg-white dark:bg-stone-900 border-r border-b border-stone-200 dark:border-white/10"
                 >
                   <div className="flex items-baseline justify-between">
-                    <span className={`text-[10px] font-mono uppercase tracking-widest ${d.color}`}>
-                      / {d.label}
-                    </span>
-                    <span className="text-xs font-mono tabular-nums text-stone-500 dark:text-stone-400">
-                      {dPct}%
-                    </span>
+                    <span className={`text-[10px] font-mono uppercase tracking-widest ${d.color}`}>/ {d.label}</span>
+                    <span className="text-xs font-mono tabular-nums text-stone-500 dark:text-stone-400">{dPct}%</span>
                   </div>
                   <p className="text-lg font-bold tracking-tight text-stone-900 dark:text-stone-50 tabular-nums">
                     {stat.solved}
@@ -284,18 +291,14 @@ export default function DsaTopicsPage() {
           </motion.div>
         )}
 
-        {/* Heatmap (logged-in) */}
+        {/* Heatmap */}
         {user && (
-          <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.09 }}
-          >
+          <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.09 }}>
             <DsaHeatmap />
           </motion.div>
         )}
 
-        {/* Quick links strip */}
+        {/* Quick links */}
         <motion.div
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
@@ -319,7 +322,7 @@ export default function DsaTopicsPage() {
           ))}
         </motion.div>
 
-        {/* LeetCode Sync — only for logged-in students */}
+        {/* LeetCode Sync */}
         {user && (
           <LeetCodeSync
             onSyncSuccess={() => {
@@ -336,17 +339,38 @@ export default function DsaTopicsPage() {
           transition={{ delay: 0.12 }}
           className="mb-6 space-y-3"
         >
-          <div className="relative">
-            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" />
-            <input
-              type="text"
-              placeholder="Search topics..."
-              value={topicSearch}
-              onChange={(e) => setTopicSearch(e.target.value)}
-              className="w-full pl-11 pr-4 py-3 bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors text-sm text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600"
-            />
+          {/* Search row — clear button lives here for top-of-filter discoverability */}
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" />
+              <input
+                type="text"
+                placeholder="Search topics..."
+                value={topicSearch}
+                onChange={(e) => setTopicSearch(e.target.value)}
+                className="w-full pl-11 pr-4 py-3 bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors text-sm text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600"
+              />
+            </div>
+
+            {/* Clear filters — animated, appears only when a filter is active */}
+            <AnimatePresence>
+              {hasFilters && (
+                <motion.button
+                  type="button"
+                  initial={{ opacity: 0, scale: 0.92 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.92 }}
+                  transition={{ duration: 0.15 }}
+                  onClick={clearFilters}
+                  className="inline-flex items-center gap-1.5 px-4 py-3 rounded-md text-xs font-mono uppercase tracking-widest text-stone-500 hover:text-red-500 border border-stone-300 dark:border-white/10 bg-white dark:bg-stone-900 hover:border-red-300 dark:hover:border-red-800 transition-colors cursor-pointer whitespace-nowrap"
+                >
+                  <X className="w-3.5 h-3.5" /> Clear filters
+                </motion.button>
+              )}
+            </AnimatePresence>
           </div>
 
+          {/* Difficulty tab pills */}
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mr-1">
               difficulty /
@@ -357,10 +381,11 @@ export default function DsaTopicsPage() {
                 <button
                   key={tab.key}
                   onClick={() => { setActiveTab(tab.key); setPage(1); }}
-                  className={`px-3 py-1.5 rounded-md text-xs font-medium border transition-colors cursor-pointer ${active
-                    ? "bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 border-stone-900 dark:border-stone-50"
-                    : "bg-transparent text-stone-600 dark:text-stone-400 border-stone-300 dark:border-white/10 hover:border-stone-500 dark:hover:border-white/30 hover:text-stone-900 dark:hover:text-stone-50"
-                    }`}
+                  className={`px-3 py-1.5 rounded-md text-xs font-medium border transition-colors cursor-pointer ${
+                    active
+                      ? "bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 border-stone-900 dark:border-stone-50"
+                      : "bg-transparent text-stone-600 dark:text-stone-400 border-stone-300 dark:border-white/10 hover:border-stone-500 dark:hover:border-white/30 hover:text-stone-900 dark:hover:text-stone-50"
+                  }`}
                 >
                   {tab.label}
                 </button>
@@ -485,15 +510,21 @@ export default function DsaTopicsPage() {
               <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mt-2">
                 try a different keyword or difficulty
               </p>
+              {/* Empty-state clear button so user doesn't have to scroll back up */}
+              {hasFilters && (
+                <button
+                  type="button"
+                  onClick={clearFilters}
+                  className="mt-4 inline-flex items-center gap-2 px-4 py-2.5 rounded-md text-xs font-bold bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 hover:bg-stone-800 dark:hover:bg-stone-200 transition-colors border-0 cursor-pointer"
+                >
+                  <X className="w-3.5 h-3.5" /> Clear filters
+                </button>
+              )}
             </div>
           )}
         </div>
 
-        <PaginationControls
-          currentPage={page}
-          totalPages={totalPages}
-          onPageChange={setPage}
-        />
+        <PaginationControls currentPage={page} totalPages={totalPages} onPageChange={setPage} />
       </div>
 
       <LoginGate open={showGate} onClose={() => setShowGate(false)} />

--- a/client/src/module/student/jobs/JobBrowsePage.tsx
+++ b/client/src/module/student/jobs/JobBrowsePage.tsx
@@ -64,6 +64,7 @@ export default function JobBrowsePage() {
   const [scrPage, setScrPage] = useState(1);
   const debouncedSearch = useDebounce(search, 400);
   const debouncedLocation = useDebounce(locationFilter, 400);
+  // Default: expired jobs are hidden. "Hide expired" toggled OFF counts as an active filter.
   const [hideExpired, setHideExpired] = useState(true);
 
   const { data, isLoading, isFetching } = useQuery({
@@ -148,18 +149,21 @@ export default function JobBrowsePage() {
     setScrPage(1);
   };
 
+  // Reset every filter back to its default value in one shot.
   const clearAll = () => {
     setSearch("");
     setLocationFilter("");
     setSelectedTags([]);
+    setHideExpired(true); // restore default
     setPage(1);
     setExtPage(1);
     setScrPage(1);
   };
 
-  const hasFilters = search || locationFilter || selectedTags.length > 0;
-
-  
+  // Showing the button when hideExpired is false catches the "I turned off
+  // expired-hiding" case that the old code missed.
+  const hasFilters =
+    !!search || !!locationFilter || selectedTags.length > 0 || !hideExpired;
 
   const filteredExtJobs = extData?.jobs ?? [];
   const scrapedJobs = scrData?.jobs ?? [];
@@ -288,6 +292,10 @@ export default function JobBrowsePage() {
           transition={{ delay: 0.1 }}
           className="mb-10 space-y-4"
         >
+          {/*
+           * Search row — "Clear filters" lives here so it's always reachable
+           * at the top of the filter block, not buried inside the tag strip.
+           */}
           <form
             onSubmit={(e) => e.preventDefault()}
             className="flex flex-col sm:flex-row gap-2"
@@ -308,6 +316,7 @@ export default function JobBrowsePage() {
                 placeholder="Search by title, company, or keyword..."
               />
             </div>
+
             <div className="relative sm:w-60">
               <MapPin className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" />
               <input
@@ -318,8 +327,26 @@ export default function JobBrowsePage() {
                 placeholder="Location"
               />
             </div>
+
+            {/* Primary "Clear filters" button — visible whenever any filter is active */}
+            <AnimatePresence>
+              {hasFilters && (
+                <motion.button
+                  type="button"
+                  initial={{ opacity: 0, scale: 0.92 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.92 }}
+                  transition={{ duration: 0.15 }}
+                  onClick={clearAll}
+                  className="inline-flex items-center gap-1.5 px-4 py-3 rounded-md text-xs font-mono uppercase tracking-widest text-stone-500 hover:text-red-500 border border-stone-300 dark:border-white/10 bg-white dark:bg-stone-900 hover:border-red-300 dark:hover:border-red-800 transition-colors cursor-pointer whitespace-nowrap"
+                >
+                  <X className="w-3.5 h-3.5" /> Clear filters
+                </motion.button>
+              )}
+            </AnimatePresence>
           </form>
 
+          {/* Tag chips + hide-expired toggle */}
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-xs font-mono uppercase tracking-widest text-stone-500 mr-1">
               filter /
@@ -355,6 +382,11 @@ export default function JobBrowsePage() {
                 Hide expired
               </span>
             </label>
+
+            {/*
+             * Secondary inline "clear" — kept for discoverability inside the
+             * tag row itself (same as before, but now also catches hideExpired).
+             */}
             <AnimatePresence>
               {hasFilters && (
                 <motion.button
@@ -464,7 +496,7 @@ export default function JobBrowsePage() {
           </motion.div>
         )}
 
-        {/* Global empty state — shown when ALL three sources return nothing */}
+        {/* Global empty state */}
         {allEmpty && (
           <motion.div
             initial={{ opacity: 0, y: 12 }}
@@ -492,7 +524,7 @@ export default function JobBrowsePage() {
           </motion.div>
         )}
 
-        {/* Internal jobs — hidden when everything is empty */}
+        {/* Internal jobs */}
         {!allEmpty && (
           <>
             <div className="flex items-end justify-between gap-4 mb-6">


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>fix: one-click "Clear filters" across Jobs, Companies, DSA, Aptitude</h2>
<h3>What</h3>
<p>Adds a single animated <strong>Clear filters</strong> button to all four browse/learn pages, visible only when at least one filter is active. One click resets every filter axis atomically.</p>
<h3>Why</h3>
<p>Users had to clear each filter individually. Two additional bugs were found in the process:</p>
<ul>
<li><strong>Jobs</strong> — <code>hideExpired</code> was excluded from <code>hasFilters</code>, so unchecking it never surfaced a clear button despite actively filtering results.</li>
<li><strong>Companies</strong> — each tab had inconsistent or missing clear logic; the Interviews tab had none at all.</li>
</ul>
<h3>Changes</h3>

File | What changed
-- | --
JobBrowsePage.tsx | Added !hideExpired to hasFilters; clearAll now resets it to true; primary clear button added to search row
CompanyListPage.tsx | Extracted shared ClearButton component; added has*Filters + clear*Filters per tab (Companies, YC, Professors, Interviews)
DsaTopicsPage.tsx | Added hasFilters, clearFilters, clear button in search row and inside empty state
AptitudeCategoriesPage.tsx | Same pattern as DSA


<h3>Details</h3>
<p><strong>Jobs — <code>hasFilters</code> fix:</strong></p>
<pre><code class="language-ts">// Before
const hasFilters = search || locationFilter || selectedTags.length &gt; 0;
// After
const hasFilters = !!search || !!locationFilter || selectedTags.length &gt; 0 || !hideExpired;
</code></pre>
<p><strong>Companies — shared component:</strong></p>
<pre><code class="language-tsx">function ClearButton({ onClick }: { onClick: () =&gt; void }) {
  return (
    &lt;motion.button ... onClick={onClick} className="..."&gt;
      &lt;X className="w-3 h-3" /&gt; Clear filters
    &lt;/motion.button&gt;
  );
}
// Used in all four tabs, each with its own scoped clear function
</code></pre>
<p><strong>DSA / Aptitude — new pattern (nothing existed before):</strong></p>
<pre><code class="language-ts">const hasFilters = activeTab !== "all" || topicSearch.trim() !== "";
const clearFilters = () =&gt; { setTopicSearch(""); setDebouncedSearch(""); setActiveTab("all"); setPage(1); };
</code></pre>
<p>A secondary clear button is also placed inside the empty-state card on DSA and Aptitude so users don't have to scroll back up to reset when zero results are shown.</p>
<h3>No breaking changes</h3>
<p>No API signatures, query keys, or dependencies changed. <code>X</code> and <code>AnimatePresence</code> were already in the project.</p>
<h3>Testing</h3>
<ul>
<li>[ ] Each page: apply filters → button appears; click → all filters reset, results restore</li>
<li>[ ] Jobs: uncheck "Hide expired" → button appears; click → checkbox returns to checked</li>
<li>[ ] Companies: switching tabs doesn't carry one tab's clear button into another</li>
<li>[ ] DSA / Aptitude: filter to zero results → empty state shows clear button; click recovers results</li>
<li>[ ] No filters active → button not rendered on any page</li>
</ul></body></html><!--EndFragment-->
</body>
</html>
Issue #502 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Clear filters" buttons to aptitude, company, DSA, and job browsing pages with animated appearance when filters are active.
  * Clear filters buttons now appear in empty-state sections to help users reset without scrolling back up.
  * Improved filter reset functionality to clear search, category selections, and return to page 1.

* **UI/UX Improvements**
  * Unified animated clear button component across multiple pages for consistent filtering experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->