### PR TITLE
fix: add Prisma client generation step to test-server CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,10 @@ jobs:
         run: npm ci
         working-directory: server
 
+      - name: Generate Prisma client
+        run: npx prisma generate --schema=src/database/prisma/schema
+        working-directory: server
+
       - name: Run unit tests
         run: npm test
         working-directory: server


### PR DESCRIPTION
## Problem
The `test-server` CI job was failing with:
`Cannot find module '.prisma/client/default'`

## Root Cause
The `typecheck-server` job generates the Prisma client before running,
but the `test-server` job was missing this step. Tests import Prisma
types and fail when the client hasn't been generated.

## Fix
Added the `Generate Prisma client` step to the `test-server` job,
right before `Run unit tests` — matching the pattern already used
in `typecheck-server`.

## Changed File
`.github/workflows/ci.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI testing process to ensure proper build setup before running unit tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/789?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->