### PR TITLE
fix(workflow): validate performedBy before storing step history

### DIFF
--- a/server/src/module/workflow/workflow.service.ts
+++ b/server/src/module/workflow/workflow.service.ts
@@ -117,6 +117,18 @@ export class WorkflowService {
     if (!instance) throw new Error("Workflow instance not found");
     if (instance.status !== "ACTIVE") throw new Error("Workflow is not active");
 
+    let validatedPerformedBy: number | undefined = undefined;
+    if (performedBy !== undefined) {
+      const userExists = await prisma.user.findUnique({
+        where: { id: performedBy },
+        select: { id: true },
+      });
+      if (!userExists) {
+        throw new Error(`User with id ${performedBy} does not exist`);
+      }
+      validatedPerformedBy = performedBy;
+    }
+
     const steps = JSON.parse(instance.definition.steps as string) as unknown[];
     const history = JSON.parse(instance.stepHistory as string) as StepHistoryEntry[];
 
@@ -124,7 +136,7 @@ export class WorkflowService {
       step: instance.currentStep,
       action,
       note,
-      performedBy,
+      performedBy: validatedPerformedBy,
       performedAt: new Date().toISOString(),
     });
 


### PR DESCRIPTION
## Description

This PR adds validation for the `performedBy` field in `workflow.service.ts` before it is stored in the workflow step history.

Previously, any value passed as `performedBy` was written directly to the `stepHistory` JSON, even if the referenced user did not exist. This could lead to invalid audit trail entries containing ghost user IDs.

# fixed issue : #869 

## Changes Made

- Added validation for the `performedBy` user ID using `prisma.user.findUnique()`.
- Throws an error when a non-existent user ID is provided.
- Stores only verified user IDs in the workflow step history.
- Preserves existing workflow behavior while improving audit trail integrity.

## Before

```ts
history.push({
  step: instance.currentStep,
  action,
  note,
  performedBy, // Stored without validation
  performedAt: new Date().toISOString(),
});

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation in workflow operations to ensure users assigned to perform steps exist in the system before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->