### PR TITLE
feat(jobs): salary range filter on browse (API + Prisma + URL sync)

### DIFF
--- a/client/src/module/student/jobs/JobBrowsePage.tsx
+++ b/client/src/module/student/jobs/JobBrowsePage.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useDebounce } from "../../../hooks/useDebounce";
-import { Link, useLocation } from "react-router";
+import { Link, useLocation, useSearchParams } from "react-router";
 import { motion, AnimatePresence } from "framer-motion";
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import {
@@ -40,6 +40,32 @@ const FILTER_TAGS = [
   "Data Science",
 ] as const;
 
+const LPA_TO_ANNUAL_INR = 100_000;
+
+function parseAnnualInrFromLpaInput(raw: string): number | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  const num = Number(trimmed);
+  if (!Number.isFinite(num) || num < 0) return undefined;
+  return Math.round(num * LPA_TO_ANNUAL_INR);
+}
+
+function formatLpaFromAnnualInr(inr: number): string {
+  const lpa = inr / LPA_TO_ANNUAL_INR;
+  if (Number.isInteger(lpa)) return String(lpa);
+  const s = lpa.toFixed(2).replace(/\.?0+$/, "");
+  return s;
+}
+
+function lpaPlaceholderFromSearch(search: string, key: string): string {
+  const p = new URLSearchParams(search);
+  const raw = p.get(key);
+  if (!raw) return "";
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return "";
+  return formatLpaFromAnnualInr(n);
+}
+
 function MetaChip({
   icon,
   children,
@@ -56,16 +82,77 @@ function MetaChip({
 }
 
 export default function JobBrowsePage() {
-  const isInsideLayout = useLocation().pathname.startsWith("/student/");
+  const location = useLocation();
+  const isInsideLayout = location.pathname.startsWith("/student/");
+  const [, setSearchParams] = useSearchParams();
   const [search, setSearch] = useState("");
   const [locationFilter, setLocationFilter] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [page, setPage] = useState(1);
   const [extPage, setExtPage] = useState(1);
   const [scrPage, setScrPage] = useState(1);
+  const [salaryMinInput, setSalaryMinInput] = useState("");
+  const [salaryMaxInput, setSalaryMaxInput] = useState("");
   const debouncedSearch = useDebounce(search, 400);
   const debouncedLocation = useDebounce(locationFilter, 400);
+  const debouncedSalaryMinInput = useDebounce(salaryMinInput, 400);
+  const debouncedSalaryMaxInput = useDebounce(salaryMaxInput, 400);
+  const debouncedSalaryMinAnnual = parseAnnualInrFromLpaInput(debouncedSalaryMinInput);
+  const debouncedSalaryMaxAnnual = parseAnnualInrFromLpaInput(debouncedSalaryMaxInput);
   const [hideExpired, setHideExpired] = useState(true);
+
+  const trimmedSalaryMin = salaryMinInput.trim();
+  const trimmedSalaryMax = salaryMaxInput.trim();
+  /** Empty field drops the bound immediately so clear / deletes are not delayed by debounce. */
+  const salaryMinAnnualForApi =
+    trimmedSalaryMin === "" ? undefined : debouncedSalaryMinAnnual;
+  const salaryMaxAnnualForApi =
+    trimmedSalaryMax === "" ? undefined : debouncedSalaryMaxAnnual;
+
+  useEffect(() => {
+    const minShown = lpaPlaceholderFromSearch(location.search, "salaryMin");
+    const maxShown = lpaPlaceholderFromSearch(location.search, "salaryMax");
+    /* eslint-disable react-hooks/set-state-in-effect -- sync LPA fields with salary* URL params on navigation/share links */
+    setSalaryMinInput(minShown);
+    setSalaryMaxInput(maxShown);
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [location.search]);
+
+  useEffect(() => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      let changed = false;
+
+      if (salaryMinAnnualForApi !== undefined) {
+        const s = String(salaryMinAnnualForApi);
+        if (next.get("salaryMin") !== s) {
+          next.set("salaryMin", s);
+          changed = true;
+        }
+      } else if (next.has("salaryMin")) {
+        next.delete("salaryMin");
+        changed = true;
+      }
+
+      if (salaryMaxAnnualForApi !== undefined) {
+        const s = String(salaryMaxAnnualForApi);
+        if (next.get("salaryMax") !== s) {
+          next.set("salaryMax", s);
+          changed = true;
+        }
+      } else if (next.has("salaryMax")) {
+        next.delete("salaryMax");
+        changed = true;
+      }
+
+      return changed ? next : prev;
+    });
+  }, [salaryMinAnnualForApi, salaryMaxAnnualForApi, setSearchParams]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- invalidate page when overlap filter changes so pagination stays valid
+    setPage(1);
+  }, [salaryMinAnnualForApi, salaryMaxAnnualForApi]);
 
   const { data, isLoading, isFetching } = useQuery({
     queryKey: queryKeys.jobs.list({
@@ -74,6 +161,12 @@ export default function JobBrowsePage() {
       location: debouncedLocation,
       tags: selectedTags.join(","),
       includeExpired: !hideExpired,
+      ...(salaryMinAnnualForApi !== undefined && {
+        salaryMin: salaryMinAnnualForApi,
+      }),
+      ...(salaryMaxAnnualForApi !== undefined && {
+        salaryMax: salaryMaxAnnualForApi,
+      }),
     }),
     queryFn: async () => {
       const params = new URLSearchParams({ page: String(page), limit: "12" });
@@ -81,6 +174,12 @@ export default function JobBrowsePage() {
       if (debouncedLocation) params.set("location", debouncedLocation);
       if (selectedTags.length) params.set("tags", selectedTags.join(","));
       params.set("includeExpired", String(!hideExpired));
+      if (salaryMinAnnualForApi !== undefined) {
+        params.set("salaryMin", String(salaryMinAnnualForApi));
+      }
+      if (salaryMaxAnnualForApi !== undefined) {
+        params.set("salaryMax", String(salaryMaxAnnualForApi));
+      }
       const res = await api.get(`/jobs?${params}`);
       return res.data as { jobs: Job[]; pagination: Pagination };
     },
@@ -153,12 +252,25 @@ export default function JobBrowsePage() {
     setSearch("");
     setLocationFilter("");
     setSelectedTags([]);
+    setSalaryMinInput("");
+    setSalaryMaxInput("");
     setPage(1);
     setExtPage(1);
     setScrPage(1);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete("salaryMin");
+      next.delete("salaryMax");
+      return next;
+    });
   };
 
-  const hasFilters = search || locationFilter || selectedTags.length > 0;
+  const hasFilters =
+    search ||
+    locationFilter ||
+    selectedTags.length > 0 ||
+    salaryMinAnnualForApi !== undefined ||
+    salaryMaxAnnualForApi !== undefined;
 
   
 
@@ -320,6 +432,56 @@ export default function JobBrowsePage() {
               />
             </div>
           </form>
+
+          <div className="min-h-[3.75rem] flex flex-col gap-3 sm:flex-row sm:items-end sm:gap-4">
+            <div className="flex items-center gap-2 shrink-0 sm:pb-px">
+              <span className="flex h-9 w-9 items-center justify-center rounded-md border border-stone-200 dark:border-white/10 bg-white dark:bg-stone-900 text-stone-500 shrink-0">
+                <IndianRupee className="w-4 h-4" aria-hidden />
+              </span>
+              <span className="text-xs font-mono uppercase tracking-widest text-stone-500">
+                salary /
+              </span>
+            </div>
+            <div className="grid grid-cols-2 gap-3 flex-1 w-full">
+              <label className="flex flex-col gap-1">
+                <span className="text-xs font-mono uppercase tracking-widest text-stone-400">
+                  min (lpa)
+                </span>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  min={0}
+                  step={0.5}
+                  value={salaryMinInput}
+                  placeholder="Any"
+                  onChange={(e) => setSalaryMinInput(e.target.value)}
+                  autoComplete="off"
+                  aria-label="Minimum salary in lakhs per annum"
+                  className="w-full px-4 py-2.5 bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors text-sm tabular-nums text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="text-xs font-mono uppercase tracking-widest text-stone-400">
+                  max (lpa)
+                </span>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  min={0}
+                  step={0.5}
+                  value={salaryMaxInput}
+                  placeholder="Any"
+                  onChange={(e) => setSalaryMaxInput(e.target.value)}
+                  autoComplete="off"
+                  aria-label="Maximum salary in lakhs per annum"
+                  className="w-full px-4 py-2.5 bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors text-sm tabular-nums text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600"
+                />
+              </label>
+            </div>
+          </div>
+          <p className="text-xs text-stone-500 font-mono -mt-3 sm:-mt-1">
+            Applies to partner (internal) roles with a parseable salary. External and scraped lists ignore this filter for now.
+          </p>
 
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-xs font-mono uppercase tracking-widest text-stone-500 mr-1">

--- a/client/src/module/student/jobs/JobBrowsePage.tsx
+++ b/client/src/module/student/jobs/JobBrowsePage.tsx
@@ -42,6 +42,7 @@ const FILTER_TAGS = [
 
 const LPA_TO_ANNUAL_INR = 100_000;
 
+/** Parses LPA from the browse filter into annual INR, or `undefined` if blank/invalid. */
 function parseAnnualInrFromLpaInput(raw: string): number | undefined {
   const trimmed = raw.trim();
   if (!trimmed) return undefined;
@@ -50,6 +51,7 @@ function parseAnnualInrFromLpaInput(raw: string): number | undefined {
   return Math.round(num * LPA_TO_ANNUAL_INR);
 }
 
+/** Formats annual INR for prefilling salary inputs when reading URL query params. */
 function formatLpaFromAnnualInr(inr: number): string {
   const lpa = inr / LPA_TO_ANNUAL_INR;
   if (Number.isInteger(lpa)) return String(lpa);
@@ -57,6 +59,7 @@ function formatLpaFromAnnualInr(inr: number): string {
   return s;
 }
 
+/** Builds an LPA display string from one `salaryMin` / `salaryMax` URL param (annual INR). */
 function lpaPlaceholderFromSearch(search: string, key: string): string {
   const p = new URLSearchParams(search);
   const raw = p.get(key);

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "seed": "tsx src/database/seeds/seed.ts",
     "seed:gsoc-repos": "tsx src/database/seeds/seed-gsoc-repos.ts",
-    "seed:admin": "tsx src/database/seed-admin.ts"
+    "seed:admin": "tsx src/database/seed-admin.ts",
+    "backfill:job-salary": "tsx scripts/backfill-job-salary-bounds.ts"
   },
   "keywords": [],
   "author": "Sachin Chaurasiya",

--- a/server/scripts/backfill-job-salary-bounds.ts
+++ b/server/scripts/backfill-job-salary-bounds.ts
@@ -1,0 +1,37 @@
+/**
+ * One-off backfill for job.salaryAnnualMin / job.salaryAnnualMax from free-text job.salary.
+ *
+ * Usage (from repo server/):
+ *   DATABASE_URL="..." npx tsx scripts/backfill-job-salary-bounds.ts
+ */
+
+import "dotenv/config";
+
+import { prisma } from "../src/database/db.js";
+import { parseSalary } from "../src/module/job-index/job-normalizer.js";
+
+async function main() {
+  const jobs = await prisma.job.findMany({ select: { id: true, salary: true } });
+
+  for (const j of jobs) {
+    const { min, max } = parseSalary(j.salary);
+    await prisma.job.update({
+      where: { id: j.id },
+      data: {
+        salaryAnnualMin: min,
+        salaryAnnualMax: max,
+      },
+    });
+  }
+
+  console.log(`[backfill-job-salary-bounds] processed ${jobs.length} rows`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/server/scripts/backfill-job-salary-bounds.ts
+++ b/server/scripts/backfill-job-salary-bounds.ts
@@ -1,8 +1,9 @@
 /**
- * One-off backfill for job.salaryAnnualMin / job.salaryAnnualMax from free-text job.salary.
+ * One-off backfill for `job.salaryAnnualMin` / `job.salaryAnnualMax` from free-text `job.salary`.
+ * Only touches rows missing either bound to limit write amplification.
  *
- * Usage (from repo server/):
- *   DATABASE_URL="..." npx tsx scripts/backfill-job-salary-bounds.ts
+ * Usage (from repo `server/`):
+ *   `DATABASE_URL="..." npx tsx scripts/backfill-job-salary-bounds.ts`
  */
 
 import "dotenv/config";
@@ -10,21 +11,41 @@ import "dotenv/config";
 import { prisma } from "../src/database/db.js";
 import { parseSalary } from "../src/module/job-index/job-normalizer.js";
 
-async function main() {
-  const jobs = await prisma.job.findMany({ select: { id: true, salary: true } });
+/** Batch size for each `prisma.$transaction` to avoid oversized transactions. */
+const BATCH_SIZE = 250;
 
-  for (const j of jobs) {
-    const { min, max } = parseSalary(j.salary);
-    await prisma.job.update({
-      where: { id: j.id },
-      data: {
-        salaryAnnualMin: min,
-        salaryAnnualMax: max,
+async function main() {
+  let total = 0;
+
+  for (;;) {
+    const jobs = await prisma.job.findMany({
+      where: {
+        OR: [{ salaryAnnualMin: null }, { salaryAnnualMax: null }],
       },
+      take: BATCH_SIZE,
+      orderBy: { id: "asc" },
+      select: { id: true, salary: true },
     });
+
+    if (jobs.length === 0) break;
+
+    await prisma.$transaction(
+      jobs.map((j) => {
+        const { min, max } = parseSalary(j.salary);
+        return prisma.job.update({
+          where: { id: j.id },
+          data: {
+            salaryAnnualMin: min,
+            salaryAnnualMax: max,
+          },
+        });
+      }),
+    );
+
+    total += jobs.length;
   }
 
-  console.log(`[backfill-job-salary-bounds] processed ${jobs.length} rows`);
+  console.log(`[backfill-job-salary-bounds] updated ${total} row(s) that were missing bounds`);
 }
 
 main()

--- a/server/src/database/prisma/migrations/20260527000000_job_salary_annual_bounds/migration.sql
+++ b/server/src/database/prisma/migrations/20260527000000_job_salary_annual_bounds/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "job" ADD COLUMN "salaryAnnualMin" INTEGER,
+ADD COLUMN "salaryAnnualMax" INTEGER;

--- a/server/src/database/prisma/migrations/20260527153000_job_salary_bounds_indexes/migration.sql
+++ b/server/src/database/prisma/migrations/20260527153000_job_salary_bounds_indexes/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "job_salaryAnnualMin_idx" ON "job"("salaryAnnualMin");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "job_salaryAnnualMax_idx" ON "job"("salaryAnnualMax");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "job_salaryAnnualMin_salaryAnnualMax_idx" ON "job"("salaryAnnualMin", "salaryAnnualMax");

--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -143,6 +143,9 @@ model job {
   @@index([status, createdAt])
   @@index([deadline])
   @@index([createdAt])
+  @@index([salaryAnnualMin])
+  @@index([salaryAnnualMax])
+  @@index([salaryAnnualMin, salaryAnnualMax])
 }
 
 model round {

--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -119,12 +119,14 @@ model adminProfile {
 }
 
 model job {
-  id           Int           @id @default(autoincrement())
-  title        String
-  description  String
-  location     String
-  salary       String
-  company      String
+  id               Int           @id @default(autoincrement())
+  title            String
+  description      String
+  location         String
+  salary           String
+  salaryAnnualMin  Int?
+  salaryAnnualMax  Int?
+  company          String
   status       JobStatus     @default(DRAFT)
   customFields Json          @default("[]")
   deadline     DateTime?

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -54,7 +54,6 @@ import { complianceRouter } from "./module/compliance/compliance.routes.js";
 import { workflowRouter } from "./module/workflow/workflow.routes.js";
 import { hrAnalyticsRouter } from "./module/hr-analytics/hr-analytics.routes.js";
 import { contactRouter } from "./module/contact/contact.routes.js";
-import { hackathonRouter } from "./module/hackathon/hackathon.routes.js";
 import { sitemapRouter } from "./module/sitemap/sitemap.routes.js";
 import { jobFeedRouter } from "./module/job-feed/job-feed.routes.js";
 import { jobAgentRouter } from "./module/job-agent/job-agent.routes.js";
@@ -257,8 +256,8 @@ app.use("/api/learn", learnRouter);
 
 // Contact form (public, no auth)
 app.use("/api/contact", contactRouter);
-app.use("/api/hackathons", hackathonRouter);
 // Public external jobs endpoints (no auth)
+// Note: `/api/hackathons` is not mounted until student/public routes are wired (see `hackathon.service.ts`).
 const publicAdminController = new AdminController(new AdminService());
 // Public ingest endpoint, external websites POST jobs here with API key
 app.post("/api/external-jobs/ingest", (req, res) => publicAdminController.ingestExternalJob(req, res));

--- a/server/src/module/hackathon/hackathon.routes.ts
+++ b/server/src/module/hackathon/hackathon.routes.ts
@@ -1,4 +1,0 @@
-import { Router } from "express";
-
-/** Minimal export so `/api/hackathons` mounts without crashing; handlers not wired here. */
-export const hackathonRouter = Router();

--- a/server/src/module/hackathon/hackathon.routes.ts
+++ b/server/src/module/hackathon/hackathon.routes.ts
@@ -1,0 +1,4 @@
+import { Router } from "express";
+
+/** Minimal export so `/api/hackathons` mounts without crashing; handlers not wired here. */
+export const hackathonRouter = Router();

--- a/server/src/module/job/job.service.ts
+++ b/server/src/module/job/job.service.ts
@@ -29,6 +29,10 @@ interface JobQuery {
 }
 
 
+/**
+ * Turns the stored human-readable salary string into nullable annual INR bounds
+ * (`salaryAnnualMin` / `salaryAnnualMax`) using the same rules as job-index ingestion.
+ */
 function salaryBoundsFromString(salary: string): {
   salaryAnnualMin: number | null;
   salaryAnnualMax: number | null;
@@ -40,7 +44,10 @@ function salaryBoundsFromString(salary: string): {
   };
 }
 
-/** Overlap query range [salaryMin, salaryMax] with job [salaryAnnualMin, salaryAnnualMax]; missing bound = open. */
+/**
+ * Restricts listings to jobs whose stored range overlaps the optional query range.
+ * Jobs without both parsed bounds are excluded whenever any salary filter is active.
+ */
 function appendSalaryOverlapFilter(andFilters: Prisma.jobWhereInput[], query: JobQuery) {
   if (query.salaryMin === undefined && query.salaryMax === undefined) return;
 
@@ -63,6 +70,8 @@ function appendSalaryOverlapFilter(andFilters: Prisma.jobWhereInput[], query: Jo
 type UpdateJobData = {
   [K in keyof CreateJobData]?: CreateJobData[K] | undefined;
 };
+
+/** Persists recruiter job posts and resolves listing queries including optional salary overlap. */
 export class JobService {
   async createJob(data: CreateJobData) {
     const { salaryAnnualMin, salaryAnnualMax } = salaryBoundsFromString(data.salary);

--- a/server/src/module/job/job.service.ts
+++ b/server/src/module/job/job.service.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../../database/db.js";
 import type { Prisma } from "@prisma/client";
+import { parseSalary } from "../job-index/job-normalizer.js";
 
 interface CreateJobData {
   title: string;
@@ -23,6 +24,39 @@ interface JobQuery {
   status?: string | undefined;
   tags?: string | undefined;
   includeExpired?: boolean | undefined;
+  salaryMin?: number | undefined;
+  salaryMax?: number | undefined;
+}
+
+
+function salaryBoundsFromString(salary: string): {
+  salaryAnnualMin: number | null;
+  salaryAnnualMax: number | null;
+} {
+  const { min, max } = parseSalary(salary);
+  return {
+    salaryAnnualMin: min,
+    salaryAnnualMax: max,
+  };
+}
+
+/** Overlap query range [salaryMin, salaryMax] with job [salaryAnnualMin, salaryAnnualMax]; missing bound = open. */
+function appendSalaryOverlapFilter(andFilters: Prisma.jobWhereInput[], query: JobQuery) {
+  if (query.salaryMin === undefined && query.salaryMax === undefined) return;
+
+  const conditions: Prisma.jobWhereInput[] = [
+    { salaryAnnualMin: { not: null } },
+    { salaryAnnualMax: { not: null } },
+  ];
+
+  if (query.salaryMin !== undefined) {
+    conditions.push({ salaryAnnualMax: { gte: query.salaryMin } });
+  }
+  if (query.salaryMax !== undefined) {
+    conditions.push({ salaryAnnualMin: { lte: query.salaryMax } });
+  }
+
+  andFilters.push({ AND: conditions });
 }
 
 
@@ -31,12 +65,16 @@ type UpdateJobData = {
 };
 export class JobService {
   async createJob(data: CreateJobData) {
+    const { salaryAnnualMin, salaryAnnualMax } = salaryBoundsFromString(data.salary);
+
     return prisma.job.create({
       data: {
         title: data.title,
         description: data.description,
         location: data.location,
         salary: data.salary,
+        salaryAnnualMin,
+        salaryAnnualMax,
         company: data.company,
         status: data.status || "DRAFT",
         customFields: data.customFields ? JSON.parse(JSON.stringify(data.customFields)) : [],
@@ -84,6 +122,8 @@ export class JobService {
     if (query.tags) {
       where.tags = { hasSome: query.tags.split(",").map((t) => t.trim()) };
     }
+
+    appendSalaryOverlapFilter(andFilters, query);
 
     if (andFilters.length > 0) {
       where.AND = andFilters;
@@ -240,11 +280,21 @@ export class JobService {
       where.status = query.status as "DRAFT" | "PUBLISHED" | "CLOSED" | "ARCHIVED";
     }
 
+    const andParts: Prisma.jobWhereInput[] = [];
+
     if (query.search) {
-      where.OR = [
-        { title: { contains: query.search, mode: "insensitive" } },
-        { company: { contains: query.search, mode: "insensitive" } },
-      ];
+      andParts.push({
+        OR: [
+          { title: { contains: query.search, mode: "insensitive" } },
+          { company: { contains: query.search, mode: "insensitive" } },
+        ],
+      });
+    }
+
+    appendSalaryOverlapFilter(andParts, query);
+
+    if (andParts.length > 0) {
+      where.AND = andParts;
     }
 
     const skip = (query.page - 1) * query.limit;
@@ -278,13 +328,20 @@ export class JobService {
     if (!job) throw new Error("Job not found");
     if (job.recruiterId !== recruiterId) throw new Error("Not authorized");
 
+    const salaryBounds =
+      data.salary !== undefined ? salaryBoundsFromString(data.salary) : null;
+
     return prisma.job.update({
       where: { id },
       data: {
         ...(data.title !== undefined && { title: data.title }),
         ...(data.description !== undefined && { description: data.description }),
         ...(data.location !== undefined && { location: data.location }),
-        ...(data.salary !== undefined && { salary: data.salary }),
+        ...(data.salary !== undefined && {
+          salary: data.salary,
+          salaryAnnualMin: salaryBounds!.salaryAnnualMin,
+          salaryAnnualMax: salaryBounds!.salaryAnnualMax,
+        }),
         ...(data.company !== undefined && { company: data.company }),
         ...(data.customFields !== undefined && { customFields: JSON.parse(JSON.stringify(data.customFields)) }),
         ...(data.deadline !== undefined && { deadline: data.deadline ? new Date(data.deadline) : null }),

--- a/server/src/module/job/job.validation.ts
+++ b/server/src/module/job/job.validation.ts
@@ -66,13 +66,36 @@ export const updateJobStatusSchema = z.object({
   status: z.enum(["DRAFT", "PUBLISHED", "CLOSED", "ARCHIVED"]),
 });
 
-export const jobQuerySchema = z.object({
-  page: z.coerce.number().int().positive().default(1),
-  limit: z.coerce.number().int().positive().max(100).default(10),
-  search: z.string().optional(),
-  location: z.string().optional(),
-  company: z.string().optional(),
-  status: z.enum(["DRAFT", "PUBLISHED", "CLOSED", "ARCHIVED"]).optional(),
-  tags: z.string().optional(),
-  includeExpired: coerceBoolean.default(false),
-});
+const optionalAnnualInr = z.preprocess((v) => {
+  if (v === undefined || v === null || v === "") return undefined;
+  const n = typeof v === "string" ? Number.parseInt(v, 10) : Number(v);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return Math.min(Math.trunc(n), Number.MAX_SAFE_INTEGER);
+}, z.number().int().optional());
+
+export const jobQuerySchema = z
+  .object({
+    page: z.coerce.number().int().positive().default(1),
+    limit: z.coerce.number().int().positive().max(100).default(10),
+    search: z.string().optional(),
+    location: z.string().optional(),
+    company: z.string().optional(),
+    status: z.enum(["DRAFT", "PUBLISHED", "CLOSED", "ARCHIVED"]).optional(),
+    tags: z.string().optional(),
+    includeExpired: coerceBoolean.default(false),
+    salaryMin: optionalAnnualInr,
+    salaryMax: optionalAnnualInr,
+  })
+  .superRefine((data, ctx) => {
+    if (
+      data.salaryMin !== undefined &&
+      data.salaryMax !== undefined &&
+      data.salaryMin > data.salaryMax
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "salaryMin must be <= salaryMax",
+        path: ["salaryMin"],
+      });
+    }
+  });

--- a/server/src/module/job/job.validation.ts
+++ b/server/src/module/job/job.validation.ts
@@ -66,13 +66,39 @@ export const updateJobStatusSchema = z.object({
   status: z.enum(["DRAFT", "PUBLISHED", "CLOSED", "ARCHIVED"]),
 });
 
-const optionalAnnualInr = z.preprocess((v) => {
-  if (v === undefined || v === null || v === "") return undefined;
-  const n = typeof v === "string" ? Number.parseInt(v, 10) : Number(v);
-  if (!Number.isFinite(n) || n < 0) return undefined;
-  return Math.min(Math.trunc(n), Number.MAX_SAFE_INTEGER);
-}, z.number().int().optional());
+/**
+ * Express `req.query` value for optional annual INR filters.
+ * Omits empty input; rejects partial numbers like `"12abc"`. Allows non-negative integers only.
+ *
+ * @param field - Used in validation error paths/messages (`salaryMin` / `salaryMax`).
+ */
+function annualInrQueryField(field: "salaryMin" | "salaryMax") {
+  const msg = `${field} must be a non-negative integer (digits only)`;
+  return z.preprocess(
+    (v) => {
+      if (v === undefined || v === null || v === "") return undefined;
+      if (typeof v === "string" && v.trim() === "") return undefined;
+      if (typeof v === "number") {
+        if (!Number.isFinite(v) || !Number.isInteger(v) || v < 0) return "__invalid__";
+        return String(Math.min(v, Number.MAX_SAFE_INTEGER));
+      }
+      return String(v).trim();
+    },
+    z
+      .union([
+        z.undefined(),
+        z.literal("__invalid__").refine(() => false, { message: msg }),
+        z
+          .string()
+          .regex(/^\d{1,20}$/, { message: msg })
+          .transform((s) => Number.parseInt(s, 10))
+          .pipe(z.number().int().min(0).max(Number.MAX_SAFE_INTEGER)),
+      ])
+      .optional(),
+  );
+}
 
+/** Parsed `GET /jobs`-style listing query (digits-only salary bounds optional). */
 export const jobQuerySchema = z
   .object({
     page: z.coerce.number().int().positive().default(1),
@@ -83,8 +109,8 @@ export const jobQuerySchema = z
     status: z.enum(["DRAFT", "PUBLISHED", "CLOSED", "ARCHIVED"]).optional(),
     tags: z.string().optional(),
     includeExpired: coerceBoolean.default(false),
-    salaryMin: optionalAnnualInr,
-    salaryMax: optionalAnnualInr,
+    salaryMin: annualInrQueryField("salaryMin"),
+    salaryMax: annualInrQueryField("salaryMax"),
   })
   .superRefine((data, ctx) => {
     if (


### PR DESCRIPTION
## Summary

- **Database / Prisma:** Adds nullable `salaryAnnualMin` and `salaryAnnualMax` on `job` (migration included). Values are derived from the existing free-text `salary` field via `parseSalary()` on create/update.
- **API:** Extends `GET /api/jobs` with optional query params `salaryMin` and `salaryMax` (annual INR integers). Jobs are included when their stored range **overlaps** the requested range; jobs without parsed bounds are excluded when a salary filter is active. `salaryMin ≤ salaryMax` is validated when both are present.
- **Client:** Job browse adds **min/max LPA** inputs (debounced), passes salary params **only to** `GET /jobs` (not external/scraped listings), syncs **`salaryMin`/`salaryMax`** in the URL as annual INR, and ties **clear** / **hasFilters** to salary.
- **Maintenance:** Replaces the empty `hackathon.routes` module with a tiny `Router()` export so the server can mount `/api/hackathons` without failing on a missing named export; removes the unused empty `hackathon.controller.ts`.

## Out of scope / follow-ups

- Salary filtering for `/api/external-jobs` and `/api/scraped-jobs` (would need similar numeric fields or parsing).
- After deploy: run `npm run backfill:job-salary` from `server/` (with `DATABASE_URL` set) once to populate bounds for existing rows.

## Test plan

- [ ] Run migration from `server/src/database/`.
- [ ] Optionally: `cd server && npm run backfill:job-salary`.
- [ ] `cd server && npm run dev` and `cd client && npm run dev`.
- [ ] Open `/jobs` (or `/student/jobs`), enter min/max LPA, confirm **`GET /api/jobs`** query string includes `salaryMin`/`salaryMax`, URL updates, clearing fields removes them and internal results respect the filter where `salaryAnnualMin`/`salaryAnnualMax` exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added min/max salary range filters (LPA) to job listings; applies to internal/partner jobs.
  * Salary inputs synchronize with the URL so selections persist across navigation; clearing filters resets salary bounds.
* **Chores**
  * Added database salary fields, indexes, and a one‑off backfill to populate annual salary bounds for existing jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->