### PR TITLE
feat: Show current aptitude streak prominently on categories page (Fixes #475)

### DIFF
--- a/client/src/lib/types/learning.types.ts
+++ b/client/src/lib/types/learning.types.ts
@@ -290,5 +290,5 @@ export interface AptitudeProgress {
   totalQuestions: number;
   totalAnswered: number;
   totalCorrect: number;
-    currentStreak: number;
+  currentStreak: number;
 }

--- a/client/src/lib/types/learning.types.ts
+++ b/client/src/lib/types/learning.types.ts
@@ -290,4 +290,5 @@ export interface AptitudeProgress {
   totalQuestions: number;
   totalAnswered: number;
   totalCorrect: number;
+    currentStreak: number;
 }

--- a/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
+++ b/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
@@ -12,6 +12,56 @@ import { canonicalUrl } from "../../../lib/seo.utils";
 import { LoadingScreen } from "../../../components/LoadingScreen";
 import { CircularProgress } from "../../../components/ui/CircularProgress";
 
+// ── Streak Banner ──────────────────────────────────────────────────────────
+type StreakBannerProps = { streak: number };
+
+function StreakBanner({ streak }: StreakBannerProps) {
+  if (streak > 0) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          padding: "12px 16px",
+          borderRadius: "8px",
+          backgroundColor: "#1c1a14",
+          border: "1px solid #a16207",
+          marginBottom: "24px",
+          color: "#fde68a",
+          fontSize: "14px",
+        }}
+      >
+        <span role="img" aria-label="flame" style={{ fontSize: "20px" }}>🔥</span>
+        <span>
+          <strong>{streak}-day streak</strong> — Keep it up! Practice today to continue your streak.
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        padding: "12px 16px",
+        borderRadius: "8px",
+        backgroundColor: "#0f172a",
+        border: "1px solid #334155",
+        marginBottom: "24px",
+        color: "#94a3b8",
+        fontSize: "14px",
+      }}
+    >
+      <span role="img" aria-label="target" style={{ fontSize: "20px" }}>🎯</span>
+      <span>
+        <strong>Start your aptitude streak today!</strong> Practice now and build your daily habit.
+      </span>
+    </div>
+  );
+}
+
 export default function AptitudeCategoriesPage() {
   const { user } = useAuthStore();
   const [activeTab, setActiveTab] = useState<string>("all");
@@ -57,6 +107,7 @@ export default function AptitudeCategoriesPage() {
         keywords="aptitude practice, quantitative aptitude, logical reasoning, verbal ability, placement exam preparation"
         canonicalUrl={canonicalUrl("/learn/aptitude")}
       />
+            {user && <StreakBanner streak={progress?.currentStreak ?? 0} />}
 
       <div
         aria-hidden

--- a/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
+++ b/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
@@ -47,7 +47,7 @@ export default function AptitudeCategoriesPage() {
     queryFn: () => api.get<AptitudeCategory[]>("/aptitude/categories").then((r) => r.data),
   });
 
-  const { data: progress } = useQuery({
+  const { data: progress, isSuccess } = useQuery({
     queryKey: queryKeys.aptitude.progress(),
     queryFn: () => api.get<AptitudeProgress>("/aptitude/progress").then((r) => r.data),
     enabled: !!user,
@@ -82,7 +82,7 @@ export default function AptitudeCategoriesPage() {
         keywords="aptitude practice, quantitative aptitude, logical reasoning, verbal ability, placement exam preparation"
         canonicalUrl={canonicalUrl("/learn/aptitude")}
       />
-            {user && <StreakBanner streak={progress?.currentStreak ?? 0} />}
+            {user && isSuccess && <StreakBanner streak={progress.currentStreak} />}
 
       <div
         aria-hidden

--- a/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
+++ b/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
@@ -35,7 +35,7 @@ function StreakBanner({ streak }: StreakBannerProps) {
       </span>
     </div>
   );
-}}
+}
 
 export default function AptitudeCategoriesPage() {
   const { user } = useAuthStore();

--- a/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
+++ b/client/src/module/student/aptitude/AptitudeCategoriesPage.tsx
@@ -12,55 +12,30 @@ import { canonicalUrl } from "../../../lib/seo.utils";
 import { LoadingScreen } from "../../../components/LoadingScreen";
 import { CircularProgress } from "../../../components/ui/CircularProgress";
 
-// ── Streak Banner ──────────────────────────────────────────────────────────
+// — Streak Banner ———————————————————————————————————————————
 type StreakBannerProps = { streak: number };
 
 function StreakBanner({ streak }: StreakBannerProps) {
   if (streak > 0) {
     return (
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "8px",
-          padding: "12px 16px",
-          borderRadius: "8px",
-          backgroundColor: "#1c1a14",
-          border: "1px solid #a16207",
-          marginBottom: "24px",
-          color: "#fde68a",
-          fontSize: "14px",
-        }}
-      >
-        <span role="img" aria-label="flame" style={{ fontSize: "20px" }}>🔥</span>
+      <div className="flex items-center gap-2 px-4 py-3 mb-6 rounded-lg bg-yellow-950 border border-yellow-700 text-yellow-200 text-sm">
+        <span role="img" aria-label="flame" className="text-xl">🔥</span>
         <span>
           <strong>{streak}-day streak</strong> — Keep it up! Practice today to continue your streak.
         </span>
       </div>
     );
   }
+
   return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "8px",
-        padding: "12px 16px",
-        borderRadius: "8px",
-        backgroundColor: "#0f172a",
-        border: "1px solid #334155",
-        marginBottom: "24px",
-        color: "#94a3b8",
-        fontSize: "14px",
-      }}
-    >
-      <span role="img" aria-label="target" style={{ fontSize: "20px" }}>🎯</span>
+    <div className="flex items-center gap-2 px-4 py-3 mb-6 rounded-lg bg-stone-100 dark:bg-stone-900 border border-stone-200 dark:border-stone-700 text-stone-700 dark:text-stone-300 text-sm">
+      <span role="img" aria-label="target" className="text-xl">🎯</span>
       <span>
         <strong>Start your aptitude streak today!</strong> Practice now and build your daily habit.
       </span>
     </div>
   );
