### PR TITLE
fix: disable repo submission for invalid GitHub URLs

### DIFF
--- a/client/src/module/student/opensource/SuggestRepoModal.tsx
+++ b/client/src/module/student/opensource/SuggestRepoModal.tsx
@@ -107,6 +107,8 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
 
   if (!open) return null;
 
+  const parsedRepo = parseGithubRepoUrl(form.url);
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -235,7 +237,7 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
               type="submit"
               variant="mono"
               size="lg"
-              disabled={mutation.isPending}
+              disabled={mutation.isPending || !parsedRepo}
               className="w-full rounded-xl"
             >
               {mutation.isPending ? (


### PR DESCRIPTION
# Pull Request

## Description

Fixes the issue where the repository suggestion form could still be submitted after GitHub URL parsing failed.

The URL parser (`parseGithubRepoUrl`) already correctly rejects malformed GitHub URLs by returning `null`, but the submit button was only disabled while a mutation was in progress. As a result, users could still attempt to submit the form with an invalid repository URL.

This change disables the submit button whenever the GitHub URL does not resolve to a valid owner/repository pair.

## Related Issue

Fixes #668

## Type of Change

* [x] Bug Fix
* [ ] Feature
* [ ] Enhancement
* [ ] Documentation

## Testing

Verified that:

1. Invalid GitHub URLs keep the submit button disabled.
2. Existing inline validation messages are still displayed.
3. Valid GitHub URLs continue to auto-fill owner and repository fields.
4. Valid GitHub URLs enable submission as expected.

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually
* [x] No credentials or generated files committed
* [ ] Docs updated (not needed)
* [ ] Screenshots added (not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added GitHub URL validation in the repository suggestion form, preventing submission of incorrectly formatted URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->