### PR TITLE
feat: added theme transition animation to landing page

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -8,7 +8,7 @@ import {
   Sun,
   Moon,
 } from "lucide-react";
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
 import { Link, useNavigate, useLocation } from "react-router";
 import { useAuthStore } from "../lib/auth.store";
 import { useThemeStore } from "../lib/theme.store";
@@ -46,6 +46,15 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
   const handleLogout = () => {
     logout();
     navigate("/");
+  };
+
+  const handleThemeToggle = (event: MouseEvent<HTMLButtonElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+
+    toggleTheme({
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    });
   };
 
   const dashboardLink =
@@ -147,7 +156,7 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
 
           <div className="hidden lg:flex items-center gap-2">
             <button
-              onClick={toggleTheme}
+              onClick={handleThemeToggle}
               aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
               className="p-2 text-stone-500 hover:text-stone-900 hover:bg-stone-200/60 dark:text-stone-400 dark:hover:text-stone-50 dark:hover:bg-white/5 rounded-md transition-colors"
             >
@@ -242,7 +251,7 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
 
           <div className="flex lg:hidden items-center gap-2">
             <button
-              onClick={toggleTheme}
+              onClick={handleThemeToggle}
               aria-label={
                 theme === "dark"
                   ? "Switch to light mode"

--- a/client/src/components/ThemeProvider.tsx
+++ b/client/src/components/ThemeProvider.tsx
@@ -1,16 +1,11 @@
 import { useEffect } from "react";
-import { useThemeStore } from "../lib/theme.store";
+import { applyThemeToDocument, useThemeStore } from "../lib/theme.store";
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const theme = useThemeStore((s) => s.theme);
 
   useEffect(() => {
-    const root = document.documentElement;
-    if (theme === "dark") {
-      root.classList.add("dark");
-    } else {
-      root.classList.remove("dark");
-    }
+    applyThemeToDocument(theme);
   }, [theme]);
 
   return <>{children}</>;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -87,6 +87,48 @@ body {
   transition: background-color 0.3s, color 0.3s;
 }
 
+html[data-theme-transition="running"]::view-transition-group(root) {
+  animation-duration: 560ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+html[data-theme-transition="running"]::view-transition-old(root),
+html[data-theme-transition="running"]::view-transition-new(root) {
+  animation-duration: 560ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  mix-blend-mode: normal;
+}
+
+html[data-theme-transition="running"]::view-transition-old(root) {
+  animation-name: none;
+}
+
+html[data-theme-transition="running"]::view-transition-new(root) {
+  animation-name: theme-reveal;
+}
+
+@keyframes theme-reveal {
+  from {
+    clip-path: circle(0 at var(--theme-transition-x) var(--theme-transition-y));
+  }
+
+  to {
+    clip-path: circle(var(--theme-transition-radius) at var(--theme-transition-x) var(--theme-transition-y));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-theme-transition="running"]::view-transition-group(root),
+  html[data-theme-transition="running"]::view-transition-old(root),
+  html[data-theme-transition="running"]::view-transition-new(root) {
+    animation-duration: 1ms;
+  }
+
+  html[data-theme-transition="running"]::view-transition-new(root) {
+    animation-name: none;
+  }
+}
+
 html,
 body {
   scrollbar-width: thin;

--- a/client/src/lib/theme.store.ts
+++ b/client/src/lib/theme.store.ts
@@ -1,31 +1,121 @@
 import { create } from "zustand";
 
 type Theme = "light" | "dark";
+type ThemeTransitionOrigin = { x: number; y: number };
+
+type ViewTransitionDocument = Document & {
+  startViewTransition?: (callback: () => void) => {
+    finished: Promise<void>;
+  };
+};
 
 interface ThemeState {
   theme: Theme;
-  toggleTheme: () => void;
-  setTheme: (theme: Theme) => void;
+  toggleTheme: (origin?: ThemeTransitionOrigin) => void;
+  setTheme: (theme: Theme, origin?: ThemeTransitionOrigin) => void;
 }
 
 function getInitialTheme(): Theme {
-  const stored = localStorage.getItem("theme");
-  if (stored === "light" || stored === "dark") return stored;
+  try {
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark") return stored;
+  } catch {
+    return "light";
+  }
+
   return "light";
 }
 
-export const useThemeStore = create<ThemeState>((set) => ({
-  theme: getInitialTheme(),
-
-  toggleTheme: () =>
-    set((state) => {
-      const next = state.theme === "light" ? "dark" : "light";
-      localStorage.setItem("theme", next);
-      return { theme: next };
-    }),
-
-  setTheme: (theme) => {
+function persistTheme(theme: Theme) {
+  try {
     localStorage.setItem("theme", theme);
+  } catch {
+    // Theme persistence is progressive enhancement; keep toggling if storage is unavailable.
+  }
+}
+
+export function applyThemeToDocument(theme: Theme) {
+  if (typeof document === "undefined") return;
+
+  document.documentElement.classList.toggle("dark", theme === "dark");
+}
+
+function prepareThemeTransition(origin?: ThemeTransitionOrigin) {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    return undefined;
+  }
+
+  const root = document.documentElement;
+  const x = origin?.x ?? window.innerWidth / 2;
+  const y = origin?.y ?? window.innerHeight / 2;
+  const radius = Math.ceil(
+    Math.hypot(Math.max(x, window.innerWidth - x), Math.max(y, window.innerHeight - y)),
+  );
+
+  root.style.setProperty("--theme-transition-x", `${x}px`);
+  root.style.setProperty("--theme-transition-y", `${y}px`);
+  root.style.setProperty("--theme-transition-radius", `${radius}px`);
+  root.setAttribute("data-theme-transition", "running");
+
+  return () => {
+    root.removeAttribute("data-theme-transition");
+    root.style.removeProperty("--theme-transition-x");
+    root.style.removeProperty("--theme-transition-y");
+    root.style.removeProperty("--theme-transition-radius");
+  };
+}
+
+function runThemeTransition(updateTheme: () => void, origin?: ThemeTransitionOrigin) {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    updateTheme();
+    return;
+  }
+
+  const viewTransition = (document as ViewTransitionDocument).startViewTransition;
+  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  if (!viewTransition || prefersReducedMotion) {
+    updateTheme();
+    return;
+  }
+
+  let cleanup: () => void = () => undefined;
+
+  try {
+    cleanup = prepareThemeTransition(origin) ?? cleanup;
+    const transition = viewTransition.call(document, updateTheme);
+    void transition.finished.then(cleanup, cleanup);
+  } catch {
+    cleanup();
+    updateTheme();
+  }
+}
+
+const initialTheme = getInitialTheme();
+applyThemeToDocument(initialTheme);
+
+export const useThemeStore = create<ThemeState>((set, get) => {
+  const commitTheme = (theme: Theme) => {
+    persistTheme(theme);
+    applyThemeToDocument(theme);
     set({ theme });
-  },
-}));
+  };
+
+  return {
+    theme: initialTheme,
+
+    toggleTheme: (origin) => {
+      const next = get().theme === "light" ? "dark" : "light";
+      runThemeTransition(() => commitTheme(next), origin);
+    },
+
+    setTheme: (theme, origin) => {
+      if (get().theme === theme) {
+        commitTheme(theme);
+        return;
+      }
+
+      runThemeTransition(() => commitTheme(theme), origin);
+    },
+  };
+});

--- a/client/src/lib/theme.store.ts
+++ b/client/src/lib/theme.store.ts
@@ -9,6 +9,8 @@ type ViewTransitionDocument = Document & {
   };
 };
 
