### PR TITLE
feat: add GSoC participation history bar to org cards

### DIFF
--- a/client/src/module/student/opensource/GSoCReposPage.tsx
+++ b/client/src/module/student/opensource/GSoCReposPage.tsx
@@ -161,6 +161,29 @@ function FilterDropdown({
   );
 }
 
+const ParticipationBar = ({ participatedYears }: { participatedYears: number[] }) => {
+  const yearsRange = Array.from({ length: 10 }, (_, i) => 2016 + i);
+
+  return (
+    <div className="mb-4 flex items-center gap-1" aria-label="GSoC Participation History (2016-2025)">
+      {yearsRange.map((year) => {
+        const participated = participatedYears.includes(year);
+        return (
+          <div
+            key={year}
+            title={participated ? `${year}: Participated` : `${year}: Did not participate`}
+            className={`h-1.5 w-1.5 rounded-sm transition-transform duration-200 hover:scale-125 cursor-help ${
+              participated
+                ? "bg-lime-500"
+                : "bg-stone-200 dark:bg-stone-700"
+            }`}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
 function GSoCOrgCard({ org, onClick }: { org: GSoCOrganization; onClick: () => void }) {
   const years = [...org.yearsParticipated].sort((a, b) => b - a);
 
@@ -201,6 +224,8 @@ function GSoCOrgCard({ org, onClick }: { org: GSoCOrganization; onClick: () => v
           {org.technologies.length > 4 && <PlainChip>+{org.technologies.length - 4}</PlainChip>}
         </div>
       )}
+
+      <ParticipationBar participatedYears={org.yearsParticipated} />
 
       <div className="mt-auto flex items-center justify-between border-t border-stone-100 pt-3 dark:border-white/5">
         <span className="text-[11px] font-mono uppercase tracking-widest text-stone-500">


### PR DESCRIPTION
Add ParticipationBar component that renders a 10-dot visual timeline (2016-2025) on each GSoCOrgCard, showing participated vs non-participated years using lime/grey dots with hover tooltips and dark mode support.

# Pull Request

## Description

Adds a visual **GSoC Participation History** bar to each organization card in the `GSoCReposPage`. Each organization now displays a compact 10-dot bar (2016–2025) where filled lime dots indicate participated years and grey dots represent years they sat out — giving students an instant visual cue of how active an org has been in Google Summer of Code over time.

The `ParticipationBar` component is fully accessible (`aria-label`, `title` tooltips per dot), dark-mode aware, and uses micro-animations on hover for a polished feel.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug Fix
- [x] Feature
- [ ] Enhancement
- [ ] Documentation

## Changes

- Added `ParticipationBar` component that renders a 10-dot bar from 2016–2025 using `org.yearsParticipated`
- Integrated `ParticipationBar` into `GSoCOrgCard` so it appears on every org card
- Lime dots (`bg-lime-500`) for participated years, grey dots (`bg-stone-200 dark:bg-stone-700`) for non-participated years
- Each dot has a `title` tooltip e.g. `"2023: Participated"` / `"2022: Did not participate"`
- `aria-label="GSoC Participation History (2016-2025)"` on the wrapper for screen reader support
- Hover `scale-125` micro-animation with `cursor-help` for discoverability

## Testing

1. Start the dev server: `cd client && npm run dev`
2. Log in as a student and navigate to **Open Source → GSoC Organizations** (`/student/opensource/gsoc`)
3. Verify each org card shows a row of 10 small dots below the tech chips
4. Hover any dot — it should scale up and show a tooltip like `"2023: Participated"`
5. Lime dots = years participated; grey dots = years skipped
6. Toggle dark mode — grey dots should switch from light to dark grey
7. Verify no console errors or TypeScript errors


## Checklist

- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [ ] Screenshots added for UI changes (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization cards now display a compact participation timeline indicator (2016–2025) that provides a quick visual reference of each organization's involvement history across years.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->