### PR TITLE
feat: add error state and retry logic for round submission

### DIFF
--- a/client/src/module/student/applications/ApplicationProgressPage.tsx
+++ b/client/src/module/student/applications/ApplicationProgressPage.tsx
@@ -129,8 +129,8 @@ export default function ApplicationProgressPage() {
                   )}
                   <h3 className="font-semibold text-gray-900 dark:text-white">Round {i + 1}: {round.name}</h3>
                   <span className={`text-xs px-2 py-0.5 rounded-full ${isCompleted ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" :
-                      isActive ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400" :
-                        "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500"
+                    isActive ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400" :
+                      "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500"
                     }`}>
                     {isCompleted ? "Completed" : isActive ? "In Progress" : "Pending"}
                   </span>
@@ -184,6 +184,21 @@ export default function ApplicationProgressPage() {
                 {/* Active round: show form or assessment */}
                 {isActive && !isCompleted && (
                   <div className="ml-8 mt-4">
+                    {/* Error banner shown for BOTH assessment and custom field submissions */}
+                    {submitError && (
+                      <div aria-live="polite" className="flex items-center gap-3 p-3 mb-3 bg-red-50 dark:bg-red-900/30 rounded-lg text-sm text-red-600 dark:text-red-400">
+                        <span>{submitError}</span>
+                        <Button
+                          variant="mono"
+                          size="sm"
+                          aria-label="Retry submission"
+                          disabled={submitting}
+                          onClick={() => lastPayload.current && handleSubmitRound(lastPayload.current.roundId, lastPayload.current.answers)}
+                        >
+                          {submitting ? "Retrying..." : "Retry"}
+                        </Button>
+                      </div>
+                    )}
                     {activeRoundId === round.id ? (
                       hasAssessment ? (
                         <AssessmentTestView
@@ -203,28 +218,12 @@ export default function ApplicationProgressPage() {
                               onChange={(fieldId, value) => setFieldAnswers({ ...fieldAnswers, [fieldId]: value })}
                             />
                           )}
-                          <div className="space-y-2">
-                            {submitError && (
-                              <div aria-live="polite" className="flex items-center gap-3 p-3 bg-red-50 dark:bg-red-900/30 rounded-lg text-sm text-red-600 dark:text-red-400">
-                                <span>{submitError}</span>
-                                <Button
-                                  variant="mono"
-                                  size="sm"
-                                  aria-label="Retry submission"
-                                  disabled={submitting}
-                                  onClick={() => lastPayload.current && handleSubmitRound(lastPayload.current.roundId, lastPayload.current.answers)}
-                                >
-                                  {submitting ? "Retrying..." : "Retry"}
-                                </Button>
-                              </div>
-                            )}
-                            <div className="flex items-center gap-3">
-                              <Button variant="mono" onClick={() => handleSubmitRound(round.id)} disabled={submitting}>
-                                <Send className="w-4 h-4" />
-                                {submitting ? "Submitting..." : "Submit Round"}
-                              </Button>
-                              <Button variant="ghost" onClick={() => { setActiveRoundId(null); setSubmitError(null); }} className="text-gray-500 hover:text-black dark:hover:text-white">Cancel</Button>
-                            </div>
+                          <div className="flex items-center gap-3">
+                            <Button variant="mono" onClick={() => handleSubmitRound(round.id)} disabled={submitting}>
+                              <Send className="w-4 h-4" />
+                              {submitting ? "Submitting..." : "Submit Round"}
+                            </Button>
+                            <Button variant="ghost" onClick={() => { setActiveRoundId(null); setSubmitError(null); }} className="text-gray-500 hover:text-black dark:hover:text-white">Cancel</Button>
                           </div>
                         </div>
                       )


### PR DESCRIPTION
# Pull Request

## Description
Adds error state handling and retry logic for round submissions in ApplicationProgressPage. When a round submission fails (both custom field and assessment types), users now see a clear error banner with the failure message and a retry button to resubmit without losing their answers. Previously, assessment submission failures showed no feedback as the error banner was only rendered in the custom fields branch.

## Related Issue
Fixes #461

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing
Tested manually by triggering a failed submission on both assessment and custom field rounds. Verified that the error banner appears in both cases and the retry button resubmits correctly.

## Screenshots
(if applicable)

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [ ] Screenshots added for UI changes (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added retry button to submission error banner, allowing quick resubmission of failed submissions.

* **Bug Fixes**
  * Submission errors now display earlier and more prominently for assessment and custom field submissions.
  * Improved visual organization of submission controls for better clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->