### PR TITLE
feat: persist Program Tracker filters to localStorage

### DIFF
--- a/client/src/module/student/opensource/ProgramTrackerPage.tsx
+++ b/client/src/module/student/opensource/ProgramTrackerPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   Search, ExternalLink, GraduationCap, ChevronDown, ChevronUp,
@@ -478,6 +478,8 @@ const PROGRAMS: Program[] = [
   },
 ];
 
+const STORAGE_KEY = "program_tracker_filters";
+
 const ELIGIBILITY_OPTIONS = ["All", "Students", "Open to All", "Diversity-focused"];
 const STATUS_OPTIONS = ["All", "Annual", "Ongoing", "Batch"];
 const STIPEND_OPTIONS = ["All", "Paid", "High ($5k+)", "Medium ($1k–5k)", "Low/None"];
@@ -645,10 +647,41 @@ function ProgramCard({ program }: { program: Program }) {
 
 // ─── Page ────────────────────────────────────────────────────────
 export default function ProgramTrackerPage() {
+  // Load saved filters from localStorage on mount, fall back to defaults
+  const getSavedFilters = () => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        return JSON.parse(saved);
+      }
+    } catch {
+      // ignore parse errors
+    }
+    return { status: "All", eligibility: "All", stipend: "All" };
+  };
+
+  const savedFilters = getSavedFilters();
+
   const [search, setSearch] = useState("");
-  const [selectedStatus, setSelectedStatus] = useState("All");
-  const [selectedEligibility, setSelectedEligibility] = useState("All");
-  const [selectedStipend, setSelectedStipend] = useState("All");
+  const [selectedStatus, setSelectedStatus] = useState<string>(savedFilters.status);
+  const [selectedEligibility, setSelectedEligibility] = useState<string>(savedFilters.eligibility);
+  const [selectedStipend, setSelectedStipend] = useState<string>(savedFilters.stipend);
+
+  // Save filters to localStorage whenever they change
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          status: selectedStatus,
+          eligibility: selectedEligibility,
+          stipend: selectedStipend,
+        })
+      );
+    } catch {
+      // ignore storage errors
+    }
+  }, [selectedStatus, selectedEligibility, selectedStipend]);
 
   const filtered = useMemo(() => {
     let list = [...PROGRAMS];

--- a/client/src/module/student/opensource/ProgramTrackerPage.tsx
+++ b/client/src/module/student/opensource/ProgramTrackerPage.tsx
@@ -649,16 +649,23 @@ function ProgramCard({ program }: { program: Program }) {
 export default function ProgramTrackerPage() {
   // Load saved filters from localStorage on mount, fall back to defaults
   const getSavedFilters = () => {
-    try {
-      const saved = localStorage.getItem(STORAGE_KEY);
-      if (saved) {
-        return JSON.parse(saved);
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      if (parsed && typeof parsed === "object") {
+        return {
+          status: STATUS_OPTIONS.includes(parsed.status) ? parsed.status : "All",
+          eligibility: ELIGIBILITY_OPTIONS.includes(parsed.eligibility) ? parsed.eligibility : "All",
+          stipend: STIPEND_OPTIONS.includes(parsed.stipend) ? parsed.stipend : "All",
+        };
       }
-    } catch {
-      // ignore parse errors
     }
-    return { status: "All", eligibility: "All", stipend: "All" };
-  };
+  } catch {
+    // ignore errors
+  }
+  return { status: "All", eligibility: "All", stipend: "All" };
+};
 
   const savedFilters = getSavedFilters();
 


### PR DESCRIPTION
Fixes #690

Changes made:
- Added useEffect to save filters to localStorage on every change
- On page load, filters are read from localStorage
- Falls back to default values if localStorage is empty or invalid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter selections for program status, eligibility, and stipend are now persisted across sessions, allowing you to maintain your preferred filter settings when returning to the page.
  * Your most recent filter choices are automatically restored on revisit and saved whenever you change them, so you won't need to reconfigure filters each visit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->