### PR TITLE
feat: add ATS report PDF download

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, useRef } from "react";
 import { Link, useNavigate } from "react-router";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
-import { useReactToPrint } from "react-to-print";
 import toast from "@/components/ui/toast";
 import { motion, AnimatePresence } from "framer-motion";
 import { uploadDirectToS3 } from "../../../utils/upload";
@@ -116,10 +115,103 @@ export default function AtsScorePage() {
   const debouncedHistorySearch = useDebounce(historySearch, 300);
   const navigate = useNavigate();
 
-  const handlePrint = useReactToPrint({
-    contentRef: printRef,
-    documentTitle: `ATS_Report_${new Date().toLocaleDateString("en-IN")}`,
-  });
+  const handleDownloadPdf = async () => {
+    if (!result) return;
+
+    const { jsPDF } = await import("jspdf");
+
+    const doc = new jsPDF({
+      orientation: "portrait",
+      unit: "mm",
+      format: "a4",
+    });
+
+    const dateStr = new Date().toISOString().slice(0, 10);
+    const filename = `ats-report-${dateStr}.pdf`;
+
+    let y = 20;
+
+    const pageHeight = doc.internal.pageSize.getHeight();
+
+    const checkPageBreak = () => {
+      if (y > pageHeight - 20) {
+        doc.addPage();
+        y = 20;
+      }
+    };
+
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(18);
+    doc.text("ATS Analysis Report", 20, y);
+
+    y += 12;
+
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(11);
+
+    doc.text(`Resume: ${getResumeName(result.resumeUrl)}`, 20, y);
+    y += 8;
+
+    doc.text(`Generated: ${dateStr}`, 20, y);
+    y += 12;
+
+    doc.setFont("helvetica", "bold");
+    doc.text(`Overall ATS Score: ${result.overallScore}/100`, 20, y);
+
+    y += 12;
+
+    doc.text("Category Scores", 20, y);
+    y += 8;
+
+    doc.setFont("helvetica", "normal");
+
+    Object.entries(result.categoryScores).forEach(([key, value]) => {
+      doc.text(`${key}: ${value}`, 25, y);
+      y += 7;
+    });
+
+    y += 5;
+
+    doc.setFont("helvetica", "bold");
+    doc.text("Missing Keywords", 20, y);
+    y += 8;
+
+    doc.setFont("helvetica", "normal");
+
+    if (result.keywordAnalysis.missing.length === 0) {
+      doc.text("None", 25, y);
+      y += 7;
+    } else {
+      result.keywordAnalysis.missing.forEach((keyword) => {
+        checkPageBreak();
+
+        doc.text(`• ${keyword}`, 25, y);
+        y += 7;
+      });
+    }
+
+    y += 5;
+
+    doc.setFont("helvetica", "bold");
+    doc.text("Suggestions", 20, y);
+    y += 8;
+
+    doc.setFont("helvetica", "normal");
+
+    result.suggestions.forEach((suggestion) => {
+      checkPageBreak();
+
+      const lines = doc.splitTextToSize(
+        `• ${suggestion}`,
+        160,
+      );
+
+      doc.text(lines, 25, y);
+      y += lines.length * 6 + 2;
+    });
+
+    doc.save(filename);
+  };
 
   const { data: usageData } = useQuery<UsageStats>({
     queryKey: queryKeys.ats.usage(),
@@ -1073,12 +1165,13 @@ export default function AtsScorePage() {
                     </div>
                     <button
                       type="button"
-                      onClick={() => handlePrint()}
-                      className="shrink-0 mr-1 inline-flex items-center gap-2 px-3.5 py-3 text-xs font-mono uppercase tracking-widest text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 transition-colors border-0 bg-transparent cursor-pointer print:hidden"
+                      onClick={handleDownloadPdf}
+                      disabled={loading}
+                      className="shrink-0 mr-1 inline-flex items-center gap-2 px-3.5 py-3 text-xs font-mono uppercase tracking-widest text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 transition-colors border-0 bg-transparent cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed print:hidden"
                       title="Download or print this ATS report"
                     >
                       <Download className="w-3.5 h-3.5" />
-                      <span className="hidden sm:inline">Print</span>
+                      <span className="hidden sm:inline">Download Report</span>
                     </button>
                   </div>
 

--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -199,15 +199,16 @@ export default function AtsScorePage() {
     doc.setFont("helvetica", "normal");
 
     result.suggestions.forEach((suggestion) => {
-      checkPageBreak();
+      const lines = doc.splitTextToSize(`• ${suggestion}`, 160);
+      const blockHeight = lines.length * 6 + 2;
 
-      const lines = doc.splitTextToSize(
-        `• ${suggestion}`,
-        160,
-      );
+      if (y + blockHeight > pageHeight - 20) {
+        doc.addPage();
+        y = 20;
+      }
 
       doc.text(lines, 25, y);
-      y += lines.length * 6 + 2;
+      y += blockHeight;
     });
 
     doc.save(filename);


### PR DESCRIPTION
# Pull Request

## Description

Adds PDF export functionality for ATS analysis reports on the ATS Score page.

The previous implementation used a print-based workflow. This change replaces it with direct PDF generation using jsPDF and allows users to download their ATS analysis as a PDF document.

The generated PDF includes:

* Overall ATS score
* Resume file name
* Generation date
* Category/section scores
* Missing keywords
* Suggestions for improvement

It also adds page-break handling for long reports.

## Related Issue

Fixes #478

## Type of Change

* [ ] Bug Fix
* [x] Feature
* [ ] Enhancement
* [ ] Documentation

## Testing

- Ran npm run lint
- Ran npm run typecheck
- Verified PDF generation logic
- Confirmed download button is disabled while analysis is loading
- Confirmed filename follows ats-report-{date}.pdf


## Screenshots

N/A

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [ ] Docs updated (if needed)
* [ ] Screenshots added for UI changes (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ATS Analysis Reports can now be downloaded as PDF files containing resume name, generation date, overall and category scores, missing keywords (with fallback), and suggestions with automatic pagination.
  * Results tab action renamed from "Print" to "Download Report" and now invokes the new download flow.
  * Download button disabled state now reflects loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->