### PR TITLE
fix: add retry button on round submission failure #462

### DIFF
--- a/client/src/module/student/applications/ApplicationProgressPage.tsx
+++ b/client/src/module/student/applications/ApplicationProgressPage.tsx
@@ -45,7 +45,6 @@ export default function ApplicationProgressPage() {
       lastPayload.current = null;
       queryClient.invalidateQueries({ queryKey: queryKeys.applications.progress(applicationId!) });
     } catch {
-      toast.error("Failed to submit round");
       setSubmitError("Submission failed. Please try again.");
     } finally {
       setSubmitting(false);

--- a/client/src/module/student/applications/ApplicationProgressPage.tsx
+++ b/client/src/module/student/applications/ApplicationProgressPage.tsx
@@ -86,7 +86,7 @@ export default function ApplicationProgressPage() {
                   title: `${application.job?.title} @ ${application.job?.company} — Application Deadline`,
                   details: `Applied via InternHack: https://internhack.xyz/student/applications/${application.id}\\nCompany: ${application.job?.company}\\nRole: ${application.job?.title}\\nLocation: ${application.job?.location || "Remote"}`,
                   start: new Date(application.job?.deadline ?? ""),
-end: new Date(new Date(application.job?.deadline ?? "").getTime() + 30 * 60000),
+                  end: new Date(new Date(application.job?.deadline ?? "").getTime() + 30 * 60000),
                 }), '_blank')}
               >
                 <CalendarIcon className="w-3 h-3" /> Google Calendar
@@ -117,9 +117,8 @@ end: new Date(new Date(application.job?.deadline ?? "").getTime() + 30 * 60000),
 
           return (
             <motion.div key={round.id} initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.1 }}
-              className={`bg-white dark:bg-gray-900 rounded-xl border shadow-sm overflow-hidden ${
-                isActive ? "border-black dark:border-white" : "border-gray-100 dark:border-gray-800"
-              }`}>
+              className={`bg-white dark:bg-gray-900 rounded-xl border shadow-sm overflow-hidden ${isActive ? "border-black dark:border-white" : "border-gray-100 dark:border-gray-800"
+                }`}>
               <div className="p-6">
                 <div className="flex items-center gap-3 mb-2">
                   {isCompleted ? (
@@ -130,11 +129,10 @@ end: new Date(new Date(application.job?.deadline ?? "").getTime() + 30 * 60000),
                     <Circle className="w-5 h-5 text-gray-300 dark:text-gray-600" />
                   )}
                   <h3 className="font-semibold text-gray-900 dark:text-white">Round {i + 1}: {round.name}</h3>
-                  <span className={`text-xs px-2 py-0.5 rounded-full ${
-                    isCompleted ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" :
-                    isActive ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400" :
-                    "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500"
-                  }`}>
+                  <span className={`text-xs px-2 py-0.5 rounded-full ${isCompleted ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" :
+                      isActive ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400" :
+                        "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500"
+                    }`}>
                     {isCompleted ? "Completed" : isActive ? "In Progress" : "Pending"}
                   </span>
                   {round.activateAt && (
@@ -207,28 +205,28 @@ end: new Date(new Date(application.job?.deadline ?? "").getTime() + 30 * 60000),
                             />
                           )}
                           <div className="space-y-2">