+let themeTransitionId = 0;
+
 interface ThemeState {
   theme: Theme;
   toggleTheme: (origin?: ThemeTransitionOrigin) => void;
@@ -46,6 +48,7 @@ function prepareThemeTransition(origin?: ThemeTransitionOrigin) {
   }
 
   const root = document.documentElement;
+  const transitionId = String(++themeTransitionId);
   const x = origin?.x ?? window.innerWidth / 2;
   const y = origin?.y ?? window.innerHeight / 2;
   const radius = Math.ceil(
@@ -56,9 +59,13 @@ function prepareThemeTransition(origin?: ThemeTransitionOrigin) {
   root.style.setProperty("--theme-transition-y", `${y}px`);
   root.style.setProperty("--theme-transition-radius", `${radius}px`);
   root.setAttribute("data-theme-transition", "running");
+  root.setAttribute("data-theme-transition-id", transitionId);
 
   return () => {
+    if (root.getAttribute("data-theme-transition-id") !== transitionId) return;
+
     root.removeAttribute("data-theme-transition");
+    root.removeAttribute("data-theme-transition-id");
     root.style.removeProperty("--theme-transition-x");
     root.style.removeProperty("--theme-transition-y");
     root.style.removeProperty("--theme-transition-radius");

--- a/server/src/utils/cron-lock.test.ts
+++ b/server/src/utils/cron-lock.test.ts
@@ -4,7 +4,7 @@ import { prisma } from "../database/db.js";
 
 vi.mock("../database/db.js", () => ({
   prisma: {
-    $transaction: vi.fn(),
+    $queryRaw: vi.fn(),
   },
 }));
 
@@ -16,39 +16,31 @@ describe("withAdvisoryLock", () => {
   });
 
   it("should run the function if lock is acquired", async () => {
-    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
-      const tx = {
-        $queryRaw: vi.fn().mockResolvedValue([{ locked: true }]),
-      };
-      return await callback(tx);
-    });
+    vi.mocked(prisma.$queryRaw)
+      .mockResolvedValueOnce([{ locked: true }])
+      .mockResolvedValueOnce([{ unlocked: true }]);
 
     await withAdvisoryLock("test-job", mockFn);
 
-    expect(prisma.$transaction).toHaveBeenCalledOnce();
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(2);
     expect(mockFn).toHaveBeenCalledOnce();
   });
 
   it("should skip the function if lock is NOT acquired", async () => {
-    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => {
-      const tx = {
-        $queryRaw: vi.fn().mockResolvedValue([{ locked: false }]),
-      };
-      return await callback(tx);
-    });
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ locked: false }]);
 
     await withAdvisoryLock("locked-job", mockFn);
 
