### PR TITLE
fix: gate /recommendations API calls behind authenticated session

### DIFF
--- a/client/src/module/student/learn/LearnHubPage.tsx
+++ b/client/src/module/student/learn/LearnHubPage.tsx
@@ -16,19 +16,28 @@ import {
   type WeakArea,
 } from "./components/RecommendationCard";
 import api from "../../../lib/axios";
+import { useAuthStore } from "../../../lib/auth.store";
 
 export default function LearnHubPage() {
   const [search, setSearch] = useState("");
   const [weakAreas, setWeakAreas] = useState<WeakArea[]>([]);
   const [loadingRecs, setLoadingRecs] = useState(true);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const userRole = useAuthStore((s) => s.user?.role);
 
   useEffect(() => {
+    if (!isAuthenticated || userRole !== "STUDENT") {
+      setWeakAreas([]);
+      setLoadingRecs(false);
+      return;
+    }
+
     api
       .get<{ weakAreas: WeakArea[] }>("/student/recommendations")
       .then((res) => setWeakAreas(res.data.weakAreas ?? []))
       .catch(() => setWeakAreas([]))
       .finally(() => setLoadingRecs(false));
-  }, []);
+  }, [isAuthenticated, userRole]);
 
   const grouped = useMemo(() => {
     const needle = search.trim().toLowerCase();

--- a/client/src/module/student/roadmap/RoadmapCanvasPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapCanvasPage.tsx
@@ -56,6 +56,7 @@ import type {
 } from "../../../lib/types";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import { queryKeys } from "../../../lib/query-keys";
+import { useAuthStore } from "../../../lib/auth.store";
 
 interface EnrollmentResponse {
   enrollment: RoadmapEnrollment;
@@ -430,8 +431,15 @@ export default function RoadmapCanvasPage() {
   const [weakTopicTitles, setWeakTopicTitles] = useState<Set<string>>(
     new Set(),
   );
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const userRole = useAuthStore((s) => s.user?.role);
 
   useEffect(() => {
+    if (!isAuthenticated || userRole !== "STUDENT") {
+      setWeakTopicTitles(new Set());
+      return;
+    }
+
     api
       .get<{
         weakAreas: { type: string; topic: string; topicSlug?: string }[];
@@ -445,7 +453,7 @@ export default function RoadmapCanvasPage() {
         setWeakTopicTitles(slugs);
       })
       .catch(() => {});
-  }, []);
+  }, [isAuthenticated, userRole]);
 
   const toggleSection = useCallback((id: number) => {
     setCollapsedSections((prev) => {

--- a/client/src/module/student/roadmap/RoadmapDashboardPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapDashboardPage.tsx
@@ -18,6 +18,7 @@ import toast from "../../../components/ui/toast";
 import type { RoadmapEnrollmentListItem } from "../../../lib/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "../../../lib/query-keys";
+import { useAuthStore } from "../../../lib/auth.store";
 import {
   RecommendationCard,
   type WeakArea,
@@ -31,14 +32,21 @@ export default function RoadmapDashboardPage() {
     null,
   );
   const [weakAreas, setWeakAreas] = useState<WeakArea[]>([]);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const userRole = useAuthStore((s) => s.user?.role);
   const queryClient = useQueryClient();
 
   useEffect(() => {
+    if (!isAuthenticated || userRole !== "STUDENT") {
+      setWeakAreas([]);
+      return;
+    }
+
     api
       .get<{ weakAreas: WeakArea[] }>("/student/recommendations")
       .then((res) => setWeakAreas(res.data.weakAreas ?? []))
       .catch(() => {});
-  }, []);
+  }, [isAuthenticated, userRole]);
   const {
     data,
     isLoading: loading,


### PR DESCRIPTION
Fixes #769

## 🚀 Description
The /recommendations endpoint was firing on the Sign In page 
before any auth token was available, causing a 401 Unauthorized 
error in the console.

Patched three call sites:
- LearnHubPage.tsx
- RoadmapDashboardPage.tsx  
- RoadmapCanvasPage.tsx

Changes:
- Added useAuthStore guard to all three recommendation effects
- API call now only fires when a valid student session exists
- Loading state is explicitly cleared for anonymous pages so 
  the UI doesn't wait on a skipped request

## 🔨 Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured weak areas, personalized recommendations, and weak topic suggestions load only for authenticated students with the appropriate role.
  * Weak areas and recommendations are now properly cleared for unauthenticated users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/796?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->