### PR TITLE
Add duplicate AI roadmap detection

### DIFF
--- a/server/src/module/roadmap/roadmap.controller.ts
+++ b/server/src/module/roadmap/roadmap.controller.ts
@@ -444,7 +444,7 @@ export async function postAiGenerate(req: Request, res: Response, next: NextFunc
   userId
 );
 
-if (duplicate) {
+if (duplicate && !input.forceCreate) {
   res.status(409).json({
     message: "Similar roadmap already exists",
     roadmap: duplicate,

--- a/server/src/module/roadmap/roadmap.controller.ts
+++ b/server/src/module/roadmap/roadmap.controller.ts
@@ -18,6 +18,7 @@ import {
 import {
   buildWeeklyPlan,
   enrollUser,
+  findDuplicateRoadmap,
   getEnrollmentForUser,
   getRoadmapBySlug,
   getTopicBySlug,
@@ -437,6 +438,20 @@ export async function postAiGenerate(req: Request, res: Response, next: NextFunc
     }
     const userId = req.user!.id;
     const input = parsed.data;
+
+    const duplicate = await findDuplicateRoadmap(
+  input.goalDescription,
+  userId
+);
+
+if (duplicate) {
+  res.status(409).json({
+    message: "Similar roadmap already exists",
+    roadmap: duplicate,
+  });
+
+  return;
+}
 
     // 1. Generate via Gemini, validate shape
     let generated;

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -9,7 +9,21 @@ interface WeeklyPlanWeek {
   topicSlugs: string[];
   totalHours: number;
 }
-
+export async function findDuplicateRoadmap(
+  title: string,
+  userId: number
+) {
+  return prisma.roadmap.findFirst({
+    where: {
+      ownerUserId: userId,
+      isAiGenerated: true,
+      title: {
+        equals: title.trim(),
+        mode: "insensitive",
+      },
+    },
+  });
+}
 export interface EnrolledRoadmap {
   enrollment: Prisma.roadmapEnrollmentGetPayload<{
     include: {

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -18,7 +18,7 @@ export async function findDuplicateRoadmap(
       ownerUserId: userId,
       isAiGenerated: true,
       title: {
-        equals: title.trim(),
+        contains: title.trim(),
         mode: "insensitive",
       },
     },

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -13,6 +13,9 @@ export async function findDuplicateRoadmap(
   goalDescription: string,
   userId: number
 ) {
+  const normalizedGoal = goalDescription.trim();
+  if (!normalizedGoal) return null;
+
   return prisma.roadmap.findFirst({
     where: {
       ownerUserId: userId,
@@ -21,9 +24,9 @@ export async function findDuplicateRoadmap(
         startsWith: 'ai-',
       },
       title: {
-        contains: goalDescription.slice(0, 30).trim(),
+        contains: normalizedGoal.slice(0, 30),
         mode: 'insensitive',
-      }
+      },
     },
   });
 }

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -10,17 +10,20 @@ interface WeeklyPlanWeek {
   totalHours: number;
 }
 export async function findDuplicateRoadmap(
-  title: string,
+  goalDescription: string,
   userId: number
 ) {
   return prisma.roadmap.findFirst({
     where: {
       ownerUserId: userId,
       isAiGenerated: true,
-      title: {
-        contains: title.trim(),
-        mode: "insensitive",
+      slug: {
+        startsWith: 'ai-',
       },
+      title: {
+        contains: goalDescription.slice(0, 30).trim(),
+        mode: 'insensitive',
+      }
     },
   });
 }

--- a/server/src/module/roadmap/roadmap.validation.ts
+++ b/server/src/module/roadmap/roadmap.validation.ts
@@ -67,6 +67,7 @@ export const aiGenerateSchema = z.object({
   knownSkills: z.array(z.string().max(40)).max(20).default([]),
   mustInclude: z.array(z.string().max(40)).max(20).default([]),
   avoid: z.array(z.string().max(40)).max(20).default([]),
+  forceCreate: z.boolean().optional().default(false),
 });
 export type AiGenerateInput = z.infer<typeof aiGenerateSchema>;
 


### PR DESCRIPTION
## Pull Request

## Description

Added duplicate AI roadmap detection before generating a new AI roadmap.

The implementation checks for existing AI-generated roadmaps for the same user using case-insensitive matching before calling the AI generation flow.

## Related Issue

Closes #100

## Type of Change

* [x] Bug Fix
* [x] Feature
* [ ] Enhancement
* [ ] Documentation

## Testing

* Added duplicate detection logic in `roadmap.service.ts`
* Added duplicate validation before `generateAiRoadmap()` in `roadmap.controller.ts`
* Verified duplicate requests now return `409 Conflict`

## Screenshots

N/A

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors introduced by this change
* [x] Tested manually
* [x] No `.env`, credentials, or `node_modules` committed
* [x] Docs updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate detection for AI-generated roadmaps: creating a roadmap via AI now checks for an existing similar roadmap and returns the existing one (HTTP 409) instead of creating a duplicate.
  * Option to override duplicate detection: an optional flag lets you force creation and bypass the duplicate check when a new roadmap is desired.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->