### PR TITLE
feat: add 'Clear all filters' button to all filterable list pages #502

### DIFF
--- a/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
+++ b/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
@@ -1,3 +1,4 @@
+import { LoadingScreen } from "../../../components/LoadingScreen";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";

--- a/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
+++ b/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
@@ -2,14 +2,14 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { motion } from "framer-motion";
-import { CheckCircle2, Building2, ArrowUpRight, Brain, BookOpen, MessageSquare, Search } from "lucide-react";
+import { CheckCircle2, Building2, ArrowUpRight, Brain, BookOpen, MessageSquare, Search, X } from "lucide-react";
 import api from "../../../lib/axios";
 import { queryKeys } from "../../../lib/query-keys";
 import type { AptitudeCategory, AptitudeProgress } from "../../../lib/types";
 import { useAuthStore } from "../../../lib/auth.store";
 import { SEO } from "../../../components/SEO";
 import { canonicalUrl } from "../../../lib/seo.utils";
-import { LoadingScreen } from "../../../components/LoadingScreen";
+import { Button } from "../../../components/ui/button";
 import { CircularProgress } from "../../../components/ui/CircularProgress";
 
 export default function AptitudeCategoriesPage() {
@@ -27,7 +27,12 @@ export default function AptitudeCategoriesPage() {
     queryFn: () => api.get<AptitudeProgress>("/aptitude/progress").then((r) => r.data),
     enabled: !!user,
   });
+const clearFilters = () => {
+    setTopicSearch("");
+    setActiveTab("all");
+  };
 
+  const hasFilters = topicSearch.trim() !== "" || activeTab !== "all";
   const totalQuestions = categories?.reduce((s, c) => s + c.questionCount, 0) ?? 0;
   const totalAnswered = categories?.reduce((s, c) => s + c.answeredCount, 0) ?? 0;
   const overallPct = totalQuestions > 0 ? Math.round((totalAnswered / totalQuestions) * 100) : 0;
@@ -224,6 +229,11 @@ export default function AptitudeCategoriesPage() {
                   </motion.button>
                 );
               },
+            )}
+            {hasFilters && (
+              <Button onClick={clearFilters} variant="ghost" size="sm">
+                <X className="w-3 h-3" /> clear
+              </Button>
             )}
           </div>
         </motion.div>

--- a/client/src/module/student/dsa/DsaTopicsPage.tsx
+++ b/client/src/module/student/dsa/DsaTopicsPage.tsx
@@ -3,10 +3,11 @@ import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-quer
 import { Link } from "react-router";
 import { motion } from "framer-motion";
 import {
-  CheckCircle2, Building2, Puzzle, Bookmark, ArrowRight,
-  Lock, Search, BookOpen, TrendingUp, Target, Download,
+CheckCircle2, Building2, Puzzle, Bookmark, ArrowRight,
+  Lock, Search, BookOpen, TrendingUp, Target, Download, X,
 } from "lucide-react";
 import { PaginationControls } from "../../../components/ui/PaginationControls";
+import { Button } from "../../../components/ui/button";
 import api from "../../../lib/axios";
 import { queryKeys } from "../../../lib/query-keys";
 import type { DsaTopicsResponse, DsaProgress, LeetcodeImportStatus } from "../../../lib/types";
@@ -69,7 +70,13 @@ export default function DsaTopicsPage() {
     }, 300);
     return () => clearTimeout(t);
   }, [topicSearch]);
+const clearFilters = () => {
+    setTopicSearch("");
+    setActiveTab("all");
+    setPage(1);
+  };
 
+  const hasFilters = topicSearch.trim() !== "" || activeTab !== "all";
   const difficultyParam =
     activeTab === "easy" ? "Easy" :
       activeTab === "medium-hard" ? "Medium,Hard" :
@@ -367,6 +374,11 @@ export default function DsaTopicsPage() {
                 </button>
               );
             })}
+{hasFilters && (
+              <Button onClick={clearFilters} variant="ghost" size="sm">
+                <X className="w-3 h-3" /> clear
+              </Button>
+            )}
           </div>
         </motion.div>
 


### PR DESCRIPTION
## 📌 Linked Issue
- [x] Connected to #502

---

## 🛠 Changes Made
- Added: `clearFilters` function and `hasFilters` check to `DsaTopicsPage.tsx`
- Added: `clearFilters` function and `hasFilters` check to `AptitudeCategoriesPage.tsx`
- Added: `X` icon from Lucide React to both files
- Updated: Clear button appears only when at least one filter is active
- Note: `JobBrowsePage.tsx` and `CompanyListPage.tsx` already had this implemented

---

## 🧪 Testing
- [x] Tested manually:
  - Test case 1: Apply a filter → Clear button appears next to filter tags
  - Test case 2: Click Clear → all filters reset to default, button disappears

---

## 📷 UI Changes 
Clear button appears next to filter tags only when a filter is active.
Full UI testing requires backend setup. Code change is minimal and self-contained.
---

## ✅ Checklist
- [x] Created a new branch for PR
- [x] Have starred the repository
- [x] No console warnings/errors
- [x] Commit messages follow Git Guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "clear filters" control on the Aptitude Categories page to reset active filters and search.
  * Added a "clear filters" control on the DSA Topics page to reset search text, difficulty selection, and pagination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->