### PR TITLE
feat(job-agent): cap conversation history to 50 messages

### DIFF
--- a/server/src/module/job-agent/job-agent.service.ts
+++ b/server/src/module/job-agent/job-agent.service.ts
@@ -7,6 +7,7 @@ import { jobAgentJobsEmailHtml, jobAgentJobsEmailText } from "../../utils/email-
 const genAI = new GoogleGenerativeAI(process.env["GEMINI_API_KEY"]!);
 const JOB_EMAIL_COOLDOWN_SECONDS = 60;
 const JOB_EMAIL_DAILY_LIMIT = 5;
+const MAX_CONVERSATION_MESSAGES = 50;
 
 export class JobAgentEmailError extends Error {
   constructor(
@@ -172,6 +173,14 @@ async function upsertPreferences(userId: number, updatedPreferences: any): Promi
   return true;
 }
 
+async function persistCappedConversation(convId: number, history: any[], context: any) {
+  const cappedHistory = history.slice(-MAX_CONVERSATION_MESSAGES);
+  await prisma.jobAgentConversation.update({
+    where: { id: convId },
+    data: { messages: cappedHistory, context },
+  });
+}
+
 function truncateContext(context?: string | null): string | null {
   const trimmed = context?.replace(/\s+/g, " ").trim();
   if (!trimmed) return null;
@@ -271,12 +280,7 @@ export class JobAgentService {
       jobIds: jobs.map((j: any) => j.id),
     });
 
-    const cappedHistory = history.slice(-50);
-
-    await prisma.jobAgentConversation.update({
-      where: { id: conv.id },
-      data: { messages: cappedHistory, context: parsed.updatedPreferences || conv.context },
-    });
+    await persistCappedConversation(conv.id, history, parsed.updatedPreferences || conv.context);
 
     return { reply: parsed.reply, jobs, preferencesUpdated };
   }
@@ -388,12 +392,7 @@ export class JobAgentService {
       jobIds: jobs.map((j: any) => j.id),
     });
 
-    const cappedHistory = history.slice(-50);
-
-    await prisma.jobAgentConversation.update({
-      where: { id: conv.id },
-      data: { messages: cappedHistory, context: parsed.updatedPreferences || conv.context },
-    });
+    await persistCappedConversation(conv.id, history, parsed.updatedPreferences || conv.context);
   }
 
   async getConversation(userId: number) {
@@ -404,7 +403,7 @@ export class JobAgentService {
     if (!conv) return null;
 
     let messages = conv.messages as any[];
-    if (messages.length > 50) messages = messages.slice(-50);
+    if (messages.length > MAX_CONVERSATION_MESSAGES) messages = messages.slice(-MAX_CONVERSATION_MESSAGES);
     const allJobIds: number[] = [];
     for (const m of messages) {
       if (m.jobIds?.length) allJobIds.push(...m.jobIds);

--- a/server/src/module/job-agent/job-agent.service.ts
+++ b/server/src/module/job-agent/job-agent.service.ts
@@ -271,9 +271,11 @@ export class JobAgentService {
       jobIds: jobs.map((j: any) => j.id),
     });
 
+    const cappedHistory = history.slice(-50);
+
     await prisma.jobAgentConversation.update({
       where: { id: conv.id },
-      data: { messages: history, context: parsed.updatedPreferences || conv.context },
+      data: { messages: cappedHistory, context: parsed.updatedPreferences || conv.context },
     });
 
     return { reply: parsed.reply, jobs, preferencesUpdated };
@@ -386,9 +388,11 @@ export class JobAgentService {
       jobIds: jobs.map((j: any) => j.id),
     });
 
+    const cappedHistory = history.slice(-50);
+
     await prisma.jobAgentConversation.update({
       where: { id: conv.id },
-      data: { messages: history, context: parsed.updatedPreferences || conv.context },
+      data: { messages: cappedHistory, context: parsed.updatedPreferences || conv.context },
     });
   }
 
@@ -399,7 +403,8 @@ export class JobAgentService {
     });
     if (!conv) return null;
 
-    const messages = conv.messages as any[];
+    let messages = conv.messages as any[];
+    if (messages.length > 50) messages = messages.slice(-50);
     const allJobIds: number[] = [];
     for (const m of messages) {
       if (m.jobIds?.length) allJobIds.push(...m.jobIds);


### PR DESCRIPTION
# Pull Request

## Description
This PR fully addresses the Job Agent history persistence requirements. While the basic infrastructure for storing conversations was already implemented under the `/job-agent/conversation` endpoint, the history was unbounded. 

This PR implements the missing critical acceptance criterion: capping the Job Agent conversation history to the last 50 messages. This cap (`.slice(-50)`) is enforced symmetrically across standard `chat`, `chatStream`, and when retrieving the conversation, preventing database bloat and avoiding context window overflows for the LLM. 

## Related Issue
Fixes #496

## Type of Change
- [ ] Bug Fix  
- [x] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
- Verified that the backend correctly truncates the `messages` array in the `jobAgentConversation` table to 50 elements upon sending a new message.
- Confirmed that LLM interactions continue working flawlessly with the capped context (maintains exact user/assistant pairings).

## Screenshots
N/A

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [ ] Screenshots added for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job agent conversation history is now limited to the 50 most recent messages during persistence and retrieval operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->