### PR TITLE
fix: make roadmap canvas page scrollable

### DIFF
--- a/client/src/module/student/roadmap/RoadmapCanvasPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapCanvasPage.tsx
@@ -1016,7 +1016,7 @@ export default function RoadmapCanvasPage() {
 
       {/* Main content area: fills the rest of the viewport, alongside sidebar */}
       <div
-        className={`flex flex-col h-screen pt-16 lg:pt-16 transition-all duration-300 ${
+        className={`flex flex-col min-h-screen overflow-y-auto pt-16 transition-all duration-300 ${
           collapsed ? "lg:ml-18" : "lg:ml-64"
         }`}
       >


### PR DESCRIPTION
## Description

The roadmap canvas page (e.g. \/learn/roadmaps/:slug\) is not scrollable — content below the visible viewport is unreachable because the main content container is fixed at \h-screen\ (100vh) with no overflow handling.

## Change

Changed \h-screen\ to \min-h-screen overflow-y-auto\ on the main content container so it grows with content and scrolls when content exceeds the viewport.

Closes #885

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Roadmap Canvas page layout so content can scroll vertically instead of being confined to a single viewport height. This prevents content cutoff, improves accessibility and usability on smaller screens, and ensures users can view full roadmap content and interact with page elements without layout constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->