### PR TITLE
feat: add repository URL copy action in repo modal

### DIFF
--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -8,6 +8,8 @@ import {
   GitFork,
   CircleDot,
   ExternalLink,
+  Copy,
+  Check,
   X,
   ChevronDown,
   TrendingUp,
@@ -58,6 +60,7 @@ export default function RepoDiscoveryPage() {
   const [sortKey, setSortKey] = useState("stars");
   const [showFilters, setShowFilters] = useState(false);
   const [selectedRepo, setSelectedRepo] = useState<OpenSourceRepo | null>(null);
+  const [repoUrlCopied, setRepoUrlCopied] = useState(false);
   const [page, setPage] = useState(1);
   const [showSuggestModal, setShowSuggestModal] = useState(false);
   const { user } = useAuthStore();
@@ -100,6 +103,17 @@ export default function RepoDiscoveryPage() {
     setter(value);
     setPage(1);
   };
+
+  const copySelectedRepoUrl = () => {
+    if (!selectedRepo) return;
+    navigator.clipboard.writeText(selectedRepo.url);
+    setRepoUrlCopied(true);
+    setTimeout(() => setRepoUrlCopied(false), 1500);
+  };
+
+  useEffect(() => {
+    setRepoUrlCopied(false);
+  }, [selectedRepo]);
 
   const activeFilters =
     (selectedDomain !== "ALL" ? 1 : 0) +
@@ -591,16 +605,36 @@ export default function RepoDiscoveryPage() {
                   </div>
                 </div>
 
-                {/* View on GitHub */}
-                <a
-                  href={selectedRepo.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center justify-center gap-2 w-full py-3 rounded-md bg-lime-400 hover:bg-lime-300 text-stone-950 text-sm font-bold transition-colors no-underline"
-                >
-                  View on GitHub
-                  <ExternalLink className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
-                </a>
+                {/* Repository actions */}
+                <div className="flex items-center gap-2">
+                  <a
+                    href={selectedRepo.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group flex flex-1 items-center justify-center gap-2 py-3 rounded-md bg-lime-400 hover:bg-lime-300 text-stone-950 text-sm font-bold transition-colors no-underline"
+                  >
+                    View on GitHub
+                    <ExternalLink className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
+                  </a>
+                  <button
+                    type="button"
+                    onClick={copySelectedRepoUrl}
+                    className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-stone-200 dark:border-white/10 bg-white dark:bg-stone-900 text-stone-700 dark:text-stone-300 transition-colors hover:bg-stone-100 dark:hover:bg-white/5 cursor-pointer"
+                    aria-label={repoUrlCopied ? "Copied repository URL" : "Copy repository URL"}
+                    title={repoUrlCopied ? "Copied!" : "Copy repository URL"}
+                  >
+                    {repoUrlCopied ? (
+                      <Check className="w-4 h-4 text-green-500" />
+                    ) : (
+                      <Copy className="w-4 h-4" />
+                    )}
+                    {repoUrlCopied && (
+                      <span className="absolute -top-8 right-0 rounded-md bg-stone-900 dark:bg-stone-50 px-2 py-1 text-[10px] font-bold text-white dark:text-stone-950 shadow-lg">
+                        Copied!
+                      </span>
+                    )}
+                  </button>
+                </div>
               </div>
             </motion.div>
           </motion.div>


### PR DESCRIPTION
# Pull Request

## Description

Adds a copy-to-clipboard action to the repository detail modal, allowing users to quickly copy a repository's GitHub URL without leaving the page.

### What changed

* Added Copy/Check icon button next to **View on GitHub**
* Copies `selectedRepo.url` using `navigator.clipboard.writeText`
* Shows **Copied!** tooltip and check icon feedback for 1.5 seconds
* Resets copied state when switching repositories or reopening the modal

## Related Issue

Fixes #675 

## Type of Change

* [ ] Bug Fix
* [x] Feature
* [ ] Enhancement
* [ ] Documentation

## Testing

### Manual Testing

1. Open the Open Source Repository Discovery page.
2. Select any repository to open the detail modal.
3. Click the new copy icon button next to **View on GitHub**.
4. Verify the repository URL is copied to the clipboard.
5. Verify the button changes to a check icon and displays **Copied!** feedback.
6. Verify the feedback automatically resets after 1.5 seconds.
7. Open another repository and confirm the copied state is reset.
8. Verify the existing **View on GitHub** button still opens the repository in a new tab.

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [ ] Docs updated (if needed)
* [ ] Screenshots added for UI changes (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to copy repository URLs directly from the detail modal. Copy action provides visual confirmation through icon changes and an instant feedback message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->