-}
+}}
 
 export default function AptitudeCategoriesPage() {
   const { user } = useAuthStore();

--- a/server/src/database/prisma/migrations/20260528000000_add_last_practiced_at_to_aptitude_progress/migration.sql
+++ b/server/src/database/prisma/migrations/20260528000000_add_last_practiced_at_to_aptitude_progress/migration.sql
@@ -1,0 +1,7 @@
+-- Add lastPracticedAt field to studentAptitudeProgress
+-- This field is updated on every answer attempt (upsert),
+-- unlike createdAt which is set only once at row creation.
+-- Using lastPracticedAt ensures the streak is calculated
+-- correctly for re-attempted questions.
+
+ALTER TABLE "studentAptitudeProgress" ADD COLUMN "lastPracticedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -751,6 +751,7 @@ model studentAptitudeProgress {
   answered   Boolean          @default(false)
   correct    Boolean          @default(false)
   createdAt  DateTime         @default(now())
+  lastPracticedAt DateTime @default(now())
   question   aptitudeQuestion @relation(fields: [questionId], references: [id], onDelete: Cascade)
   student    user             @relation("StudentAptitudeProgress", fields: [studentId], references: [id], onDelete: Cascade)
 

--- a/server/src/module/aptitude/aptitude.service.ts
+++ b/server/src/module/aptitude/aptitude.service.ts
@@ -275,7 +275,7 @@ export class AptitudeService {
           } else if (dateMs < expected) {
             break;
           }
-        }    }
+        }    
 
     return {
       totalQuestions: total,

--- a/server/src/module/aptitude/aptitude.service.ts
+++ b/server/src/module/aptitude/aptitude.service.ts
@@ -134,7 +134,7 @@ export class AptitudeService {
 
     await prisma.studentAptitudeProgress.upsert({
       where: { studentId_questionId: { studentId, questionId } },
-      create: { studentId, questionId, answered: true, correct: isCorrect },
+      create: { studentId, questionId, answered: true, correct: isCorrect , lastPracticedAt: new Date()},
       update: { answered: true, correct: isCorrect, lastPracticedAt: new Date() },
     });
 

--- a/server/src/module/aptitude/aptitude.service.ts
+++ b/server/src/module/aptitude/aptitude.service.ts
@@ -135,7 +135,7 @@ export class AptitudeService {
     await prisma.studentAptitudeProgress.upsert({
       where: { studentId_questionId: { studentId, questionId } },
       create: { studentId, questionId, answered: true, correct: isCorrect },
-      update: { answered: true, correct: isCorrect },
+      update: { answered: true, correct: isCorrect, lastPracticedAt: new Date() },
     });
 
     // Fire-and-forget milestone check
@@ -250,7 +250,7 @@ export class AptitudeService {
     const total = await prisma.aptitudeQuestion.count();
     const progress = await prisma.studentAptitudeProgress.findMany({
       where: { studentId },
-      select: { correct: true , createdAt: true},
+      select: { correct: true , lastPracticedAt: true},
     });
     
         // Calculate current streak from aptitude practice history (UTC-based to avoid timezone/DST issues)
@@ -259,7 +259,7 @@ export class AptitudeService {
         const yesterdayUTC = todayUTC.getTime() - 86400000;
 
         const dates = [...new Set(progress.map((p) => {
-          const d = new Date(p.createdAt);
+          const d = new Date(p.lastPracticedAt);
           d.setUTCHours(0, 0, 0, 0);
           return d.getTime();
         }))].sort((a, b) => b - a);

--- a/server/src/module/aptitude/aptitude.service.ts
+++ b/server/src/module/aptitude/aptitude.service.ts
@@ -253,31 +253,35 @@ export class AptitudeService {
       select: { correct: true , createdAt: true},
     });
     
-    // Calculate current streak from aptitude practice history
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const dates = [...new Set(progress.map((p) => {
-      const d = new Date(p.createdAt);
-      d.setHours(0, 0, 0, 0);
-      return d.getTime();
-    }))].sort((a, b) => b - a);
+        // Calculate current streak from aptitude practice history (UTC-based to avoid timezone/DST issues)
+        const todayUTC = new Date();
+        todayUTC.setUTCHours(0, 0, 0, 0);
+        const yesterdayUTC = todayUTC.getTime() - 86400000;
 
-    let currentStreak = 0;
-    let expected = today.getTime();
-    for (const dateMs of dates) {
-      if (dateMs === expected) {
-        currentStreak++;
-        expected -= 86400000;
-      } else if (dateMs < expected) {
-        break;
-      }
-    }
+        const dates = [...new Set(progress.map((p) => {
+          const d = new Date(p.createdAt);
+          d.setUTCHours(0, 0, 0, 0);
+          return d.getTime();
+        }))].sort((a, b) => b - a);
+
+        let currentStreak = 0;
+        // Allow streak to start from today or yesterday (so user doesn't lose streak if they haven't practiced yet today)
+        let expected = dates[0] === todayUTC.getTime() ? todayUTC.getTime() : yesterdayUTC;
+
+        for (const dateMs of dates) {
+          if (dateMs === expected) {
+            currentStreak++;
+            expected -= 86400000;
+          } else if (dateMs < expected) {
+            break;
+          }
+        }    }
 
     return {
       totalQuestions: total,
       totalAnswered: progress.length,
       totalCorrect: progress.filter((p) => p.correct).length,
-            currentStreak,
+      currentStreak,
     };
   }
 }

--- a/server/src/module/aptitude/aptitude.service.ts
+++ b/server/src/module/aptitude/aptitude.service.ts
@@ -250,13 +250,34 @@ export class AptitudeService {
     const total = await prisma.aptitudeQuestion.count();
     const progress = await prisma.studentAptitudeProgress.findMany({
       where: { studentId },
-      select: { correct: true },
+      select: { correct: true , createdAt: true},
     });
+    
+    // Calculate current streak from aptitude practice history
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const dates = [...new Set(progress.map((p) => {
+      const d = new Date(p.createdAt);
+      d.setHours(0, 0, 0, 0);
+      return d.getTime();
+    }))].sort((a, b) => b - a);
+
+    let currentStreak = 0;
+    let expected = today.getTime();
+    for (const dateMs of dates) {
+      if (dateMs === expected) {
+        currentStreak++;
+        expected -= 86400000;
+      } else if (dateMs < expected) {
+        break;
+      }
+    }
 
     return {
       totalQuestions: total,
       totalAnswered: progress.length,
       totalCorrect: progress.filter((p) => p.correct).length,
+            currentStreak,
     };
   }
 }


### PR DESCRIPTION
# Pull Request

## Description
Adds a `StreakBanner` component to the aptitude categories page that prominently displays the user's current aptitude practice streak. The streak is calculated from daily practice history in the backend and shown at the top of the page for logged-in users.

- If streak > 0: shows 🔥 "{n}-day streak — Keep it up! Practice today to continue your streak."
- If streak = 0: shows 🎯 "Start your aptitude streak today! Practice now and build your daily habit."

## Related Issue
Fixes #475

## Type of Change
- [ ] Bug Fix
- [x] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing
- Verified `StreakBanner` renders correctly for `streak > 0` by reading the component logic
- Verified `StreakBanner` renders the CTA state when `streak = 0`
- No existing functionality on the categories page is modified; the banner is additive only
- The `progress` query was already present in the page — no new API call added

## Screenshots
(UI banner added at top of categories page — visible only when logged in)

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [ ] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [x] Screenshots added for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streak tracking for aptitude practice—users now see their consecutive practice-day count in a dedicated banner.
  * Banner shows a flame-style streak display when active or a motivational prompt to start a streak when none exists.
  * Banner appears only when user data is available and progress has loaded.

* **Chores**
  * Backend and data store updated to record practice times and compute streaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->