### PR TITLE
feat: add Open Graph and Twitter Card meta tags to public profile page

### DIFF
--- a/client/src/module/student/profile/PublicProfilePage.tsx
+++ b/client/src/module/student/profile/PublicProfilePage.tsx
@@ -100,7 +100,13 @@ export default function PublicProfilePage() {
 
   return (
     <div className="relative pb-12 max-w-5xl mx-auto">
-      <SEO title={`${profile.name} - Profile`} noIndex />
+      <SEO
+  title={`${profile.name} — InternHack Profile`}
+  description={`${profile.name}'s skills: ${profile.skills.slice(0, 5).join(", ")}${profile.skills.length > 5 ? " and more" : ""}. ${profile.bio ? profile.bio.slice(0, 100) : "View their projects, achievements, and verified skills on InternHack."}`}
+  ogImage={profile.profilePic || undefined}
+  ogType="profile"
+  canonicalUrl={`https://internhack.xyz/student/profile/${profile.id}`}
+/>
 
       {/* Back button */}
       <motion.button


### PR DESCRIPTION
Closes #495

## What changed

Updated `PublicProfilePage.tsx` to pass dynamic props to the existing `SEO` component:

- Removed `noIndex` — it was blocking all crawlers, making OG tags pointless
- Added `ogType="profile"` — correct Open Graph type for a person's page
- Added `ogImage` — uses the student's profile picture, falls back to site default if not set
- Added `canonicalUrl` — explicit canonical so `og:url` and `twitter:url` point to the correct profile

The `SEO` component already handles all Open Graph and Twitter Card tags internally, so no new packages or files were needed.

## Testing

- Inspected `<head>` in DevTools on the profile page — og tags present with real profile data
- Verified with https://www.opengraph.xyz once deployed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced student profile pages with improved SEO titles displaying the student's name
  * Added rich metadata and Open Graph configuration for better sharing on social platforms
  * Implemented canonical URLs and descriptive summaries based on skills and bio for improved search engine optimization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->