### PR TITLE
fix: replace hover-only dropdowns with click-toggle in GSoCReposPage

### DIFF
--- a/client/src/module/student/opensource/GSoCReposPage.tsx
+++ b/client/src/module/student/opensource/GSoCReposPage.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useState, useRef, useEffect, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -102,17 +102,25 @@ function FilterDropdown({
   value,
   options,
   onChange,
+  isOpen,
+  setIsOpen,
+  dropdownRef,
 }: {
   label: string;
   icon: ReactNode;
   value: string;
   options: string[];
   onChange: (v: string) => void;
+  isOpen: boolean;
+  setIsOpen: (v: boolean | ((prev: boolean) => boolean)) => void;
+  dropdownRef: React.RefObject<HTMLDivElement | null>;
 }) {
   return (
-    <div className="relative group">
+    <div className="relative" ref={dropdownRef}>
       <button
         type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
         className="inline-flex h-10 cursor-pointer items-center gap-2 rounded-md border border-stone-300 bg-white px-3 text-xs font-mono uppercase tracking-widest text-stone-600 transition-colors hover:border-stone-500 dark:border-white/10 dark:bg-stone-900 dark:text-stone-400 dark:hover:border-white/30"
       >
         <span className="text-stone-400">{icon}</span>
@@ -120,16 +128,23 @@ function FilterDropdown({
         <span className="max-w-28 truncate font-bold normal-case tracking-normal text-stone-900 dark:text-stone-50">
           {value}
         </span>
-        <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+        <ChevronDown className={`h-3.5 w-3.5 opacity-60 transition-transform ${isOpen ? "rotate-180" : ""}`} />
       </button>
-      <div className="absolute left-0 top-full z-20 mt-1 hidden max-h-80 min-w-56 overflow-y-auto rounded-md border border-stone-200 bg-white p-1 shadow-xl group-hover:block dark:border-white/10 dark:bg-stone-900">
+      <div
+        className={`${
+          isOpen ? "block active" : "hidden"
+        } absolute left-0 top-full z-20 mt-1 max-h-80 min-w-56 overflow-y-auto rounded-md border border-stone-200 bg-white p-1 shadow-xl dark:border-white/10 dark:bg-stone-900`}
+      >
         {options.map((opt) => {
           const active = opt === value;
           return (
             <button
               key={opt}
               type="button"
-              onClick={() => onChange(opt)}
+              onClick={() => {
+                onChange(opt);
+                setIsOpen(false);
+              }}
               className={`flex w-full items-center justify-between gap-3 rounded px-3 py-2 text-left text-sm transition-colors ${
                 active
                   ? "bg-stone-900 font-medium text-stone-50 dark:bg-stone-50 dark:text-stone-900"
@@ -455,6 +470,47 @@ export default function GSoCReposPage() {
   const [selectedYear, setSelectedYear] = useState("All");
   const [page, setPage] = useState(1);
   const [selectedOrg, setSelectedOrg] = useState<GSoCOrganization | null>(null);
+
+  // Dropdown states
+  const [categoryOpen, setCategoryOpen] = useState(false);
+  const [techOpen, setTechOpen] = useState(false);
+  const [yearOpen, setYearOpen] = useState(false);
+
+  // Refs for outside click detection
+  const categoryRef = useRef<HTMLDivElement>(null);
+  const techRef = useRef<HTMLDivElement>(null);
+  const yearRef = useRef<HTMLDivElement>(null);
+
+  // Outside click handler
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (categoryRef.current && !categoryRef.current.contains(e.target as Node)) {
+        setCategoryOpen(false);
+      }
+      if (techRef.current && !techRef.current.contains(e.target as Node)) {
+        setTechOpen(false);
+      }
+      if (yearRef.current && !yearRef.current.contains(e.target as Node)) {
+        setYearOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // Escape key handler
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setCategoryOpen(false);
+        setTechOpen(false);
+        setYearOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, []);
+
   const [timer, setTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
   const limit = 18;
 
@@ -584,6 +640,9 @@ export default function GSoCReposPage() {
             label="category"
             value={selectedCategory}
             options={categoryOptions}
+            isOpen={categoryOpen}
+            setIsOpen={setCategoryOpen}
+            dropdownRef={categoryRef}
             onChange={(value) => {
               setSelectedCategory(value);
               setPage(1);
@@ -594,6 +653,9 @@ export default function GSoCReposPage() {
             label="year"
             value={selectedYear}
             options={yearOptions}
+            isOpen={yearOpen}
+            setIsOpen={setYearOpen}
+            dropdownRef={yearRef}
             onChange={(value) => {
               setSelectedYear(value);
               setPage(1);
@@ -604,6 +666,9 @@ export default function GSoCReposPage() {
             label="tech"
             value={selectedTech}
             options={techOptions}
+            isOpen={techOpen}
+            setIsOpen={setTechOpen}
+            dropdownRef={techRef}
             onChange={(value) => {
               setSelectedTech(value);
               setPage(1);


### PR DESCRIPTION
## Description
GSoCReposPage filter dropdowns used CSS group-hover: to reveal menus. On mobile and touch devices there is no hover state, making category, tech, and year filters completely inaccessible on phones — students could not filter GSoC organizations at all.

Changes:
- Replaced group-hover:block/flex with click-toggled useState
- One useRef per dropdown with outside-click handler
- Escape key closes all open dropdowns
- Selecting an option applies filter and closes dropdown
- aria-expanded on trigger buttons for screen readers
- Desktop click behavior identical to before
- Consistent with RepoDiscoveryPage filter toggle pattern

## Related Issue
Fixes #671

## Type of Change
- [x] Bug Fix
- [x] Accessibility

## Testing
1. Mobile 375px — tap Category → dropdown opens
2. Tap an option → filter applies, dropdown closes
3. Tap outside → dropdown closes
4. Press Escape → all dropdowns close
5. Desktop — click behavior unchanged
6. aria-expanded reflects open/closed state

## Screenshots

<img width="363" height="738" alt="image" src="https://github.com/user-attachments/assets/12624ad5-681d-47d6-baa7-1c098aa6e57d" />


<img width="364" height="733" alt="image" src="https://github.com/user-attachments/assets/d7f02288-08f5-4382-9a67-24f2ca24ca74" />


## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed