### PR TITLE
test(middleware): add unit tests for error, role, bot-seo, and cache …

### DIFF
--- a/server/src/middleware/bot-seo.middleware.test.ts
+++ b/server/src/middleware/bot-seo.middleware.test.ts
@@ -85,6 +85,7 @@ describe("botSeoMiddleware", () => {
     botSeoMiddleware(req, res, next);
 
     expect(res._headers["X-Is-Bot"]).toBeUndefined();
+    expect(res.setHeader).toHaveBeenCalledWith("Vary", "User-Agent");
     expect(next).toHaveBeenCalledOnce();
   });
 

--- a/server/src/middleware/bot-seo.middleware.test.ts
+++ b/server/src/middleware/bot-seo.middleware.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+import { botSeoMiddleware } from "./bot-seo.middleware.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+function mockReq(userAgent: string = ""): Request {
+  return {
+    headers: { "user-agent": userAgent },
+  } as unknown as Request;
+}
+
+function mockRes(): Response & { _headers: Record<string, string> } {
+  const headers: Record<string, string> = {};
+  return {
+    _headers: headers,
+    setHeader: vi.fn((key: string, value: string) => {
+      headers[key] = value;
+    }),
+  } as unknown as Response & { _headers: Record<string, string> };
+}
+
+describe("botSeoMiddleware", () => {
+  it("should set X-Is-Bot: 1 for Googlebot", () => {
+    const req = mockReq("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)");
+    const res = mockRes();
+    const next = vi.fn();
+
+    botSeoMiddleware(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith("X-Is-Bot", "1");
+    expect(res.setHeader).toHaveBeenCalledWith("Vary", "User-Agent");
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("should set X-Is-Bot: 1 for Bingbot", () => {
+    const req = mockReq("Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)");
+    const res = mockRes();
+    const next = vi.fn();
+
+    botSeoMiddleware(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith("X-Is-Bot", "1");
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("should set X-Is-Bot: 1 for facebookexternalhit", () => {
+    const req = mockReq("facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)");
+    const res = mockRes();
+    const next = vi.fn();
+
+    botSeoMiddleware(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith("X-Is-Bot", "1");
+  });
+
+  it("should set X-Is-Bot: 1 for LinkedInBot", () => {
+    const req = mockReq("LinkedInBot/1.0 (compatible; Mozilla/5.0)");
+    const res = mockRes();
+    const next = vi.fn();
+
+    botSeoMiddleware(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith("X-Is-Bot", "1");
+  });
+
+  it("should NOT set X-Is-Bot for regular browser user-agents", () => {
+    const req = mockReq("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120");
+    const res = mockRes();
+    const next = vi.fn();
+
+    botSeoMiddleware(req, res, next);
+
+    // Should NOT have X-Is-Bot header set
+    expect(res._headers["X-Is-Bot"]).toBeUndefined();
+    // But should always set Vary
+    expect(res.setHeader).toHaveBeenCalledWith("Vary", "User-Agent");
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("should NOT set X-Is-Bot for empty user-agent", () => {
+    const req = mockReq("");
+    const res = mockRes();
+    const next = vi.fn();
+
+    botSeoMiddleware(req, res, next);
+
+    expect(res._headers["X-Is-Bot"]).toBeUndefined();
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("should always set Vary: User-Agent header", () => {
+    const req = mockReq("some-random-client");
+    const res = mockRes();
+    const next = vi.fn();
+
+    botSeoMiddleware(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith("Vary", "User-Agent");
+  });
+
+  it("should always call next()", () => {
+    const req = mockReq("Googlebot");
+    const res = mockRes();
+    const next = vi.fn();
+
+    botSeoMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+});

--- a/server/src/middleware/cache.middleware.test.ts
+++ b/server/src/middleware/cache.middleware.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+import { cacheMiddleware, clearCache, appCache } from "./cache.middleware.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+function mockReq(method: string = "GET", url: string = "/api/test"): Request {
+  return {
+    method,
+    originalUrl: url,
+    url,
+  } as unknown as Request;
+}
+
+function mockRes(): Response {
+  const locals: Record<string, unknown> = {};
+  const res = {
+    statusCode: 200,
+    locals,
+    setHeader: vi.fn(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  return res;
+}
+
+describe("cacheMiddleware", () => {
+  beforeEach(() => {
+    // Clear all cached entries between tests
+    appCache.flushAll();
+  });
+
+  it("should skip caching for non-GET requests", () => {
+    const middleware = cacheMiddleware();
+    const req = mockReq("POST");
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.setHeader).not.toHaveBeenCalled();
+  });
+
+  it("should return MISS on first GET request", () => {
+    const middleware = cacheMiddleware(300, "test");
+    const req = mockReq("GET", "/api/users");
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    // Middleware sets up response interception and calls next
+    expect(next).toHaveBeenCalledOnce();
+
+    // Simulate the route handler calling res.json()
+    res.json({ users: ["alice"] });
+
+    expect(res.setHeader).toHaveBeenCalledWith("X-Cache", "MISS");
+  });
+
+  it("should return HIT on second GET request to same URL", () => {
+    const middleware = cacheMiddleware(300, "test");
+    const url = "/api/cached-endpoint";
+
+    // First request: MISS
+    const req1 = mockReq("GET", url);
+    const res1 = mockRes();
+    const next1 = vi.fn();
+    middleware(req1, res1, next1);
+    res1.json({ data: "hello" });
+
+    // Second request: HIT
+    const req2 = mockReq("GET", url);
+    const res2 = mockRes();
+    const next2 = vi.fn();
+    middleware(req2, res2, next2);
+
+    expect(res2.setHeader).toHaveBeenCalledWith("X-Cache", "HIT");
+    expect(res2.json).toHaveBeenCalledWith({ data: "hello" });
+    // next should NOT be called on cache HIT
+    expect(next2).not.toHaveBeenCalled();
+  });
+
+  it("should NOT cache non-2xx responses", () => {
+    const middleware = cacheMiddleware(300, "test");
+    const url = "/api/error-endpoint";
+
+    // First request: 500 error
+    const req1 = mockReq("GET", url);
+    const res1 = mockRes();
+    res1.statusCode = 500;
+    const next1 = vi.fn();
+    middleware(req1, res1, next1);
+    res1.json({ error: "fail" });
+
+    // Second request: should still be a MISS
+    const req2 = mockReq("GET", url);
+    const res2 = mockRes();
+    const next2 = vi.fn();
+    middleware(req2, res2, next2);
+
+    expect(next2).toHaveBeenCalledOnce(); // No cache hit
+  });
+
+  it("should respect skipCache flag in res.locals", () => {
+    const middleware = cacheMiddleware(300, "test");
+    const url = "/api/skip-cache";
+
+    // First request with skipCache
+    const req1 = mockReq("GET", url);
+    const res1 = mockRes();
+    res1.locals["skipCache"] = true;
+    const next1 = vi.fn();
+    middleware(req1, res1, next1);
+    res1.json({ data: "no-cache" });
+
+    // Second request: should be a MISS since first was skipped
+    const req2 = mockReq("GET", url);
+    const res2 = mockRes();
+    const next2 = vi.fn();
+    middleware(req2, res2, next2);
+
+    expect(next2).toHaveBeenCalledOnce();
+  });
+
+  it("should use different cache keys for different URLs", () => {
+    const middleware = cacheMiddleware(300, "test");
+
+    // Cache /api/a
+    const req1 = mockReq("GET", "/api/a");
+    const res1 = mockRes();
+    middleware(req1, res1, vi.fn());
+    res1.json({ route: "a" });
+
+    // Cache /api/b
+    const req2 = mockReq("GET", "/api/b");
+    const res2 = mockRes();
+    middleware(req2, res2, vi.fn());
+    res2.json({ route: "b" });
+
+    // Verify /api/a returns its own cached data
+    const req3 = mockReq("GET", "/api/a");
+    const res3 = mockRes();
+    middleware(req3, res3, vi.fn());
+    expect(res3.json).toHaveBeenCalledWith({ route: "a" });
+
+    // Verify /api/b returns its own cached data
+    const req4 = mockReq("GET", "/api/b");
+    const res4 = mockRes();
+    middleware(req4, res4, vi.fn());
+    expect(res4.json).toHaveBeenCalledWith({ route: "b" });
+  });
+});
+
+describe("clearCache", () => {
+  beforeEach(() => {
+    appCache.flushAll();
+  });
+
+  it("should clear all keys matching a prefix", () => {
+    appCache.set("blog:/api/blog/1", { id: 1 });
+    appCache.set("blog:/api/blog/2", { id: 2 });
+    appCache.set("user:/api/users/1", { id: 1 });
+
+    clearCache("blog:");
+
+    expect(appCache.get("blog:/api/blog/1")).toBeUndefined();
+    expect(appCache.get("blog:/api/blog/2")).toBeUndefined();
+    // user cache should NOT be cleared
+    expect(appCache.get("user:/api/users/1")).toEqual({ id: 1 });
+  });
+
+  it("should do nothing if no keys match the prefix", () => {
+    appCache.set("blog:/api/blog/1", { id: 1 });
+
+    clearCache("nonexistent:");
+
+    expect(appCache.get("blog:/api/blog/1")).toEqual({ id: 1 });
+  });
+});

--- a/server/src/middleware/error.middleware.test.ts
+++ b/server/src/middleware/error.middleware.test.ts
@@ -168,34 +168,38 @@ describe("errorMiddleware", () => {
   describe("unknown errors", () => {
     it("should return 500 with generic message in production", () => {
       const originalEnv = process.env["NODE_ENV"];
-      process.env["NODE_ENV"] = "production";
+      try {
+        process.env["NODE_ENV"] = "production";
 
-      const err = new Error("something secret broke");
-      const req = mockReq();
-      const res = mockRes();
+        const err = new Error("something secret broke");
+        const req = mockReq();
+        const res = mockRes();
 
-      errorMiddleware(err, req, res, noop);
+        errorMiddleware(err, req, res, noop);
 
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ message: "Internal Server Error" });
-
-      process.env["NODE_ENV"] = originalEnv;
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ message: "Internal Server Error" });
+      } finally {
+        process.env["NODE_ENV"] = originalEnv;
+      }
     });
 
     it("should return 500 with actual message in development", () => {
       const originalEnv = process.env["NODE_ENV"];
-      process.env["NODE_ENV"] = "development";
+      try {
+        process.env["NODE_ENV"] = "development";
 
-      const err = new Error("detailed dev error");
-      const req = mockReq();
-      const res = mockRes();
+        const err = new Error("detailed dev error");
+        const req = mockReq();
+        const res = mockRes();
 
-      errorMiddleware(err, req, res, noop);
+        errorMiddleware(err, req, res, noop);
 
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ message: "detailed dev error" });
-
-      process.env["NODE_ENV"] = originalEnv;
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ message: "detailed dev error" });
+      } finally {
+        process.env["NODE_ENV"] = originalEnv;
+      }
     });
   });
 
@@ -209,6 +213,7 @@ describe("errorMiddleware", () => {
           email: "user@test.com",
           password: "secret123",
           token: "jwt-token",
+          cvv: "123",
           name: "Test User",
         },
       });
@@ -226,6 +231,7 @@ describe("errorMiddleware", () => {
         email: "user@test.com",
         password: "[REDACTED]",
         token: "[REDACTED]",
+        cvv: "[REDACTED]",
         name: "Test User",
       });
     });

--- a/server/src/middleware/error.middleware.test.ts
+++ b/server/src/middleware/error.middleware.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+
+// ── Mock Prisma before importing the module under test ──────────────
+vi.mock("../database/db.js", () => ({
+  prisma: {
+    errorLog: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+// We need real Prisma error classes, so import them directly
+import { Prisma } from "@prisma/client";
+import { errorMiddleware } from "./error.middleware.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+function mockReq(overrides: Partial<Request> = {}): Request {
+  return {
+    method: "POST",
+    originalUrl: "/api/test",
+    url: "/api/test",
+    ip: "127.0.0.1",
+    headers: { "user-agent": "vitest" },
+    body: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+function mockRes(): Response {
+  const res = {
+    statusCode: 200,
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  return res;
+}
+
+const noop: NextFunction = () => {};
+
+describe("errorMiddleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Prisma known request errors ───────────────────────────────────
+  describe("Prisma known request errors", () => {
+    it("should return 409 for P2002 (unique constraint violation)", () => {
+      const err = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "5.0.0",
+      });
+      const req = mockReq();
+      const res = mockRes();
+
+      errorMiddleware(err, req, res, noop);
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "A record with this value already exists",
+      });
+    });
+
+    it("should return 404 for P2025 (record not found)", () => {
+      const err = new Prisma.PrismaClientKnownRequestError("Record not found", {
+        code: "P2025",
+        clientVersion: "5.0.0",
+      });
+      const req = mockReq();
+      const res = mockRes();
+
+      errorMiddleware(err, req, res, noop);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: "Resource not found" });
+    });
+
+    it("should return 400 for P2003 (foreign key constraint)", () => {
+      const err = new Prisma.PrismaClientKnownRequestError("Foreign key constraint failed", {
+        code: "P2003",
+        clientVersion: "5.0.0",
+      });
+      const req = mockReq();
+      const res = mockRes();
+
+      errorMiddleware(err, req, res, noop);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: "Related resource not found" });
+    });
+
+    it("should return 500 for unknown Prisma error codes", () => {
+      const err = new Prisma.PrismaClientKnownRequestError("Unknown error", {
+        code: "P9999",
+        clientVersion: "5.0.0",
+      });
+      const req = mockReq();
+      const res = mockRes();
+
+      errorMiddleware(err, req, res, noop);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: "Database error" });
+    });
+  });
+
+  // ── Prisma validation errors ──────────────────────────────────────
+  describe("Prisma validation errors", () => {
+    it("should return 400 for PrismaClientValidationError", () => {
+      const err = new Prisma.PrismaClientValidationError("Validation failed", {
+        clientVersion: "5.0.0",
+      });
+      const req = mockReq();
+      const res = mockRes();
+
+      errorMiddleware(err, req, res, noop);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: "Invalid data provided" });
+    });
+  });
+
+  // ── Multer / file upload errors ───────────────────────────────────
+  describe("Multer / file upload errors", () => {
+    it.each([
+      "File type not allowed",
+      "Only PDF and Word documents are allowed",
+      "Only JPEG, PNG, and WebP images are allowed",
+    ])('should return 400 for "%s"', (message) => {
+      const err = new Error(message);
+      const req = mockReq();
+      const res = mockRes();
+
+      errorMiddleware(err, req, res, noop);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message });
+    });
+  });
+
+  // ── Business-logic client errors ──────────────────────────────────
+  describe("business-logic client errors", () => {
+    it.each([
+      ["Email already registered", 409],
+      ["Invalid email or password", 401],
+      ["Account is deactivated", 403],
+      ["Not authorized", 403],
+      ["User not found", 404],
+      ["Job not found", 404],
+      ["Application not found", 404],
+      ["Company not found", 404],
+      ["Already applied", 409],
+      ["Invalid Google token", 401],
+      ["Topic not found", 404],
+    ] as const)('should return %i for "%s"', (message, expectedStatus) => {
+      const err = new Error(message);
+      const req = mockReq();
+      const res = mockRes();
+
+      errorMiddleware(err, req, res, noop);
+
+      expect(res.status).toHaveBeenCalledWith(expectedStatus);
+      expect(res.json).toHaveBeenCalledWith({ message });
+    });
+  });
+
+  // ── Unknown / unhandled errors ────────────────────────────────────
+  describe("unknown errors", () => {
+    it("should return 500 with generic message in production", () => {
+      const originalEnv = process.env["NODE_ENV"];
+      process.env["NODE_ENV"] = "production";
+
+      const err = new Error("something secret broke");
+      const req = mockReq();
+      const res = mockRes();
+
+      errorMiddleware(err, req, res, noop);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: "Internal Server Error" });
+
+      process.env["NODE_ENV"] = originalEnv;
+    });
+
+    it("should return 500 with actual message in development", () => {
+      const originalEnv = process.env["NODE_ENV"];
+      process.env["NODE_ENV"] = "development";
+
+      const err = new Error("detailed dev error");
+      const req = mockReq();
+      const res = mockRes();
+
+      errorMiddleware(err, req, res, noop);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: "detailed dev error" });
+
+      process.env["NODE_ENV"] = originalEnv;
+    });
+  });
+
+  // ── Sensitive data sanitization ───────────────────────────────────
+  describe("sensitive data sanitization", () => {
+    it("should redact sensitive fields in request body before logging", async () => {
+      const { prisma } = await import("../database/db.js");
+      const err = new Error("User not found");
+      const req = mockReq({
+        body: {
+          email: "user@test.com",
+          password: "secret123",
+          token: "jwt-token",
+          name: "Test User",
+        },
+      });
+      const res = mockRes();
+
+      errorMiddleware(err, req, res, noop);
+
+      // Give the async create a tick to resolve
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(prisma.errorLog.create).toHaveBeenCalled();
+      const callArg = (prisma.errorLog.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      const body = callArg?.data?.requestBody;
+      expect(body).toEqual({
+        email: "user@test.com",
+        password: "[REDACTED]",
+        token: "[REDACTED]",
+        name: "Test User",
+      });
+    });
+  });
+});

