### PR TITLE
fix: open source search ignores language and only does exact case-sensitive tag matches

### DIFF
--- a/server/src/module/opensource/opensource.routes.ts
+++ b/server/src/module/opensource/opensource.routes.ts
@@ -43,11 +43,23 @@ opensourceRouter.get("/", async (req, res, next) => {
     if (difficulty) where["difficulty"] = difficulty;
     if (domain) where["domain"] = domain;
     if (search) {
+      // Prisma's scalar-list filters can't do case-insensitive substring match
+      // on array elements, so resolve tag matches via a raw ILIKE-on-unnest
+      // subquery and merge the matching ids into the OR clause.
+      const tagMatches = await prisma.$queryRaw<Array<{ id: number }>>`
+        SELECT id FROM "opensourceRepo"
+        WHERE EXISTS (
+          SELECT 1 FROM unnest(tags) AS t WHERE t ILIKE ${`%${search}%`}
+        )
+      `;
+      const tagMatchIds = tagMatches.map((r) => r.id);
+
       where["OR"] = [
         { name: { contains: search, mode: "insensitive" } },
         { owner: { contains: search, mode: "insensitive" } },
         { description: { contains: search, mode: "insensitive" } },
-        { tags: { hasSome: [search] } },
+        { language: { contains: search, mode: "insensitive" } },
+        ...(tagMatchIds.length > 0 ? [{ id: { in: tagMatchIds } }] : []),
       ];
     }
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes the search bar on the Open Source Discovery page (`/student/opensource`). The search input has the placeholder "Search repos, languages, tags..." but only name, owner, and description were actually being searched. This PR makes the bar do what it advertises:

1. The `language` column is now included in the search OR clause (case-insensitive substring), so typing `Dart` finds `flutter`, `JavaScript` finds `react`, etc.
2. The tag clause used `hasSome: [search]`, which is exact-equality, case-sensitive scalar-list match. Replaced it with a parameterized raw `ILIKE`-on-`unnest` subquery so tag search is now case-insensitive substring match. `back` finds `backend`, `Frontend` finds repos tagged `frontend`, `agen` finds `agents`.

All four existing branches in the OR (`name`, `owner`, `description`, `tags`) plus the new `language` branch now behave consistently: case-insensitive substring matching.

The change is scoped to one block in `server/src/module/opensource/opensource.routes.ts`.

## Related Issue

Fixes #<paste-the-issue-number-here>

## Type of Change

- [x] Bug Fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing

Tested locally with `docker compose up` and seeded data (`docker compose exec server npm run seed`). The seed includes 7 repos with various languages and tags, which covers all three sub-bugs nicely.

**Before the fix** (all three of these were broken):

```bash
# Bug 1: language column wasn't searched at all
curl -s "http://localhost:3000/api/opensource?search=Dart" | grep -oE '"total":[0-9]+'
# → "total":0  (despite flutter using language: "Dart")

# Bug 2: partial tag match didn't work
curl -s "http://localhost:3000/api/opensource?search=agen" | grep -oE '"total":[0-9]+'
# → "total":0  (despite langchain having tag "agents")

# Bug 3: tag search was case-sensitive
curl -s "http://localhost:3000/api/opensource?search=frontend" | grep -oE '"total":[0-9]+'
# → "total":1
curl -s "http://localhost:3000/api/opensource?search=Frontend" | grep -oE '"total":[0-9]+'
# → "total":0  (same word, capital F, no result)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository tag search to use case-insensitive substring matching, aligning it with how other search fields (name, owner, description, language) function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->