### PR TITLE
feat: implement duplicate enrollment prevention and max limit guards …

### DIFF
--- a/client/src/components/ui/toast.tsx
+++ b/client/src/components/ui/toast.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { motion } from "framer-motion";
 import {
   Toaster as SonnerToaster,
@@ -52,7 +53,7 @@ function ToastContent({
 }: {
   toastId: string | number;
   variant: Variant;
-  message: string;
+  message: ReactNode;
 }) {
   const Icon = variantIcons[variant];
 
@@ -70,7 +71,7 @@ function ToastContent({
     >
       <div className="flex items-start gap-2">
         <Icon className={cn("h-4 w-4 mt-0.5 shrink-0", iconColor[variant])} />
-        <p className="text-xs text-muted-foreground">{message}</p>
+        <div className="text-xs text-muted-foreground">{message}</div>
       </div>
 
       <button
@@ -91,7 +92,7 @@ interface ToastOptions {
   id?: string;
 }
 
-function show(variant: Variant, message: string, opts?: ToastOptions) {
+function show(variant: Variant, message: ReactNode, opts?: ToastOptions) {
   sonnerToast.custom(
     (toastId) => (
       <ToastContent toastId={toastId} variant={variant} message={message} />
@@ -101,10 +102,11 @@ function show(variant: Variant, message: string, opts?: ToastOptions) {
 }
 
 const toast = {
-  success: (msg: string, opts?: ToastOptions) => show("success", msg, opts),
-  error: (msg: string, opts?: ToastOptions) => show("error", msg, opts),
-  info: (msg: string, opts?: ToastOptions) => show("default", msg, opts),
-  warning: (msg: string, opts?: ToastOptions) => show("warning", msg, opts),
+  success: (msg: ReactNode, opts?: ToastOptions) => show("success", msg, opts),
+  error: (msg: ReactNode, opts?: ToastOptions) => show("error", msg, opts),
+  info: (msg: ReactNode, opts?: ToastOptions) => show("default", msg, opts),
+  warning: (msg: ReactNode, opts?: ToastOptions) => show("warning", msg, opts),
+  dismiss: (id?: string | number) => sonnerToast.dismiss(id),
 };
 
 // eslint-disable-next-line react-refresh/only-export-components

--- a/client/src/lib/types/roadmap.types.ts
+++ b/client/src/lib/types/roadmap.types.ts
@@ -150,6 +150,7 @@ export interface RoadmapEnrollmentListItem {
     coverImage: string | null;
     topicCount: number;
     estimatedHours: number;
+    ownerUserId: number | null;
   };
   createdAt: string;
 }

--- a/client/src/module/student/roadmap/AiRoadmapWizardPage.tsx
+++ b/client/src/module/student/roadmap/AiRoadmapWizardPage.tsx
@@ -15,6 +15,7 @@ import { SEO } from "../../../components/SEO";
 import { Button } from "../../../components/ui/button";
 import { Navbar } from "../../../components/Navbar";
 import { useStudentSidebar } from "../../../components/StudentSidebar";
+import { useAuthStore } from "../../../lib/auth.store";
 import api from "../../../lib/axios";
 import toast from "../../../components/ui/toast";
 import type { DayOfWeek, RoadmapEnrollmentListItem } from "../../../lib/types";
@@ -81,6 +82,7 @@ function Chrome({ children, sidebarWidth, collapsed, sidebar }: {
 
 export default function AiRoadmapWizardPage() {
   const navigate = useNavigate();
+  const { user } = useAuthStore();
   const { collapsed, sidebarWidth, sidebar } = useStudentSidebar();
   const [step, setStep] = useState(0);
 
@@ -98,14 +100,30 @@ export default function AiRoadmapWizardPage() {
   // Submission
   const [submitting, setSubmitting] = useState(false);
   const [submitMsgIdx, setSubmitMsgIdx] = useState(0);
+  const [dismissedWarning, setDismissedWarning] = useState(false);
 
   // Existing enrollments link
   const { data: enrollmentsData } = useQuery({
     queryKey: queryKeys.roadmaps.enrollments(),
     queryFn: () => api.get<{ enrollments: RoadmapEnrollmentListItem[] }>("/roadmaps/me/enrollments").then(res => res.data),
+    enabled: !!user,
+    staleTime: 2 * 60 * 1000,
   });
 
   const enrollments = enrollmentsData?.enrollments || [];
+
+  const similarEnrollment = (() => {
+    if (!user) return null;
+    const userAiRoadmaps = enrollments.filter(e => e.roadmap.ownerUserId === user.id);
+    const normalize = (str: string) => str.toLowerCase().replace(/[^\w\s]/g, "");
+    const goalNorm = normalize(goalDescription);
+    if (!goalNorm) return null;
+    
+    return userAiRoadmaps.find(e => {
+      const titleNorm = normalize(e.roadmap.title);
+      return titleNorm.includes(goalNorm) || goalNorm.includes(titleNorm);
+    });
+  })();
 
   // Rotating loading copy
   useEffect(() => {
@@ -124,7 +142,7 @@ export default function AiRoadmapWizardPage() {
     return true;
   })();
 
-  const submit = async () => {
+  const submit = async (force = false) => {
     setSubmitting(true);
     try {
       const res = await api.post<{ slug: string; enrollmentId: number }>(
@@ -139,14 +157,51 @@ export default function AiRoadmapWizardPage() {
           knownSkills,
           mustInclude,
           avoid,
+          forceCreate: force,
         },
       );
       toast.success("Your roadmap is ready");
       navigate(`/learn/roadmaps/${res.data.slug}`);
-    } catch (err) {
-      const msg = (err as { response?: { data?: { message?: string } } }).response?.data?.message
-        ?? "Could not generate roadmap. Please try again.";
-      toast.error(msg);
+    } catch (err: any) {
+      if (err.response?.status === 409) {
+        if (err.response.data.message.includes("limit")) {
+          toast.error(
+            <div className="flex flex-col gap-2 p-1 text-left">
+              <p>You have reached the limit of 5 active AI roadmaps. Please complete or delete existing ones first.</p>
+              <Link to="/student/roadmaps" className="text-sm font-bold text-stone-950 dark:text-stone-50 hover:underline">
+                Manage roadmaps →
+              </Link>
+            </div>,
+            { duration: 8000 }
+          );
+        } else if (err.response.data.roadmap) {
+          const duplicate = err.response.data.roadmap;
+          toast.warning(
+            <div className="flex flex-col gap-2 p-1 text-left">
+              <p className="font-bold">Similar roadmap exists</p>
+              <p className="text-[10px] opacity-70">We found &quot;{duplicate.title}&quot; which seems similar to your goal.</p>
+              <div className="flex items-center gap-3 mt-1">
+                <Link to={`/learn/roadmaps/${duplicate.slug}`} className="text-xs font-bold text-stone-950 dark:text-stone-50 hover:underline">
+                  View existing
+                </Link>
+                <button 
+                  onClick={() => {
+                    toast.dismiss();
+                    submit(true);
+                  }}
+                  className="text-xs font-bold text-lime-600 dark:text-lime-400 hover:underline bg-transparent border-0 p-0 cursor-pointer"
+                >
+                  Create anyway
+                </button>
+              </div>
+            </div>,
+            { duration: 10000 }
+          );
+        }
+      } else {
+        const msg = err.response?.data?.message ?? "Could not generate roadmap. Please try again.";
+        toast.error(msg);
+      }
       setSubmitting(false);
     }
   };
@@ -489,23 +544,53 @@ export default function AiRoadmapWizardPage() {
           </motion.div>
         </AnimatePresence>
 
-        <div className="flex items-center justify-between mt-8">
-          <Button variant="ghost" onClick={() => setStep((s) => Math.max(0, s - 1))} disabled={step === 0}>
-            <ChevronLeft className="w-4 h-4" />
-            Back
-          </Button>
-          {step < STEPS.length - 1 ? (
-            <Button variant="mono" onClick={() => setStep((s) => s + 1)} disabled={!canProceed}>
-              Next
-              <ChevronRight className="w-4 h-4" />
-            </Button>
-          ) : (
-            <Button variant="mono" onClick={submit} disabled={!canProceed}>
-              <Wand2 className="w-4 h-4" />
-              Generate my roadmap
-              <ArrowRight className="w-4 h-4" />
-            </Button>
+        <div className="flex flex-col gap-4 mt-8">
+          {step === STEPS.length - 1 && similarEnrollment && !dismissedWarning && (
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-xl p-4 flex gap-3 text-amber-900 dark:text-amber-200 relative"
+            >
+              <div className="flex-1 text-sm">
+                <p className="font-medium mb-1">
+                  You already have a roadmap for &quot;{similarEnrollment.roadmap.title}&quot;.
+                </p>
+                <p className="opacity-80">Generating again will create a separate copy.</p>
+                <Link
+                  to={`/learn/roadmaps/${similarEnrollment.roadmap.slug}`}
+                  className="inline-block mt-2 text-amber-700 dark:text-amber-400 font-bold hover:underline"
+                >
+                  View existing →
+                </Link>
+              </div>
+              <button
+                type="button"
+                onClick={() => setDismissedWarning(true)}
+                className="text-amber-500 hover:text-amber-700 dark:hover:text-amber-300 self-start"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </motion.div>
           )}
+
+          <div className="flex items-center justify-between">
+            <Button variant="ghost" onClick={() => setStep((s) => Math.max(0, s - 1))} disabled={step === 0}>
+              <ChevronLeft className="w-4 h-4" />
+              Back
+            </Button>
+            {step < STEPS.length - 1 ? (
+              <Button variant="mono" onClick={() => setStep((s) => s + 1)} disabled={!canProceed}>
+                Next
+                <ChevronRight className="w-4 h-4" />
+              </Button>
+            ) : (
+              <Button variant="mono" onClick={() => submit(false)} disabled={!canProceed}>
+                <Wand2 className="w-4 h-4" />
+                Generate my roadmap
+                <ArrowRight className="w-4 h-4" />
+              </Button>
+            )}
+          </div>
         </div>
       </div>
     </Chrome>

--- a/server/src/module/roadmap/roadmap.controller.ts
+++ b/server/src/module/roadmap/roadmap.controller.ts
@@ -467,19 +467,35 @@ export async function postAiGenerate(req: Request, res: Response, next: NextFunc
     const userId = req.user!.id;
     const input = parsed.data;
 
+    // 1. Enforce max capacity threshold guard
+    const MAX_AI_ROADMAPS = 5;
+    const existingCount = await prisma.roadmapEnrollment.count({
+      where: {
+        userId,
+        roadmap: { ownerUserId: userId },
+      },
+    });
+
+    if (existingCount >= MAX_AI_ROADMAPS) {
+      res.status(409).json({
+        message: "You have reached the limit of 5 active AI roadmaps. Please complete or delete existing ones before generating new ones.",
+      });
+      return;
+    }
+
+    // 2. Evaluate similarity duplicate check block
     const duplicate = await findDuplicateRoadmap(
-  input.goalDescription,
-  userId
-);
+      input.goalDescription,
+      userId
+    );
 
-if (duplicate && !input.forceCreate) {
-  res.status(409).json({
-    message: "Similar roadmap already exists",
-    roadmap: duplicate,
-  });
-
-  return;
-}
+    if (duplicate && !input.forceCreate) {
+      res.status(409).json({
+        message: "Similar roadmap already exists",
+        roadmap: duplicate,
+      });
+      return;
+    }
 
     // 1. Generate via Gemini, validate shape
     let generated;
@@ -859,7 +875,7 @@ export async function postRegenerateSection(req: Request, res: Response, next: N
     };
 
     const updatedSection = await prisma.$transaction(async (tx) => {
-      
+
       await tx.roadmapTopic.deleteMany({ where: { sectionId } });
 
       await tx.roadmapSection.update({

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -14,21 +14,28 @@ export async function findDuplicateRoadmap(
   goalDescription: string,
   userId: number
 ) {
-  const normalizedGoal = goalDescription.trim();
+  const normalizedGoal = goalDescription.toLowerCase().trim();
   if (!normalizedGoal) return null;
 
+  // Simple keyword-based similarity: extract significant words
+  const keywords = normalizedGoal
+    .split(/\s+/)
+    .filter((w) => w.length >= 3 && !["want", "learn", "how", "for", "the", "and"].includes(w));
+
+  if (keywords.length === 0) return null;
+
+  // We'll search for roadmaps where the title contains at least one of the major keywords
+  // and then we can do a secondary check if needed, or just let the user Decide.
+  // For now, let's find the most recent one that matches.
   return prisma.roadmap.findFirst({
     where: {
       ownerUserId: userId,
       isAiGenerated: true,
-      slug: {
-        startsWith: 'ai-',
-      },
-      title: {
-        contains: normalizedGoal.slice(0, 30),
-        mode: 'insensitive',
-      },
+      OR: keywords.map(kw => ({
+        title: { contains: kw, mode: 'insensitive' }
+      }))
     },
+    orderBy: { updatedAt: 'desc' }
   });
 }
 export interface EnrolledRoadmap {
@@ -362,6 +369,7 @@ export async function listEnrollmentsForUser(userId: number) {
           coverImage: true,
           topicCount: true,
           estimatedHours: true,
+          ownerUserId: true,
         },
       },
       topicProgress: true,


### PR DESCRIPTION
## Description
No guard existed to prevent users from generating duplicate AI roadmaps. A user could generate the same roadmap concept multiple times, filling their dashboard with near-identical enrollments and wasting AI API credits.

Two-layer protection added:
- Frontend: warning banner on wizard summary step when a similar title already exists in the user's enrollments
- Backend: hard cap of 5 active AI-generated roadmaps per user, returns 409 with a clear message and link to manage existing ones

## Related Issue
Fixes #626

## Type of Change
- [x] Bug Fix
- [x] Enhancement

## Testing
1. Generate 5 AI roadmaps — 6th shows 409 error with clear message
2. Start wizard with same topic as existing roadmap — warning banner appears above Generate button
3. Dismiss warning and proceed — generation works normally
4. Different topic with no similar roadmap — no warning shown
5. Link to /student/roadmaps works from error message

## Screenshots

- Before

<img width="1843" height="865" alt="Screenshot 2026-05-29 175544" src="https://github.com/user-attachments/assets/a48094c8-6edc-444e-b18f-17d4b8d7406e" />

---

<img width="1634" height="559" alt="Screenshot 2026-05-29 184827" src="https://github.com/user-attachments/assets/2017f4d1-43fd-460e-a0cb-0ecc6f7117c9" />

---

- After

<img width="948" height="568" alt="Screenshot 2026-05-29 184531" src="https://github.com/user-attachments/assets/679c101a-c6a7-41be-862f-b787a5c18e76" />

---

<img width="1895" height="893" alt="Screenshot 2026-05-29 185849" src="https://github.com/user-attachments/assets/79291ac5-9740-4673-8927-48c8800945f1" />

---

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed