### PR TITLE
fix(job): harden server-side tag filtering for jobs endpoint

### DIFF
--- a/server/src/module/job/job.service.ts
+++ b/server/src/module/job/job.service.ts
@@ -82,7 +82,10 @@ export class JobService {
     }
 
     if (query.tags) {
-      where.tags = { hasSome: query.tags.split(",").map((t) => t.trim()) };
+      const tagList = query.tags.split(",").map((t) => t.trim()).filter(Boolean);
+      if (tagList.length > 0) {
+        where.tags = { hasSome: tagList };
+      }
     }
 
     if (andFilters.length > 0) {


### PR DESCRIPTION
# Pull Request

## Description
This PR addresses the tag filtering logic on the server-side to make it more robust. It adds an array length check and filters out empty strings (`filter(Boolean)`) before applying Prisma's `hasSome` condition for the `/api/jobs` endpoint. This guarantees consistency across other services (like external/scraped jobs) and prevents potential DB query errors for empty tag arrays.

## Related Issue
Fixes #464

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
- Verified `JobBrowsePage` works correctly with backend tag filtering.
- Applied tags through the UI (e.g. React, Remote) and confirmed the backend payload processed it properly without empty string arrays breaking Prisma constraints.

## Screenshots
N/A

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [ ] Screenshots added for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag filtering in job search to properly handle whitespace and empty values, ensuring more reliable filter results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->