--- a/server/src/middleware/role.middleware.test.ts
+++ b/server/src/middleware/role.middleware.test.ts
@@ -75,6 +75,7 @@ describe("requireRole middleware", () => {
     middleware(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ message: "Insufficient permissions" });
     expect(next).not.toHaveBeenCalled();
   });
 });

--- a/server/src/middleware/role.middleware.test.ts
+++ b/server/src/middleware/role.middleware.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+import type { UserRole } from "@prisma/client";
+import { requireRole } from "./role.middleware.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+function mockReq(user?: { id: number; email: string; role: UserRole }): Request {
+  return { user } as unknown as Request;
+}
+
+function mockRes(): Response {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  return res;
+}
+
+describe("requireRole middleware", () => {
+  it("should return 401 if no user is attached to request", () => {
+    const middleware = requireRole("ADMIN");
+    const req = mockReq(); // no user
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ message: "Authentication required" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("should return 403 if user role is not in allowed list", () => {
+    const middleware = requireRole("ADMIN");
+    const req = mockReq({ id: 1, email: "s@t.com", role: "STUDENT" });
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ message: "Insufficient permissions" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("should call next() if user role matches a single allowed role", () => {
+    const middleware = requireRole("STUDENT");
+    const req = mockReq({ id: 1, email: "s@t.com", role: "STUDENT" });
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("should call next() if user role matches one of multiple allowed roles", () => {
+    const middleware = requireRole("STUDENT", "RECRUITER");
+    const req = mockReq({ id: 2, email: "r@t.com", role: "RECRUITER" });
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("should return 403 when user role is not in a multi-role list", () => {
+    const middleware = requireRole("STUDENT", "RECRUITER");
+    const req = mockReq({ id: 3, email: "a@t.com", role: "ADMIN" });
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #621

## Summary

Adds **43 unit tests** across 4 new test files for the server middleware layer, bringing the untested `server/src/middleware/` directory from 0% to meaningful test coverage.

Zero existing files modified — only new `*.test.ts` files added.

## Changes

| File | Tests | Coverage |
|---|---|---|
| `error.middleware.test.ts` | 22 | Prisma error code → HTTP status mapping (P2002→409, P2025→404, P2003→400), validation errors→400, Multer file-type errors, 11 business-logic message→status mappings, production error masking, dev error detail exposure, sensitive field redaction (password, token, cvv) |
| `role.middleware.test.ts` | 5 | 401 when no user, 403 when role excluded, pass-through for matching single/multi role |
| `bot-seo.middleware.test.ts` | 8 | Detection for Googlebot, Bingbot, facebookexternalhit, LinkedInBot; pass-through for browsers and empty UA; Vary header always set |
| `cache.middleware.test.ts` | 8 | GET-only caching, HIT/MISS headers, non-2xx skip, skipCache flag, URL key isolation, clearCache prefix matching |

## How to test

```bash
cd server

# Run only middleware tests
npx vitest run src/middleware/ --reporter=verbose
# ✅ 43/43 pass

# Run full test suite
npx vitest run --reporter=verbose
# ✅ 90/90 pass

### GSSoC '26 Contribution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for middleware: bot/crawler detection, HTTP caching behavior and cache clearing, centralized error handling and logging with sensitive-data redaction, and role-based authorization checks across missing, unauthorized, and allowed-role scenarios. No public APIs changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->