### PR TITLE
feat: show student submitted repo requests with status on discovery page

### DIFF
--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -190,7 +190,12 @@ export default function RepoDiscoveryPage() {
     staleTime: 10 * 60 * 1000,
   });
 
-  const { data: myRequestsData, isLoading: isMyRequestsLoading } = useQuery({
+  const {
+    data: myRequestsData,
+    isLoading: isMyRequestsLoading,
+    isError: isMyRequestsError,
+    refetch: refetchMyRequests,
+  } = useQuery({
     queryKey: ["opensource-my-requests"],
     queryFn: () => api.get("/opensource/requests/mine").then((r) => r.data.requests as RepoRequest[]),
     enabled: !!user,
@@ -381,7 +386,7 @@ export default function RepoDiscoveryPage() {
           <div className="mb-8">
             <div className="flex items-center justify-between mb-3">
               <div className="flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500">
-                <span className="h-1.5 w-1.5 bg-lime-400 rounded-full" />
+                <div className="h-1 w-1 bg-lime-400" />
                 my submissions
               </div>
             </div>
@@ -398,15 +403,29 @@ export default function RepoDiscoveryPage() {
               </div>
             )}
 
+            {/* Error state */}
+            {!isMyRequestsLoading && isMyRequestsError && (
+              <div className="flex items-center justify-between py-2 px-1">
+                <p className="text-sm text-red-500">Failed to load submissions</p>
+                <button
+                  type="button"
+                  onClick={() => refetchMyRequests()}
+                  className="text-[10px] font-mono uppercase tracking-widest text-stone-400 hover:text-lime-500 transition-colors cursor-pointer border-0 bg-transparent"
+                >
+                  Retry ↻
+                </button>
+              </div>
+            )}
+
             {/* Empty state */}
-            {!isMyRequestsLoading && myRequests?.length === 0 && (
+            {!isMyRequestsLoading && !isMyRequestsError && myRequests?.length === 0 && (
               <p className="text-sm text-stone-400 dark:text-stone-500 py-2">
                 You haven't suggested any repos yet.
               </p>
             )}
 
             {/* Submissions list */}
-            {!isMyRequestsLoading && myRequests && myRequests.length > 0 && (
+            {!isMyRequestsLoading && !isMyRequestsError && myRequests && myRequests.length > 0 && (
               <div className="space-y-2">
                 {(showAllSubmissions ? myRequests : myRequests.slice(0, 3)).map(
                   (req) => (

--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -28,7 +28,7 @@ import { queryKeys } from "../../../lib/query-keys";
 import { SEO } from "../../../components/SEO";
 import { canonicalUrl } from "../../../lib/seo.utils";
 import { PaginationControls } from "../../../components/ui/PaginationControls";
-import type { OpenSourceRepo, Pagination } from "../../../lib/types";
+import type { OpenSourceRepo, Pagination, RepoRequest } from "../../../lib/types";
 import { useAuthStore } from "../../../lib/auth.store";
 import { REPO_DOMAINS, DIFFICULTY_OPTIONS, SORT_OPTIONS, LANGUAGE_COLORS } from "./reposData";
 import { formatCount, difficultyBadge } from "./_shared/repo-utils";
@@ -40,6 +40,12 @@ import { RecentlyViewedSection } from "./_shared/RecentlyViewedSection";
 
 const ghostBtnCls =
   "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-bold text-stone-700 dark:text-stone-300 bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/15 hover:bg-stone-50 dark:hover:bg-white/5 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed";
+
+const STATUS_STYLE: Record<string, string> = {
+  PENDING: "bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800",
+  APPROVED: "bg-lime-50 dark:bg-lime-900/20 text-lime-700 dark:text-lime-400 border-lime-200 dark:border-lime-800",
+  REJECTED: "bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 border-red-200 dark:border-red-800",
+};
 
 
 export default function RepoDiscoveryPage() {
@@ -94,6 +100,7 @@ export default function RepoDiscoveryPage() {
   const [showFilters, setShowFilters] = useState(false);
   const [selectedRepo, setSelectedRepo] = useState<OpenSourceRepo | null>(null);
   const [showSuggestModal, setShowSuggestModal] = useState(false);
+  const [showAllSubmissions, setShowAllSubmissions] = useState(false);
   const [copiedShareUrl, setCopiedShareUrl] = useState(false);
   const { user } = useAuthStore();
   // CONFLICT 2 RESOLVED: keep both recently-viewed AND deep-linking, unified into one handler
@@ -182,6 +189,15 @@ export default function RepoDiscoveryPage() {
     queryFn: () => api.get("/opensource/languages").then((r) => r.data.languages as string[]),
     staleTime: 10 * 60 * 1000,
   });
+
+  const { data: myRequestsData, isLoading: isMyRequestsLoading } = useQuery({
+    queryKey: ["opensource-my-requests"],
+    queryFn: () => api.get("/opensource/requests/mine").then((r) => r.data.requests as RepoRequest[]),
+    enabled: !!user,
+    staleTime: 2 * 60 * 1000,
+  });
+
+  const myRequests = myRequestsData;
 
   const languages = useMemo(() => {
     return languagesData || (Object.keys(LANGUAGE_COLORS) as string[]);
@@ -359,6 +375,83 @@ export default function RepoDiscoveryPage() {
             <ArrowRight className="w-4 h-4 text-stone-400 dark:text-stone-500 group-hover:text-lime-400 group-hover:translate-x-0.5 transition-all shrink-0" />
           </button>
         </div>
+
+        {/* My Submissions */}
+        {!!user && (
+          <div className="mb-8">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500">
+                <span className="h-1.5 w-1.5 bg-lime-400 rounded-full" />
+                my submissions
+              </div>
+            </div>
+
+            {/* Loading skeleton */}
+            {isMyRequestsLoading && (
+              <div className="space-y-2">
+                {[1, 2, 3].map((i) => (
+                  <div
+                    key={i}
+                    className="h-10 bg-stone-100 dark:bg-stone-800 rounded-md animate-pulse"
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Empty state */}
+            {!isMyRequestsLoading && myRequests?.length === 0 && (
+              <p className="text-sm text-stone-400 dark:text-stone-500 py-2">
+                You haven't suggested any repos yet.
+              </p>
+            )}
+
+            {/* Submissions list */}
+            {!isMyRequestsLoading && myRequests && myRequests.length > 0 && (
+              <div className="space-y-2">
+                {(showAllSubmissions ? myRequests : myRequests.slice(0, 3)).map(
+                  (req) => (
+                    <div
+                      key={req.id}
+                      className="flex items-center justify-between px-3 py-2 border border-stone-200 dark:border-white/10 rounded-md bg-white dark:bg-stone-900"
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        <span className="text-sm text-stone-700 dark:text-stone-300 truncate font-medium">
+                          {req.url ?? req.name}
+                        </span>
+                        <span className="text-xs text-stone-400 shrink-0">
+                          {new Date(req.createdAt).toLocaleDateString("en-GB", {
+                            day: "2-digit",
+                            month: "short",
+                            year: "numeric",
+                          })}
+                        </span>
+                      </div>
+                      <span
+                        className={`text-[10px] font-mono uppercase tracking-widest px-2 py-0.5 rounded-md border shrink-0 ml-3 ${
+                          STATUS_STYLE[req.status] ?? STATUS_STYLE.PENDING
+                        }`}
+                      >
+                        {req.status}
+                      </span>
+                    </div>
+                  )
+                )}
+
+                {myRequests.length > 3 && (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllSubmissions((v) => !v)}
+                    className="text-[10px] font-mono uppercase tracking-widest text-stone-400 hover:text-lime-500 transition-colors cursor-pointer border-0 bg-transparent mt-1"
+                  >
+                    {showAllSubmissions
+                      ? "Show less ↑"
+                      : `Show all ${myRequests.length} →`}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Guidance Cards */}
         <GuidanceCards />

--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -196,7 +196,7 @@ export default function RepoDiscoveryPage() {
     isError: isMyRequestsError,
     refetch: refetchMyRequests,
   } = useQuery({
-    queryKey: ["opensource-my-requests"],
+    queryKey: queryKeys.opensource.myRequests(),
     queryFn: () => api.get("/opensource/requests/mine").then((r) => r.data.requests as RepoRequest[]),
     enabled: !!user,
     staleTime: 2 * 60 * 1000,
@@ -435,7 +435,7 @@ export default function RepoDiscoveryPage() {
                     >
                       <div className="flex items-center gap-3 min-w-0">
                         <span className="text-sm text-stone-700 dark:text-stone-300 truncate font-medium">
-                          {req.url ?? req.name}
+                          {req.owner}/{req.name}
                         </span>
                         <span className="text-xs text-stone-400 shrink-0">
                           {new Date(req.createdAt).toLocaleDateString("en-GB", {

--- a/client/src/module/student/opensource/SuggestRepoModal.tsx
+++ b/client/src/module/student/opensource/SuggestRepoModal.tsx
@@ -143,12 +143,12 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
 
   const set =
     (key: keyof SuggestRepoForm) =>
-    (
-      e: React.ChangeEvent<
-        HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-      >,
-    ) =>
-      setForm((f) => ({ ...f, [key]: e.target.value }));
+      (
+        e: React.ChangeEvent<
+          HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+        >,
+      ) =>
+        setForm((f) => ({ ...f, [key]: e.target.value }));
 
   const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -432,7 +432,7 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
                 {(mutation.error as { response?: { status?: number; data?: { message?: string } } })?.response?.status === 429
                   ? (mutation.error as { response?: { data?: { message?: string } } })?.response?.data?.message
                   : (mutation.error as { response?: { data?: { message?: string } } })?.response?.data?.message ||
-                    "Failed to submit. Please try again."}
+                  "Failed to submit. Please try again."}
               </p>
             )}
 

--- a/client/src/module/student/opensource/SuggestRepoModal.tsx
+++ b/client/src/module/student/opensource/SuggestRepoModal.tsx
@@ -131,7 +131,7 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
     onSuccess: () => {
       setSuccess(true);
       queryClient.invalidateQueries({
-        queryKey: queryKeys.opensource.myRequests(),
+        queryKey: ["opensource-my-requests"],
       });
       setTimeout(() => {
         setSuccess(false);

--- a/client/src/module/student/opensource/SuggestRepoModal.tsx
+++ b/client/src/module/student/opensource/SuggestRepoModal.tsx
@@ -131,7 +131,7 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
     onSuccess: () => {
       setSuccess(true);
       queryClient.invalidateQueries({
-        queryKey: ["opensource-my-requests"],
+        queryKey: queryKeys.opensource.myRequests(),
       });
       setTimeout(() => {
         setSuccess(false);


### PR DESCRIPTION
## Description
After submitting a repo via SuggestRepoModal, students had no way to track whether their request was pending, approved, or rejected without navigating to a separate page.

Changes:
- My Submissions panel added below suggest strip on Repo Discovery
- Fetches from existing GET /opensource/requests/mine endpoint
- Each row shows repo name, submission date, and status chip
- PENDING: amber, APPROVED: lime, REJECTED: red — all rounded-md
- Shows 3 items by default with Show all / Show less toggle
- Empty state for students with no submissions
- Loading skeleton while data fetches
- Auto-refreshes after new submission via query invalidation
- Anonymous visitors see nothing

## Related Issue
Fixes #678

## Type of Change
- [x] Feature

## Testing
1. Log in as student → My Submissions section visible
2. Status chips show correct colors per status
3. More than 3 submissions → Show all X → button appears
4. Submit a new repo → panel refreshes automatically
5. Log out → section not rendered
6. Student with no submissions → empty state message shown

## Screenshots
<img width="1678" height="866" alt="image" src="https://github.com/user-attachments/assets/163ec74a-df3c-4b49-aada-3bb25dbd4f9b" />

---

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed
- [x] Screenshots added for UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authenticated users can now view their submissions on the Repository Discovery page.
  * Added toggle to display all submissions or a limited preview.
  * Submissions now display with owner name, creation date, and status information.
  * Enhanced user experience with loading states, error handling with retry capability, and appropriate empty-state messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->