### PR TITLE
fix(cover-letter): format PDF with header and dynamic filename

### DIFF
--- a/client/src/module/student/ats/CoverLetterPage.tsx
+++ b/client/src/module/student/ats/CoverLetterPage.tsx
@@ -332,45 +332,121 @@ useEffect(() => {
   const handleDownloadPdf = async () => {
     if (!coverLetter) return;
     setShowDownloadMenu(false);
+
+    // Build a slug-safe company name for the filename
+    const safeCompany = (companyName || "company")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    const dateStr = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+    const filename = `cover-letter-${safeCompany}-${dateStr}.pdf`;
+
     const html2pdf = (await import("html2pdf.js")).default;
+
+    // Build a nicely formatted HTML container
     const container = document.createElement("div");
     container.style.cssText =
-      "font-family:Georgia,serif;max-width:700px;padding:40px;line-height:1.7;color:#1a1a1a;font-size:14px;white-space:pre-wrap;";
-    container.innerText = coverLetter;
+      "font-family:Georgia,serif;max-width:680px;padding:48px 52px;color:#1a1a1a;font-size:13.5px;line-height:1.75;";
+
+    // Header block
+    const header = document.createElement("div");
+    header.style.cssText = "margin-bottom:24px;";
+
+    if (user?.name) {
+      const nameEl = document.createElement("p");
+      nameEl.style.cssText =
+        "font-size:22px;font-weight:700;margin:0 0 4px 0;letter-spacing:-0.3px;";
+      nameEl.textContent = user.name;
+      header.appendChild(nameEl);
+    }
+
+    if (companyName || jobTitle) {
+      const subEl = document.createElement("p");
+      subEl.style.cssText =
+        "font-size:12px;color:#666;margin:0 0 16px 0;letter-spacing:0.5px;text-transform:uppercase;";
+      const parts = [jobTitle, companyName].filter(Boolean);
+      subEl.textContent = parts.join(" · ");
+      header.appendChild(subEl);
+    }
+
+    const divider = document.createElement("hr");
+    divider.style.cssText =
+      "border:none;border-top:2px solid #1a1a1a;margin:0 0 24px 0;";
+    header.appendChild(divider);
+
+    container.appendChild(header);
+
+    // Body — preserve line breaks
+    const body = document.createElement("div");
+    body.style.cssText = "white-space:pre-wrap;";
+    body.textContent = coverLetter;
+    container.appendChild(body);
+
     document.body.appendChild(container);
+
     await html2pdf()
       .set({
-        margin: 20,
-        filename: "cover-letter.pdf",
+        margin: [14, 14, 14, 14],
+        filename,
         image: { type: "jpeg", quality: 0.98 },
         html2canvas: { scale: 2 },
         jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
       })
       .from(container)
       .save();
+
     document.body.removeChild(container);
   };
 
   const handleDownloadDocx = async () => {
     if (!coverLetter) return;
     setShowDownloadMenu(false);
-    const { Document, Paragraph, TextRun, Packer } = await import("docx");
+    const { Document, Paragraph, TextRun, Packer, HeadingLevel } = await import("docx");
     const { saveAs } = await import("file-saver");
 
-    const paragraphs = coverLetter.split("\n").map(
-      (line) =>
+    const safeCompany = (companyName || "company")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const filename = `cover-letter-${safeCompany}-${dateStr}.docx`;
+
+    const children = [];
+
+    if (user?.name) {
+      children.push(
+        new Paragraph({
+          text: user.name,
+          heading: HeadingLevel.HEADING_1,
+          spacing: { after: 80 },
+        }),
+      );
+    }
+
+    if (companyName || jobTitle) {
+      const subtitle = [jobTitle, companyName].filter(Boolean).join(" · ");
+      children.push(
+        new Paragraph({
+          children: [
+            new TextRun({ text: subtitle, font: "Georgia", size: 20, color: "666666", allCaps: true }),
+          ],
+          spacing: { after: 200 },
+        }),
+      );
+    }
+
+    coverLetter.split("\n").forEach((line) => {
+      children.push(
         new Paragraph({
           children: [new TextRun({ text: line, font: "Georgia", size: 24 })],
           spacing: { after: 120 },
         }),
-    );
-
-    const doc = new Document({
-      sections: [{ children: paragraphs }],
+      );
     });
 
+    const doc = new Document({ sections: [{ children }] });
     const blob = await Packer.toBlob(doc);
-    saveAs(blob, "cover-letter.docx");
+    saveAs(blob, filename);
   };
 
   return (
@@ -919,24 +995,12 @@ useEffect(() => {
                       <div className="relative" ref={downloadMenuRef}>
                         <button
                           type="button"
+                          disabled={loading}
                           onClick={() => setShowDownloadMenu((v) => !v)}
-                          className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md text-[11px] font-bold text-stone-950 bg-lime-400 hover:bg-lime-300 transition-colors border-0 cursor-pointer"
+                          className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md text-[11px] font-bold text-stone-950 bg-lime-400 hover:bg-lime-300 transition-colors border-0 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                           <Download className="w-3 h-3" /> Download
                         </button>
-
-                        <button
-  type="button"
-  onClick={() => {
-    setCoverLetter(originalCoverLetter);
-    setIsModified(false);
-    localStorage.setItem(STORAGE_KEY, originalCoverLetter);
-  }}
-  disabled={!isModified}
-  className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md text-[11px] font-bold text-stone-700 dark:text-stone-300 bg-transparent border border-stone-300 dark:border-white/15 hover:bg-stone-100 dark:hover:bg-white/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
->
-  Reset
-</button>
 
                         <AnimatePresence>
                           {showDownloadMenu && (
@@ -967,6 +1031,18 @@ useEffect(() => {
                           )}
                         </AnimatePresence>
                       </div>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setCoverLetter(originalCoverLetter);
+                          setIsModified(false);
+                          localStorage.setItem(STORAGE_KEY, originalCoverLetter);
+                        }}
+                        disabled={!isModified}
+                        className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-md text-[11px] font-bold text-stone-700 dark:text-stone-300 bg-transparent border border-stone-300 dark:border-white/15 hover:bg-stone-100 dark:hover:bg-white/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                      >
+                        Reset
+                      </button>
                     </div>
                   }
                 />


### PR DESCRIPTION
## Summary
- Upgraded the Cover Letter PDF export to include a professionally formatted header and dynamic filenames (e.g. `cover-letter-google-2026-05-27.pdf`), matching standard job application requirements.

## Changes
- `CoverLetterPage.tsx`:
  - Fixed `handleDownloadPdf` to generate an HTML container with the student's name (H1), job title + company (subtitle), and a divider before the letter body.
  - Set `white-space: pre-wrap` to preserve paragraph breaks in the PDF layout.
  - Implemented dynamic, slug-safe filenames for both PDF and DOCX downloads based on the company name and current date.
  - Added `disabled={loading}` to the Download button so it cannot be clicked while the AI is generating.
  - Fixed layout issue by moving the "Reset" button outside the download dropdown wrapper so it sits correctly in the action bar.
- No server changes or new dependencies required.

## How to test
1. Run `cd server && npm run dev` and `cd client && npm run dev`.
2. Ensure you have a valid `GEMINI_API_KEY` in `server/.env`.
3. Go to `/student/ats/cover-letter` and generate a cover letter for a specific company and role.
4. Verify the "Download" button is disabled while generating.
5. Click Download -> PDF.
6. Open the downloaded PDF: verify the filename format, the header with your name/company, and the preserved paragraph spacing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cover letter exports now generate descriptive, date-stamped filenames for easier file organization
  * Exported cover letters feature enhanced formatting with improved structure and readability

* **Style**
  * Download button now clearly shows disabled state while processing
  * Reset button styling improved for enhanced user experience

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->