### PR TITLE
Feat/opensource trending only filter

### DIFF
--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -56,6 +56,7 @@ export default function RepoDiscoveryPage() {
   const [selectedDomain, setSelectedDomain] = useState("ALL");
   const [selectedDifficulty, setSelectedDifficulty] = useState("ALL");
   const [sortKey, setSortKey] = useState("stars");
+  const [trendingOnly, setTrendingOnly] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [selectedRepo, setSelectedRepo] = useState<OpenSourceRepo | null>(null);
   const [page, setPage] = useState(1);
@@ -67,10 +68,11 @@ export default function RepoDiscoveryPage() {
     if (search.trim()) params.search = search.trim();
     if (selectedDomain !== "ALL") params.domain = selectedDomain;
     if (selectedDifficulty !== "ALL") params.difficulty = selectedDifficulty;
+    if (trendingOnly) params.trending = "true";
     const sortOpt = SORT_OPTIONS.find((s) => s.key === sortKey);
     if (sortOpt) params.sortOrder = sortOpt.order;
     return params;
-  }, [search, selectedDomain, selectedDifficulty, sortKey, page]);
+  }, [search, selectedDomain, selectedDifficulty, sortKey, trendingOnly, page]);
 
   const { data, isLoading, isError } = useQuery({
     queryKey: queryKeys.opensource.list(queryParams),
@@ -248,6 +250,23 @@ export default function RepoDiscoveryPage() {
               </button>
             );
           })}
+
+          {/* Trending toggle */}
+          <button
+            type="button"
+            onClick={() => {
+              setTrendingOnly((v) => !v);
+              setPage(1);
+            }}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${
+              trendingOnly
+                ? "bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 border-lime-200 dark:border-lime-400/30"
+                : "text-stone-500 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25"
+            }`}
+          >
+            <Flame className="w-3 h-3" />
+            Trending
+          </button>
 
           {/* More filters toggle */}
           <button

--- a/server/src/module/opensource/opensource.routes.ts
+++ b/server/src/module/opensource/opensource.routes.ts
@@ -36,12 +36,13 @@ opensourceRouter.get("/", async (req, res, next) => {
       res.status(400).json({ message: "Invalid query parameters", errors: parsed.error.flatten().fieldErrors });
       return;
     }
-    const { page, limit, search, language, difficulty, domain, sortBy, sortOrder } = parsed.data;
+    const { page, limit, search, language, difficulty, domain, sortBy, sortOrder, trending } = parsed.data;
 
     const where: Record<string, unknown> = {};
     if (language) where["language"] = { equals: language, mode: "insensitive" };
     if (difficulty) where["difficulty"] = difficulty;
     if (domain) where["domain"] = domain;
+    if (trending === "true") where["trending"] = true;
     if (search) {
       where["OR"] = [
         { name: { contains: search, mode: "insensitive" } },

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -7,8 +7,9 @@ export const opensourceListQuerySchema = z.object({
   language: z.string().optional(),
   difficulty: z.string().optional(),
   domain: z.string().optional(),
-  sortBy: z.enum(["stars", "forks", "name", "createdAt", "openIssues"]).default("stars"),
+  sortBy: z.enum(["stars", "forks", "name", "createdAt", "openIssues", "lastUpdated"]).default("stars"),
   sortOrder: z.enum(["asc", "desc"]).default("desc"),
+  trending: z.enum(["true", "false"]).optional(),
 });
 
 export const repoIdSchema = z.object({


### PR DESCRIPTION
## Description
Students interested in trending repos had to scan all cards looking for the flame badge manually. There was no one-click
way to filter to only trending repositories.

Changes:
- Flame icon "Trending" toggle button added to filter bar
- Active state uses lime accent consistent with other active chips
- Adds trending=true to API query params when active
- Server validates and filters by trending=true in where clause
- Page resets to 1 on toggle to prevent empty pagination state
- Works alongside all existing filters simultaneously

## Related Issue
Fixes #676

## Type of Change
- [x] Feature

## Testing
1. Visit /student/opensource/repos
2. Trending toggle button visible in filter bar
3. Click → button turns lime, results filter to trending only
4. Network tab → ?trending=true in request URL
5. Click again → all repos return, button resets to default
6. Combine trending with language filter — both apply
7. Dark mode — lime active state correct

## Screenshots

<img width="1407" height="714" alt="image" src="https://github.com/user-attachments/assets/edca6d61-e774-4749-ab29-1ca3eb98080a" />

---

<img width="1407" height="825" alt="image" src="https://github.com/user-attachments/assets/055579c8-7409-4742-a300-c3c5c1b3e54c" />

---

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed
- [x] Screenshots added for UI changes