### PR TITLE
Fix #812: Add reading progress indicator for learning and guide pages

### DIFF
--- a/client/src/components/ReadingProgressBar.tsx
+++ b/client/src/components/ReadingProgressBar.tsx
@@ -5,15 +5,21 @@ export function ReadingProgressBar() {
   const [progress, setProgress] = useState(0);
 
   useEffect(() => {
+    let frame = 0;
+
     const updateProgress = () => {
-      const scrollTop = window.scrollY;
-      const scrollHeight =
-        document.documentElement.scrollHeight - window.innerHeight;
+      cancelAnimationFrame(frame);
 
-      const scrollProgress =
-        scrollHeight > 0 ? (scrollTop / scrollHeight) * 100 : 0;
+      frame = requestAnimationFrame(() => {
+        const scrollTop = window.scrollY;
+        const scrollHeight =
+          document.documentElement.scrollHeight - window.innerHeight;
 
-      setProgress(Math.min(scrollProgress, 100));
+        const scrollProgress =
+          scrollHeight > 0 ? (scrollTop / scrollHeight) * 100 : 0;
+
+        setProgress(Math.min(scrollProgress, 100));
+      });
     };
 
     updateProgress();
@@ -22,6 +28,7 @@ export function ReadingProgressBar() {
     window.addEventListener("resize", updateProgress);
 
     return () => {
+      cancelAnimationFrame(frame);
       window.removeEventListener("scroll", updateProgress);
       window.removeEventListener("resize", updateProgress);
     };
@@ -31,7 +38,12 @@ export function ReadingProgressBar() {
     <div className="fixed left-0 top-0 z-50 h-1 w-full bg-transparent">
       <motion.div
         className="h-full bg-indigo-600 dark:bg-indigo-400"
-        style={{ width: `${progress}%` }}
+        role="progressbar"
+        aria-valuenow={Math.round(progress)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        initial={{ width: "0%" }}
+        animate={{ width: `${progress}%` }}
         transition={{ duration: 0.15, ease: "easeOut" }}
       />
     </div>

--- a/client/src/components/ReadingProgressBar.tsx
+++ b/client/src/components/ReadingProgressBar.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+
+export function ReadingProgressBar() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const updateProgress = () => {
+      const scrollTop = window.scrollY;
+      const scrollHeight =
+        document.documentElement.scrollHeight - window.innerHeight;
+
+      const scrollProgress =
+        scrollHeight > 0 ? (scrollTop / scrollHeight) * 100 : 0;
+
+      setProgress(Math.min(scrollProgress, 100));
+    };
+
+    updateProgress();
+
+    window.addEventListener("scroll", updateProgress, { passive: true });
+    window.addEventListener("resize", updateProgress);
+
+    return () => {
+      window.removeEventListener("scroll", updateProgress);
+      window.removeEventListener("resize", updateProgress);
+    };
+  }, []);
+
+  return (
+    <div className="fixed left-0 top-0 z-50 h-1 w-full bg-transparent">
+      <motion.div
+        className="h-full bg-indigo-600 dark:bg-indigo-400"
+        style={{ width: `${progress}%` }}
+        transition={{ duration: 0.15, ease: "easeOut" }}
+      />
+    </div>
+  );
+}

--- a/client/src/module/LandingPage/landingPage.tsx
+++ b/client/src/module/LandingPage/landingPage.tsx
@@ -13,11 +13,9 @@ import { SEO } from "../../components/SEO"
 import { canonicalUrl } from "../../lib/seo.utils"
 import { faqSchema, websiteSchema, platformOrganizationSchema } from "../../lib/structured-data"
 
-
 export default function LandingPage(){
     return(
         <div className="font-sans bg-stone-50 dark:bg-stone-950 text-stone-900 dark:text-stone-50 pt-16 md:pt-0">
-           
             <SEO
               title="Free ATS Resume Scorer, Internships & Career Roadmaps for Students"
               description="Score your resume with AI, browse 1,200+ curated internships, follow developer career roadmaps, and get placed. Trusted by students at IITs, NITs, and 200+ colleges. Free to start."

--- a/client/src/module/LandingPage/landingPage.tsx
+++ b/client/src/module/LandingPage/landingPage.tsx
@@ -13,9 +13,11 @@ import { SEO } from "../../components/SEO"
 import { canonicalUrl } from "../../lib/seo.utils"
 import { faqSchema, websiteSchema, platformOrganizationSchema } from "../../lib/structured-data"
 
+
 export default function LandingPage(){
     return(
         <div className="font-sans bg-stone-50 dark:bg-stone-950 text-stone-900 dark:text-stone-50 pt-16 md:pt-0">
+           
             <SEO
               title="Free ATS Resume Scorer, Internships & Career Roadmaps for Students"
               description="Score your resume with AI, browse 1,200+ curated internships, follow developer career roadmaps, and get placed. Trusted by students at IITs, NITs, and 200+ colleges. Free to start."

--- a/client/src/module/blog/BlogPostPage.tsx
+++ b/client/src/module/blog/BlogPostPage.tsx
@@ -41,6 +41,7 @@ import { formatBlogDate } from "./utils/formatBlogDate";
 import { calculateReadingTime } from "./utils/calculateReadingTime";
 
 import type { BlogPost } from "../../lib/types";
+import { ReadingProgressBar } from "../../components/ReadingProgressBar";
 
 // ─────────────────────────────────────────────────────────────
 // HTML Escaping
@@ -260,6 +261,7 @@ export default function BlogPostPage() {
 
   return (
     <div className="font-sans min-h-screen bg-stone-50 dark:bg-stone-950 text-stone-900 dark:text-stone-50">
+      <ReadingProgressBar />
       {post && (
         <SEO
           title={post.title}

--- a/client/src/module/student/opensource/FirstPRSectionPage.tsx
+++ b/client/src/module/student/opensource/FirstPRSectionPage.tsx
@@ -16,6 +16,7 @@ import { CodeBlock } from "../../../components/ui/CodeBlock";
 import { canonicalUrl } from "../../../lib/seo.utils";
 import guideData from "./data/open-source-guide.json";
 import { useKeyboardNavigation } from "../../../hooks/useKeyboardNavigation";
+import { ReadingProgressBar } from "../../../components/ReadingProgressBar";
 
 // ─── Types ─────────────────────────────────────────────────────
 interface Resource { title: string; url: string; type: string }
@@ -82,6 +83,7 @@ export default function FirstPRSectionPage() {
 
   return (
     <div className="relative pb-12">
+      <ReadingProgressBar />
       <SEO
         title={`${step.title} - First PR Guide`}
         description={step.description || `Learn ${step.title} in our step-by-step first pull request guide.`}

--- a/client/src/module/student/opensource/components/GuideSectionPage.tsx
+++ b/client/src/module/student/opensource/components/GuideSectionPage.tsx
@@ -10,6 +10,7 @@ import { Button } from "../../../../components/ui/button";
 import { CodeBlock } from "../../../../components/ui/CodeBlock";
 import { canonicalUrl } from "../../../../lib/seo.utils";
 import { InlineCodeText } from "../../../../components/ui/InlineCodeText";
+import { ReadingProgressBar } from "../../../../components/ReadingProgressBar";
 
 interface Resource { title: string; url: string; type: string }
 interface Command { label: string; code: string }
@@ -137,6 +138,7 @@ const submitFeedback = async (
 
   return (
     <div className="relative pb-12">
+      <ReadingProgressBar />
       <SEO
         title={`${step.title} - ${seoSuffix}`}
         description={step.description}

--- a/client/src/module/student/opensource/components/GuideSectionPage.tsx
+++ b/client/src/module/student/opensource/components/GuideSectionPage.tsx
@@ -9,6 +9,7 @@ import { SEO } from "../../../../components/SEO";
 import { Button } from "../../../../components/ui/button";
 import { CodeBlock } from "../../../../components/ui/CodeBlock";
 import { canonicalUrl } from "../../../../lib/seo.utils";
+import { ReadingProgressBar } from "../../../../components/ReadingProgressBar";
 
 interface Resource { title: string; url: string; type: string }
 interface Command { label: string; code: string }
@@ -121,6 +122,7 @@ const submitFeedback = async (
 
   return (
     <div className="relative pb-12">
+      <ReadingProgressBar />
       <SEO
         title={`${step.title} - ${seoSuffix}`}
         description={step.description}


### PR DESCRIPTION
# Pull Request

## Description

Added a reusable reading progress indicator component for long educational and guide pages.

The progress bar dynamically updates based on scroll position and improves navigation experience for users reading long-form content.

Integrated the progress indicator into:

* Guide section pages
* First PR roadmap pages
* Blog post pages

## Related Issue

Fixes #812

## Type of Change

* [ ] Bug Fix
* [x] Feature
* [x] Enhancement
* [ ] Documentation

## Testing

Tested manually by:

1. Running the frontend locally using `npm run dev`
2. Opening long guide/learning pages
3. Scrolling through content
4. Verifying that the reading progress bar updates smoothly based on page scroll percentage
5. Checked responsiveness and dark mode compatibility

## Screenshots

(if applicable)

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [ ] Docs updated (if needed)
* [ ] Screenshots added for UI changes (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reading progress indicator bar that appears at the top of blog posts, guide pages, and the "First PR" tutorial page, showing your scroll position and animating smoothly as you navigate content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->