-    expect(prisma.$transaction).toHaveBeenCalledOnce();
+    expect(prisma.$queryRaw).toHaveBeenCalledOnce();
     expect(mockFn).not.toHaveBeenCalled();
   });
 
   it("should handle transaction errors gracefully", async () => {
-    vi.mocked(prisma.$transaction).mockRejectedValueOnce(new Error("DB Error"));
+    vi.mocked(prisma.$queryRaw).mockRejectedValueOnce(new Error("DB Error"));
 
     await withAdvisoryLock("error-job", mockFn);
 
-    expect(prisma.$transaction).toHaveBeenCalledOnce();
+    expect(prisma.$queryRaw).toHaveBeenCalledOnce();
     expect(mockFn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# Pull Request

## Description
Added a smooth, lightweight theme-changing transition for the shared navbar theme toggle. The transition uses the browser View Transitions API with a radial reveal starting from the clicked toggle button, and safely falls back to the existing instant switch when unsupported or when reduced motion is preferred.
Also updates the stale cron-lock unit test mock to match the current `$queryRaw` advisory-lock implementation so the server test suite remains green.

## Related Issue
Fixes #773

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
- Ran server typecheck, lint, and tests.
- Ran client lint, production build, and typecheck.
- Manually previewed the landing page theme toggle flow without requiring env variables.

## Screenshots

https://github.com/user-attachments/assets/10ec0e81-b7cf-45c6-af05-2980ddc15f4e


## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] Screenshots added for UI changes (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme switching now includes a smooth circular reveal animation that originates from the toggle click location.
  * Animations respect system reduced-motion preferences and disable accordingly.

* **Refactor**
  * Centralized and hardened theme management and persistence for more reliable behavior.

* **Tests**
  * Updated tests and mocking strategy to improve coverage of lock-handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->