### PR TITLE
fix: add lastUpdated to sortBy validation enum

### DIFF
--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -7,7 +7,7 @@ export const opensourceListQuerySchema = z.object({
   language: z.string().optional(),
   difficulty: z.string().optional(),
   domain: z.string().optional(),
-  sortBy: z.enum(["stars", "forks", "name", "createdAt", "openIssues"]).default("stars"),
+  sortBy: z.enum(["stars", "forks", "name", "createdAt", "openIssues", "lastUpdated"]).default("stars"),
   sortOrder: z.enum(["asc", "desc"]).default("desc"),
 });
 


### PR DESCRIPTION
## Description
Selecting "Recently Updated" in the Repo Discovery sort dropdown caused a 400 validation error. The client correctly sent
sortBy=lastUpdated but the server Zod schema only accepted ["stars", "forks", "name", "createdAt", "openIssues"] — lastUpdated was missing from the enum despite being a valid column on the opensourceRepo Prisma model.

Changes:
- Added "lastUpdated" to sortBy z.enum in opensource.validation.ts
- Verified lastUpdated maps to correct Prisma field in service

## Related Issue
Fixes #667

## Type of Change
- [x] Bug Fix

## Testing
1. Visit /student/opensource/repos
2. Open sort dropdown → select Recently Updated
3. Network tab → request returns 200 not 400
4. Results sorted by last updated date descending
5. All other sort options work correctly

## Screenshots

<img width="1645" height="928" alt="image" src="https://github.com/user-attachments/assets/6a89ce6a-37c5-473d-854b-513968e15ee9" />

---

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to sort open source projects by "last updated" date alongside existing sort options (stars, forks, name, created date, and open issues).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->