### PR TITLE
feat(ats): update startup tone to startup-casual for cover letters

### DIFF
--- a/client/src/module/student/ats/CoverLetterPage.tsx
+++ b/client/src/module/student/ats/CoverLetterPage.tsx
@@ -56,7 +56,7 @@ const TONES: { id: CoverLetterTone; label: string; description: string }[] = [
   },
   { id: "formal", label: "Formal", description: "Executive and measured" },
   { id: "concise", label: "Concise", description: "Short and direct" },
-  { id: "startup", label: "Startup", description: "Bold and mission-driven" },
+  { id: "startup", label: "Startup-Casual", description: "Bold and mission-driven" },
 ];
 const LENGTHS = [
   {

--- a/server/src/module/ats/cover-letter.service.ts
+++ b/server/src/module/ats/cover-letter.service.ts
@@ -139,7 +139,7 @@ export class CoverLetterService {
       concise:
         "Be extremely brief and direct. Use short sentences. Cut all filler. Write 1-2 short paragraphs maximum, targeting 150-200 words. Ignore the default paragraph count and word limit — brevity is the priority. Every sentence must earn its place.",
       startup:
-        "Use bold, mission-driven language. Show that you understand the startup's vision and want to help build something meaningful. Be direct, energetic, and avoid corporate speak.",
+        "Use bold, mission-driven language with a startup-casual vibe. Show that you understand the startup's vision and want to help build something meaningful. Be direct, energetic, and avoid corporate speak.",
     };
     
 


### PR DESCRIPTION
# Pull Request

## Description
This PR addresses the requested enhancement to the cover letter generator by explicitly supporting a "Startup-Casual" tone. The foundation for tone selection was already present in the UI and backend logic; this PR refines it to perfectly match the requested styling.

Changes included:
1. Updated the tone selector UI in `CoverLetterPage.tsx` to explicitly label the startup option as **Startup-Casual**.
2. Adjusted the backend system prompt mapping in `cover-letter.service.ts` to explicitly enforce a "startup-casual vibe" when feeding the generation context into the Gemini API.

## Related Issue
Fixes #479

## Type of Change
- [ ] Bug Fix  
- [x] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
- Verified that the tone selector in the UI correctly displays the "Startup-Casual" label.
- Confirmed the backend API successfully receives the tone string and maps it to the updated, highly-specific system prompt instruction.
- Verified that the cover letter generated with this tone adopts a bold, energetic, and non-corporate style.

## Screenshots
N/A

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [ ] Screenshots added for UI changes (if applicable)