### PR TITLE
fix: handle object-type suggestion entries in ATS PDF export

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -202,7 +202,8 @@ export default function AtsScorePage() {
     doc.setFont("helvetica", "normal");
 
     result.suggestions.forEach((suggestion) => {
-      const lines = doc.splitTextToSize(`• ${suggestion}`, 160);
+      const text = typeof suggestion === "string" ? suggestion : (suggestion as { suggestion?: string }).suggestion ?? String(suggestion);
+      const lines = doc.splitTextToSize(`• ${text}`, 160);
       const blockHeight = lines.length * 6 + 2;
 
       if (y + blockHeight > pageHeight - 20) {
@@ -1123,7 +1124,7 @@ export default function AtsScorePage() {
                           text={[
                             `ATS Score: ${result.overallScore}/100`,
                             `Tier: ${overallTier.label}`,
-                            `\nSuggestions:\n${result.suggestions.map((s, i) => `${i + 1}. ${s}`).join("\n")}`,
+                            `\nSuggestions:\n${result.suggestions.map((s, i) => `${i + 1}. ${typeof s === "string" ? s : (s as { suggestion?: string }).suggestion ?? ""}`).join("\n")}`,
                           ].join("\n")}
                         />
                         <span

--- a/server/src/module/ats/ats.service.ts
+++ b/server/src/module/ats/ats.service.ts
@@ -382,7 +382,15 @@ Respond with ONLY valid JSON (no markdown formatting, no code blocks, no explana
 
   private validateSuggestions(raw: unknown): string[] {
     if (!Array.isArray(raw)) return ["No specific suggestions available."];
-    return raw.filter((s): s is string => typeof s === "string").slice(0, 10);
+    return raw
+      .map((s) => {
+        if (typeof s === "string") return s;
+        if (s && typeof s === "object" && "suggestion" in s && typeof (s as Record<string, unknown>).suggestion === "string")
+          return (s as Record<string, string>).suggestion;
+        return null;
+      })
+      .filter((s): s is string => s !== null)
+      .slice(0, 10);
   }
 
   private validateKeywordAnalysis(raw: unknown): AtsKeywordAnalysis {


### PR DESCRIPTION
## Description

The ATS PDF export and CopyButton both assume every item in \esult.suggestions\ is a plain string, but some suggestion entries from the AI can be objects with a \.suggestion\ property. When interpolated via template literal, these render as \[object Object]\ in the exported PDF and clipboard text.

## Changes

1. **\AtsScorePage.tsx\** (PDF generation): Added a runtime type guard with \\.suggestion\ extraction before string interpolation
2. **\AtsScorePage.tsx\** (CopyButton): Same safety check in the \\.map()\ callback
3. **\ts.service.ts\** (\alidateSuggestions\): Instead of silently dropping object-type items, extract the \.suggestion\ property from them

## Related Issue

Fixes #908

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings