### PR TITLE
feat: add About page, register route, and add Navbar link

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -67,6 +67,7 @@ const TermsPage = lazyWithRetry(() => import("./module/legal/TermsPage"));
 const PrivacyPage = lazyWithRetry(() => import("./module/legal/PrivacyPage"));
 const ShippingPage = lazyWithRetry(() => import("./module/legal/ShippingPage"));
 const ContactPage = lazyWithRetry(() => import("./module/legal/ContactPage"));
+const AboutPage = lazyWithRetry(() => import("./module/legal/AboutPage"));
 const RefundPage = lazyWithRetry(() => import("./module/legal/RefundPage"));
 
 // Student pages
@@ -357,6 +358,7 @@ function App() {
           <Route path="/privacy" element={<PrivacyPage />} />
           <Route path="/shipping" element={<ShippingPage />} />
           <Route path="/contact" element={<ContactPage />} />
+          <Route path="/about" element={<AboutPage />} />
           <Route path="/refund" element={<RefundPage />} />
           {/* Learning Hub - all learning content under /learn */}
           <Route path="/learn" element={<LearnLayout />}>

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -32,6 +32,7 @@ const NAV_ITEMS = [
   { label: "Companies", href: "/companies" },
   { label: "Recruiters", href: "/for-recruiters" },
   { label: "Blog", href: "/blog" },
+  { label: "About", href: "/about" },
 ];
 
 export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {

--- a/client/src/module/legal/AboutPage.tsx
+++ b/client/src/module/legal/AboutPage.tsx
@@ -1,0 +1,146 @@
+import { Navbar } from "../../components/Navbar";
+import { Footer } from "../../components/Footer";
+import { SEO } from "../../components/SEO";
+import {
+  Cpu,
+  FileText,
+  Mic,
+  Search,
+  Briefcase,
+  LayoutDashboard,
+  GitMerge,
+  BarChart2,
+  Users,
+  Mail,
+  Target,
+  Globe,
+} from "lucide-react";
+
+interface FeatureItem {
+  icon: React.ElementType;
+  title: string;
+  description: string;
+}
+
+const features: FeatureItem[] = [
+  { icon: Cpu, title: "AI-Powered Platform", description: "Career and hiring decisions backed by smart AI, not guesswork." },
+  { icon: FileText, title: "Resume Scoring", description: "ATS-friendly resume scoring and job matching so your profile actually gets seen." },
+  { icon: Mic, title: "Mock Interviews", description: "Practice with AI-driven interview simulations and get real feedback before the real thing." },
+  { icon: Search, title: "Job Discovery", description: "Find opportunities and track every application in one place — no more lost tabs." },
+  { icon: Briefcase, title: "Recruiter Tools", description: "Post jobs, manage candidates, and streamline entire hiring workflows with ease." },
+  { icon: LayoutDashboard, title: "Smart Dashboards", description: "Dedicated dashboards for students, recruiters, and admins — each built for their needs." },
+  { icon: GitMerge, title: "Hiring Workflows", description: "Streamlined multi-round interview processes that save time for both sides of the table." },
+  { icon: BarChart2, title: "Data-Driven Hiring", description: "Built to make hiring more accessible, efficient, and informed by real data." },
+  { icon: Users, title: "For Everyone", description: "Whether you are a student, recruiter, or admin — InternHack has a space built just for you." },
+];
+
+export default function AboutPage() {
+  return (
+    <div className="min-h-screen flex flex-col bg-linear-to-br from-white via-indigo-50 to-purple-50 dark:from-gray-950 dark:via-gray-900 dark:to-black">
+      <SEO
+        title="About Us"
+        description="Learn more about InternHack — the AI-powered career and hiring platform built for students and recruiters."
+      />
+      <Navbar />
+
+      <main className="flex-1 px-4 pt-28 pb-20">
+        <div className="max-w-6xl mx-auto">
+
+          {/* Hero */}
+          <div className="text-center mt-6 mb-14">
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-indigo-100 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 mb-5">
+              <Globe size={30} />
+            </div>
+            <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 dark:text-white mb-4">
+              About InternHack
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto text-base md:text-lg">
+              InternHack is an AI-powered career and hiring platform that helps students
+              prepare for placements, practice interviews, and get placed — while giving
+              recruiters the tools to hire smarter.
+            </p>
+          </div>
+
+          {/* Mission & Vision */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-14">
+            <div className="rounded-2xl border border-gray-200/70 dark:border-gray-800 bg-white/80 dark:bg-gray-900/60 backdrop-blur-lg shadow-sm p-6 md:p-8">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-3 rounded-xl bg-indigo-100 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-400">
+                  <Target size={22} />
+                </div>
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Our Mission</h2>
+              </div>
+              <p className="text-gray-600 dark:text-gray-300 leading-relaxed text-sm md:text-base">
+                To democratize access to career opportunities for students globally —
+                regardless of their background, college, or location — by giving them
+                world-class tools to compete and succeed.
+              </p>
+            </div>
+
+            <div className="rounded-2xl border border-gray-200/70 dark:border-gray-800 bg-white/80 dark:bg-gray-900/60 backdrop-blur-lg shadow-sm p-6 md:p-8">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-3 rounded-xl bg-indigo-100 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-400">
+                  <Globe size={22} />
+                </div>
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Our Vision</h2>
+              </div>
+              <p className="text-gray-600 dark:text-gray-300 leading-relaxed text-sm md:text-base">
+                To become the most trusted early-career ecosystem on the planet —
+                connecting millions of students with companies that value their
+                potential, not just their pedigree.
+              </p>
+            </div>
+          </div>
+
+          {/* What We Offer */}
+          <div className="mb-14">
+            <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-2">What We Offer</h2>
+            <p className="text-gray-500 dark:text-gray-400 mb-8 text-sm md:text-base">
+              Everything you need to prepare, practice, and get placed — in one platform.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {features.map((feature, index) => {
+                const Icon = feature.icon;
+                return (
+                  <div
+                    key={index}
+                    className="rounded-2xl border border-gray-200/70 dark:border-gray-800 bg-white/80 dark:bg-gray-900/60 backdrop-blur-lg shadow-sm hover:shadow-xl transition-all duration-300 p-6"
+                  >
+                    <div className="p-3 rounded-xl bg-indigo-100 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 w-fit mb-4">
+                      <Icon size={22} />
+                    </div>
+                    <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-2">{feature.title}</h3>
+                    <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">{feature.description}</p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* CTA Banner */}
+          <div className="rounded-3xl overflow-hidden border border-indigo-200 dark:border-indigo-500/20 bg-linear-to-r from-indigo-600 to-purple-600 shadow-2xl">
+            <div className="p-8 md:p-10 text-center">
+              <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-white/20 mb-5">
+                <Mail className="text-white" size={26} />
+              </div>
+              <h2 className="text-2xl md:text-3xl font-bold text-white mb-3">Want to get in touch?</h2>
+              <p className="text-indigo-100 max-w-2xl mx-auto mb-6">
+                Have questions, feedback, or partnership ideas? We would love to hear from you.
+              </p>
+              <a
+                href="/contact"
+                className="inline-flex items-center gap-2 bg-white text-indigo-700 hover:bg-gray-100 transition px-6 py-3 rounded-xl font-semibold shadow-lg"
+              >
+                <Mail size={18} />
+                Contact Us
+              </a>
+            </div>
+          </div>
+
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Added the missing About page to the platform and wired it up properly.

## Changes
- Created `client/src/module/legal/AboutPage.tsx` matching the exact style of existing legal pages (PrivacyPage, TermsPage, etc.)
- Registered `/about` route in `src/App.tsx`
- Added About link to the Navbar alongside Home, Jobs, Learn, etc.

## Preview
The About page includes:
- Hero section with InternHack description
- Mission & Vision cards
- 9 feature cards (AI platform, resume scoring, mock interviews, job discovery, etc.)
- Contact CTA banner linking to the existing `/contact` page

## Why
The About page was missing from the platform. Users had no way to learn about InternHack or navigate to it from the main menu.

## Type of Change
- [x] New feature / new page

Closes #598