### PR TITLE
fix: remove public test cover letter route

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -334,7 +334,6 @@ function App() {
 
 
  <Route path="/ats-score" element={<PublicAtsPage />} />
-<Route path="/test-cover-letter" element={<CoverLetterPage />} />
 <Route path="/grants" element={<GrantsPage />} />
 
 


### PR DESCRIPTION
## Description
Removes the public `/test-cover-letter` route from `client/src/App.tsx`.

That route looked like a leftover test entry point and was reachable without going through the normal student dashboard flow. The actual cover letter page is still available through the protected student route at `/student/ats/cover-letter`.

## Related Issue
Fixes #748

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing
- Ran `npm run typecheck` in `client`
- Ran `npm run lint` in `client` (passes with existing warnings elsewhere)
- Verified `CoverLetterPage` is still referenced by the protected student ATS route

## Screenshots
Not applicable, route cleanup only.

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (not needed)
- [x] Screenshots added for UI changes (not applicable)

This PR is raised as part of GSSoC 2026. Please add the GSSoC/type/level labels if they do not get applied automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ATS scoring functionality to the application.

* **Removed Features**
  * Removed the standalone cover letter testing feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->