### PR TITLE
fix: preserve salary filter pagination order and cap candidate query

### DIFF
--- a/server/src/module/job/job.service.ts
+++ b/server/src/module/job/job.service.ts
@@ -27,10 +27,10 @@ interface JobQuery {
   salaryMax?: number | undefined;
 }
 
-
 type UpdateJobData = {
   [K in keyof CreateJobData]?: CreateJobData[K] | undefined;
 };
+
 export class JobService {
   async createJob(data: CreateJobData) {
     return prisma.job.create({
@@ -109,6 +109,7 @@ export class JobService {
         where,
         select: { id: true, salary: true },
         orderBy: { createdAt: "desc" },
+        take: 1000,
       });
 
       const filtered = candidates.filter((job) => {
@@ -124,15 +125,21 @@ export class JobService {
 
       const jobs = await prisma.job.findMany({
         where: { id: { in: pageIds } },
-        orderBy: { createdAt: "desc" },
         include: {
           recruiter: { select: { id: true, name: true, company: true } },
           _count: { select: { applications: true, rounds: true } },
         },
       });
 
+      // Restore salary-filtered order — IN(...) does not preserve order in PostgreSQL
+      const jobMap = new Map(jobs.map((j) => [j.id, j]));
+      // Properly typed — removes undefined with type predicate
+      const orderedJobs = pageIds
+        .map((id) => jobMap.get(id))
+        .filter((job): job is NonNullable<typeof job> => job !== undefined);
+
       return {
-        jobs,
+        jobs: orderedJobs,
         pagination: {
           page: query.page,
           limit: query.limit,
@@ -178,7 +185,6 @@ export class JobService {
 
     let tag = slug;
     let location: string | undefined;
-
     // Check if the last part is a location
     const lastPart = parts[parts.length - 1]!.toLowerCase();
     if (LOCATIONS.includes(lastPart) && parts.length > 1) {


### PR DESCRIPTION
Fixes #830 
Two problems in the salary range filter inside getJobs():

First — the second findMany used WHERE id IN (pageIds) but 
PostgreSQL doesn't return rows in the same order as the IDs 
you pass in. The orderBy: { createdAt: "desc" } was then 
re-sorting everything by date, completely throwing away the 
salary-filtered page order. Page 2 could show jobs that 
belong on page 1.

Fixed by building a Map from job id to job object after the 
second query, then re-mapping pageIds in order to restore 
the correct sequence.

Second — the first query had no limit, so every matching 
job was being pulled into Node memory before any salary 
filtering. Added take: 1000 to prevent that.

Files changed:
- server/src/module/job/job.service.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Job search results now maintain consistent ordering when filtering by salary.
  * Enhanced performance when searching jobs with salary range filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->