### PR TITLE
feat: export contribution history as CSV from analytics page

### DIFF
--- a/client/src/module/student/opensource/OpenSourceAnalyticsPage.tsx
+++ b/client/src/module/student/opensource/OpenSourceAnalyticsPage.tsx
@@ -7,7 +7,8 @@ import {
   AlertCircle,
   Filter,
   X,
-  Maximize2
+  Maximize2,
+  Download
 } from "lucide-react";
 import { LoadingScreen } from "../../../components/LoadingScreen";
 import {
@@ -231,6 +232,24 @@ export default function OpenSourceAnalyticsPage() {
   const contributionTotal = contributionTrendData?.total ?? 0;
   const hasContributionActivity = contributionTrend.some((entry) => entry.count > 0);
 
+  const handleExportCSV = () => {
+    if (!contributionTrend || contributionTrend.length === 0) return;
+
+    const header = "Month,Label,Contributions";
+    const rows = contributionTrend.map(m => `${m.month},${m.label},${m.count}`);
+    const csv = [header, ...rows].join("\n");
+
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "my-oss-contributions.csv";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
   // ─── Derive filter options ──────────────────────────────────
   const years = useMemo(() => {
     const set = new Set<number>();
@@ -380,6 +399,16 @@ export default function OpenSourceAnalyticsPage() {
               {hasActiveFilter && " (filtered)"}
               {stats && ` \u00b7 ${stats.years.length} years \u00b7 ${stats.technologies.length} technologies`}
             </p>
+          </div>
+          <div className="ml-auto flex items-center gap-3">
+            <button
+              onClick={handleExportCSV}
+              disabled={trendIsLoading || !contributionTrend || contributionTrend.length === 0}
+              className="border border-stone-200 dark:border-white/10 text-xs font-mono uppercase tracking-widest px-3 py-2 rounded-md hover:border-stone-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1.5 text-stone-600 dark:text-stone-400 bg-white dark:bg-stone-900 shadow-sm"
+            >
+              <Download className="w-3.5 h-3.5" />
+              Export CSV
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
OpenSourceAnalyticsPage showed contribution history visually but offered no way to download it. Students writing resumes or GSoC applications needed to reference their contribution history in documents without manually copying data.

Changes:
- Export CSV button added in page header with Download icon
- Builds CSV from existing trend data already in client state
- CSV includes Month key, Label, and Contributions columns
- Filename: my-oss-contributions.csv
- Button disabled while loading or when no data exists
- No server endpoint needed — pure client-side Blob download

## Related Issue
Fixes #687

## Type of Change
- [x] Feature

## Testing
1. Visit analytics page with contribution data
2. Export CSV button visible in header area
3. Click button → file downloads immediately
4. Open CSV — correct headers and data rows
5. Button disabled on page load before data arrives
6. Dark mode — button visible and readable

## Screenshots

<img width="1740" height="968" alt="image" src="https://github.com/user-attachments/assets/c2c363fd-9e49-4af2-9c7d-e353d61329a0" />

---

<img width="812" height="549" alt="image" src="https://github.com/user-attachments/assets/9d1cbf26-b61d-4432-894e-3f7e2e3e9c6a" />

---

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed
- [x] Screenshots added for UI changes