### PR TITLE
fix: apply DSA CSV import body limit before global parser

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -156,6 +156,8 @@ app.get("/api/health", (_req, res) => {
 app.use("/api/email-inbound/webhook", express.raw({ type: "application/json" }));
 // Raw body for Dodo Payments webhook (must be BEFORE express.json())
 app.use(PAYMENT_WEBHOOK_PATH, express.raw({ type: "application/json" }));
+// Larger body parser for DSA CSV import (must be BEFORE the global parser)
+app.use("/api/dsa/import/csv", express.json({ limit: "6mb" }));
 
 app.use(express.json());
 app.use(cookieParser());
@@ -343,5 +345,4 @@ app.listen(PORT, async () => {
 app.get("/", (req, res) => {
   res.send("Server Running Successfully");
 });
-
 

--- a/server/src/module/dsa/dsa.routes.ts
+++ b/server/src/module/dsa/dsa.routes.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import express from "express";
 import { DsaController } from "./dsa.controller.js";
 import { DsaService } from "./dsa.service.js";
 import { DsaImportController } from "./dsa-import.controller.js";
@@ -18,7 +17,7 @@ export const dsaRouter = Router();
 
 // ── LeetCode / CSV import routes (must be before /:id catch-alls) ──
 dsaRouter.post("/import/leetcode", authMiddleware, requireRole("STUDENT"), (req, res, next) => dsaImportController.previewLeetcode(req, res, next));
-dsaRouter.post("/import/csv", authMiddleware, requireRole("STUDENT"), express.json({ limit: "6mb" }), (req, res, next) => dsaImportController.previewCsv(req, res, next));
+dsaRouter.post("/import/csv", authMiddleware, requireRole("STUDENT"), (req, res, next) => dsaImportController.previewCsv(req, res, next));
 dsaRouter.post("/import/confirm", authMiddleware, requireRole("STUDENT"), (req, res, next) => dsaImportController.confirm(req, res, next));
 dsaRouter.get("/import/status", authMiddleware, requireRole("STUDENT"), (req, res, next) => dsaImportController.status(req, res, next));
 


### PR DESCRIPTION
# Pull Request

## Description
Fixes the DSA CSV import body parser ordering so the `6mb` JSON limit is applied before the global `express.json()` middleware.

The CSV import endpoint previously declared `express.json({ limit: "6mb" })` inside `dsa.routes.ts`, but by then the global parser in `index.ts` had already parsed or rejected the request. This moves the DSA CSV parser to `server/src/index.ts` before the global parser, matching the existing webhook parser pattern.

## Related Issue
Closes #776

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing
- `cd server && npm run typecheck`
- `cd server && npm test`
- `cd server && npm run lint`

## Screenshots
N/A - backend middleware fix.

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] Screenshots added for UI changes (if applicable)

Raised as part of GSSoC 2026. Maintainers, please add the relevant GSSoC label if this PR is eligible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced CSV import functionality to support larger file uploads (up to 6MB).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->