### PR TITLE
fix: jobs page UX improvements across browse and detail pages

### DIFF
--- a/client/src/components/ui/ResultCount.tsx
+++ b/client/src/components/ui/ResultCount.tsx
@@ -7,6 +7,8 @@ interface ResultCountProps {
 }
 
 export function ResultCount({ currentCount, totalCount, className }: ResultCountProps) {
+  if (currentCount >= totalCount) return null;
+
   return (
     <p
       aria-live="polite"

--- a/client/src/module/student/jobs/JobBrowsePage.tsx
+++ b/client/src/module/student/jobs/JobBrowsePage.tsx
@@ -229,7 +229,7 @@ export default function JobBrowsePage() {
             </p>
           </div>
           <div className="flex items-center gap-4 text-xs font-mono uppercase tracking-widest text-stone-500">
-            {typeof internalTotal === "number" && (
+            {typeof internalTotal === "number" && internalTotal > 0 && (
               <span>
                 internal{" "}
                 <span className="text-stone-900 dark:text-stone-50 text-sm font-bold tabular-nums ml-1">
@@ -345,14 +345,24 @@ export default function JobBrowsePage() {
               );
             })}
 
-            <label className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-stone-300 dark:border-white/10 hover:border-stone-500 dark:hover:border-white/30 transition-colors cursor-pointer select-none">
+            <label
+              className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-md border transition-colors cursor-pointer select-none ${
+                hideExpired
+                  ? "bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 border-lime-200 dark:border-lime-400/30"
+                  : "bg-transparent text-stone-600 dark:text-stone-400 border-stone-300 dark:border-white/10 hover:border-stone-500 dark:hover:border-white/30"
+              }`}
+            >
               <input
                 type="checkbox"
                 checked={hideExpired}
                 onChange={(e) => setHideExpired(e.target.checked)}
-                className="w-4 h-4 rounded bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/20"
+                className="w-4 h-4 rounded bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/20 accent-lime-400"
               />
-              <span className="text-xs font-mono uppercase tracking-widest text-stone-500">
+              <span
+                className={`text-xs font-mono uppercase tracking-widest ${
+                  hideExpired ? "text-lime-700 dark:text-lime-400" : "text-stone-500"
+                }`}
+              >
                 Hide expired
               </span>
             </label>

--- a/client/src/module/student/jobs/JobDetailPage.tsx
+++ b/client/src/module/student/jobs/JobDetailPage.tsx
@@ -164,7 +164,7 @@ export default function JobDetailPage() {
     )
   ) : !isAuthenticated ? (
     <Link
-      to="/login"
+      to={`/login?from=${encodeURIComponent(inStudentLayout ? `/student/jobs/${id}` : `/jobs/${Number(id)}`)}`}
       className="inline-flex items-center gap-2 px-6 py-3 bg-lime-400 text-stone-900 font-semibold rounded-md hover:bg-lime-500 transition-colors no-underline text-sm"
     >
       Sign in to apply <ArrowUpRight className="w-4 h-4" />
@@ -359,7 +359,7 @@ export default function JobDetailPage() {
             <motion.div variants={fadeUp}>
               <Kicker>related / similar roles</Kicker>
               <h2 className="mt-3 text-xl font-bold tracking-tight text-stone-900 dark:text-stone-50 mb-5">
-                Similar positions.
+                Similar Jobs
               </h2>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 {isRelatedJobsLoading &&


### PR DESCRIPTION
## Description
Five UX improvements across the job browse and detail pages fixing real production gaps visible to unauthenticated and authenticated users.

- Login to apply now passes ?from= redirect param so user lands back  on the same job page after signing in instead of the dashboard
- INTERNAL 0 count hidden when no internal jobs exist — avoids  surfacing an empty state as a visible metric
- "Showing X of X results" hidden when filtered count equals total —  only shown when a filter is actually reducing results
- HIDE EXPIRED checkbox color changed from red to lime-400 consistent  with platform brand (red implied an error state)
- "Similar jobs." heading fixed to "Similar Jobs" — removes period  and matches platform typography conventions

## Related Issue
Fixes #463

## Type of Change
- [x] Bug Fix
- [x] Enhancement

## Testing
1. Log out → visit any job detail → click Login to apply →  confirm URL has ?from= param → log in → confirm redirect back
2. Jobs page → INTERNAL count hidden when 0
3. No filters active → "Showing 4 of 4" not shown
4. Apply a filter → "Showing X of Y" appears correctly
5. Check HIDE EXPIRED checkbox → lime color not red
6. Job detail → Similar Jobs section has correct heading

## Screenshots
<img width="1333" height="737" alt="image" src="https://github.com/user-attachments/assets/314f1afc-d476-4eda-8dcd-6a6783435944" />

<img width="1811" height="888" alt="image" src="https://github.com/user-attachments/assets/fe4d92e2-395d-45ce-be30-874fca0b1126" />


## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No .env, credentials, or node_modules committed
- [ ] Docs updated (if needed)
- [x] Screenshots added for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Result count no longer displays when all results are shown
  * Internal jobs count only appears when jobs are available
  * Sign-in flow now preserves your current page for seamless navigation

* **Style**
  * Enhanced "Hide expired" filter with improved visual feedback
  * Updated section heading to "Similar Jobs"

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->