### PR TITLE
fix(client): resolve active navigation underline indicator for Jobs a…

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -85,10 +85,41 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
 
           <div className="hidden lg:flex items-center gap-1">
             {NAV_ITEMS.map((item) => {
-              const active =
-                item.href === "/"
-                  ? location.pathname === "/"
-                  : location.pathname.startsWith(item.href + "/") || location.pathname === item.href;
+              const active = (() => {
+                if (item.href === "/") {
+                  return location.pathname === "/";
+                }
+                if (item.href === "/jobs") {
+                  return (
+                    location.pathname === "/jobs" ||
+                    location.pathname.startsWith("/jobs/") ||
+                    location.pathname === "/student/jobs" ||
+                    location.pathname.startsWith("/student/jobs/") ||
+                    location.pathname === "/internships" ||
+                    location.pathname.startsWith("/internships/") ||
+                    location.pathname === "/student/internships" ||
+                    location.pathname.startsWith("/student/internships/") ||
+                    location.pathname === "/external-jobs" ||
+                    location.pathname.startsWith("/external-jobs/")
+                  );
+                }
+                if (item.href === "/companies") {
+                  return (
+                    location.pathname === "/companies" ||
+                    location.pathname.startsWith("/companies/") ||
+                    location.pathname === "/student/companies" ||
+                    location.pathname.startsWith("/student/companies/") ||
+                    location.pathname === "/yc" ||
+                    location.pathname.startsWith("/yc/") ||
+                    location.pathname === "/student/yc" ||
+                    location.pathname.startsWith("/student/yc/")
+                  );
+                }
+                return (
+                  location.pathname === item.href ||
+                  location.pathname.startsWith(item.href + "/")
+                );
+              })();
               return (
                 <Link key={item.href} to={item.href} aria-current={active ? "page" : undefined} className="no-underline">
                   <button

--- a/client/src/module/student/grants/grants-accelerator.ts
+++ b/client/src/module/student/grants/grants-accelerator.ts
@@ -1,4 +1,3 @@
-<<<<<<< main
 import type { Grant } from "./grantsData";
 
 export const grantsAccelerator: Grant[] = [
@@ -1048,4 +1047,3 @@ export const grantsAccelerator: Grant[] = [
     ],
   },
 ];
->>>>>>> main

--- a/client/src/module/student/grants/grants-climate.ts
+++ b/client/src/module/student/grants/grants-climate.ts
@@ -1,4 +1,3 @@
-<<<<<<< main
 import type { Grant } from "./grantsData";
 
 export const grantsClimate: Grant[] = [
@@ -528,4 +527,3 @@ export const grantsClimate: Grant[] = [
     ],
   },
 ];
->>>>>>> main

--- a/client/src/module/student/grants/grants-gaming.ts
+++ b/client/src/module/student/grants/grants-gaming.ts
@@ -1,4 +1,3 @@
-<<<<<<< main
 import type { Grant } from "./grantsData";
 
 export const grantsGaming: Grant[] = [
@@ -164,4 +163,3 @@ export const grantsGaming: Grant[] = [
     ],
   },
 ];
->>>>>>> main

--- a/client/src/module/student/grants/grants-research.ts
+++ b/client/src/module/student/grants/grants-research.ts
@@ -1,4 +1,3 @@
-<<<<<<< main
 import type { Grant } from "./grantsData";
 
 export const grantsResearch: Grant[] = [
@@ -1048,4 +1047,3 @@ export const grantsResearch: Grant[] = [
     ],
   },
 ];
->>>>>>> main


### PR DESCRIPTION


## Description
This PR fixes a bug in the global navigation bar (`client/src/components/Navbar.tsx`) where the active navigation green underline indicator was missing for the **Jobs** and **Companies** links when those pages were active. 

Previously, the active state check only checked if `location.pathname` equaled or started with `/jobs` and `/companies`. When a student logged in, they were redirected to the nested student dashboard routes (`/student/jobs` and `/student/companies`). Because these pathnames did not match the hardcoded public paths, the indicator failed to render.

The matching logic has been rewritten to comprehensively support:
- Public paths (`/jobs`, `/companies`)
- Student dashboard sub-routes (`/student/jobs`, `/student/companies`)
- Nested pages (`/student/jobs/:id`, `/student/companies/:slug`, `/yc/:slug`, `/student/yc/:slug`, etc.)
- Related sub-modules (e.g. government internships at `/internships` and scraped jobs at `/external-jobs`)

## Related Issue
Fixes the navigation active indicator visibility issue for Jobs and Companies.

## Fixes
865 

## Type of Change
- [x] Bug Fix  


## Testing
- Verified path matching handles all nested student dashboard pathnames (`/student/jobs`, `/student/companies`, `/student/jobs/:id`, `/student/companies/:slug`).
- Ran compilation checks (`npm run typecheck` / `tsc -b`) to ensure no TypeScript compilation or linting errors are introduced.

## Screenshots
<img width="1502" height="220" alt="Screenshot 2026-05-31 150419" src="https://github.com/user-attachments/assets/32c3897c-c5a6-4331-bd70-d96e80a0afb6" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop navigation highlighting so the active navbar item is identified more accurately across sections (including Jobs and Companies) and their related subsections, giving clearer visual feedback as you navigate.

* **Chores**
  * Cleaned up dataset files and removed leftover merge artifacts; standardized grant deadlines to a single normalized date across multiple grant listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->