-  {submitError && (
-    <div aria-live="polite" className="flex items-center gap-3 p-3 bg-red-50 dark:bg-red-900/30 rounded-lg text-sm text-red-600 dark:text-red-400">
-      <span>{submitError}</span>
-      <Button
-        variant="mono"
-        size="sm"
-        aria-label="Retry submission"
-        disabled={submitting}
-        onClick={() => lastPayload.current && handleSubmitRound(lastPayload.current.roundId, lastPayload.current.answers)}
-      >
-        {submitting ? "Retrying..." : "Retry"}
-      </Button>
-    </div>
-  )}
-  <div className="flex items-center gap-3">
-    <Button variant="mono" onClick={() => handleSubmitRound(round.id)} disabled={submitting}>
-      <Send className="w-4 h-4" />
-      {submitting ? "Submitting..." : "Submit Round"}
-    </Button>
-    <Button variant="ghost" onClick={() => setActiveRoundId(null)} className="text-gray-500 hover:text-black dark:hover:text-white">Cancel</Button>
-  </div>
-</div>
+                            {submitError && (
+                              <div aria-live="polite" className="flex items-center gap-3 p-3 bg-red-50 dark:bg-red-900/30 rounded-lg text-sm text-red-600 dark:text-red-400">
+                                <span>{submitError}</span>
+                                <Button
+                                  variant="mono"
+                                  size="sm"
+                                  aria-label="Retry submission"
+                                  disabled={submitting}
+                                  onClick={() => lastPayload.current && handleSubmitRound(lastPayload.current.roundId, lastPayload.current.answers)}
+                                >
+                                  {submitting ? "Retrying..." : "Retry"}
+                                </Button>
+                              </div>
+                            )}
+                            <div className="flex items-center gap-3">
+                              <Button variant="mono" onClick={() => handleSubmitRound(round.id)} disabled={submitting}>
+                                <Send className="w-4 h-4" />
+                                {submitting ? "Submitting..." : "Submit Round"}
+                              </Button>
+                              <Button variant="ghost" onClick={() => { setActiveRoundId(null); setSubmitError(null); }} className="text-gray-500 hover:text-black dark:hover:text-white">Cancel</Button>
+                            </div>
+                          </div>
                         </div>
                       )
                     ) : (

--- a/client/src/module/student/applications/ApplicationProgressPage.tsx
+++ b/client/src/module/student/applications/ApplicationProgressPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { getStatusColor } from "../../../lib/application-colors";
 import { useParams, useNavigate, Link } from "react-router";
 import { ArrowLeft, CheckCircle, Clock, Circle, Send, ExternalLink, Calendar as CalendarIcon, Download } from "lucide-react";
@@ -20,6 +20,8 @@ export default function ApplicationProgressPage() {
   const [activeRoundId, setActiveRoundId] = useState<number | null>(null);
   const [fieldAnswers, setFieldAnswers] = useState<Record<string, unknown>>({});
   const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const lastPayload = useRef<{ roundId: number; answers: Record<string, unknown> } | null>(null);
 
   const queryClient = useQueryClient();
   const { data: application, isLoading: loading } = useQuery({
@@ -29,17 +31,22 @@ export default function ApplicationProgressPage() {
   });
 
   const handleSubmitRound = async (roundId: number, overrideAnswers?: Record<string, unknown>) => {
+    const answers = overrideAnswers ?? fieldAnswers;
+    lastPayload.current = { roundId, answers };
     setSubmitting(true);
+    setSubmitError(null);
     try {
       await api.post(`/student/applications/${applicationId}/rounds/${roundId}/submit`, {
-        fieldAnswers: overrideAnswers ?? fieldAnswers,
+        fieldAnswers: answers,
         attachments: [],
       });
       setActiveRoundId(null);
       setFieldAnswers({});
+      lastPayload.current = null;
       queryClient.invalidateQueries({ queryKey: queryKeys.applications.progress(applicationId!) });
     } catch {
       toast.error("Failed to submit round");
+      setSubmitError("Submission failed. Please try again.");
     } finally {
       setSubmitting(false);
     }
@@ -199,13 +206,29 @@ end: new Date(new Date(application.job?.deadline ?? "").getTime() + 30 * 60000),
                               onChange={(fieldId, value) => setFieldAnswers({ ...fieldAnswers, [fieldId]: value })}
                             />
                           )}
-                          <div className="flex items-center gap-3">
-                            <Button variant="mono" onClick={() => handleSubmitRound(round.id)} disabled={submitting}>
-                              <Send className="w-4 h-4" />
-                              {submitting ? "Submitting..." : "Submit Round"}
-                            </Button>
-                            <Button variant="ghost" onClick={() => setActiveRoundId(null)} className="text-gray-500 hover:text-black dark:hover:text-white">Cancel</Button>
-                          </div>
+                          <div className="space-y-2">
+  {submitError && (
+    <div aria-live="polite" className="flex items-center gap-3 p-3 bg-red-50 dark:bg-red-900/30 rounded-lg text-sm text-red-600 dark:text-red-400">
+      <span>{submitError}</span>
+      <Button
+        variant="mono"
+        size="sm"
+        aria-label="Retry submission"
+        disabled={submitting}
+        onClick={() => lastPayload.current && handleSubmitRound(lastPayload.current.roundId, lastPayload.current.answers)}
+      >
+        {submitting ? "Retrying..." : "Retry"}
+      </Button>
+    </div>
+  )}
+  <div className="flex items-center gap-3">
+    <Button variant="mono" onClick={() => handleSubmitRound(round.id)} disabled={submitting}>
+      <Send className="w-4 h-4" />
+      {submitting ? "Submitting..." : "Submit Round"}
+    </Button>
+    <Button variant="ghost" onClick={() => setActiveRoundId(null)} className="text-gray-500 hover:text-black dark:hover:text-white">Cancel</Button>
+  </div>
+</div>
                         </div>
                       )
                     ) : (


### PR DESCRIPTION
## Description
Added a Retry button that appears when a round submission API call fails, allowing students to re-submit without refreshing the page or losing form state.

## Related Issue
Fixes #462

## Type of Change
- [x] Bug Fix

## Testing
- Verified zero TypeScript/compile errors in VS Code
- Logic tested: `useRef` stores last payload, error state triggers retry UI, retry re-calls mutation with same payload

## Screenshots
(not applicable - error state UI only visible on API failure)

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] Screenshots added for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Retry button on failed submissions to attempt resubmission.

* **Bug Fixes**
  * Replaced toast errors with an inline error panel for submission failures.
  * Successful submissions now clear the form and refresh progress immediately.

* **Style**
  * Adjusted timeline/status card and calendar markup/formatting with no change to behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->