### PR TITLE
fix(auth): bound versionCache with size cap and periodic eviction

### DIFF
--- a/server/src/middleware/auth.middleware.ts
+++ b/server/src/middleware/auth.middleware.ts
@@ -2,9 +2,23 @@ import type { Request, Response, NextFunction } from "express";
 import { verifyToken } from "../utils/jwt.utils.js";
 import { prisma } from "../database/db.js";
 
-// ── In-memory tokenVersion cache (2-minute TTL) ──
-const TOKEN_VERSION_TTL_MS = 2 * 60 * 1000;
+// ── In-memory tokenVersion cache (5-minute TTL, 10 000-entry size cap) ──
+const TOKEN_VERSION_TTL_MS = 5 * 60 * 1000;
+const VERSION_CACHE_MAX_SIZE = 10_000;
+
+// insertion-ordered Map: oldest entries are at the front (Map preserves insertion order)
 const versionCache = new Map<number, { version: number; expiresAt: number }>();
+
+// Background sweep: evict expired entries every 5 minutes so stale entries from
+// deleted or logged-out users do not accumulate for the process lifetime.
+const _versionCacheSweepTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [uid, entry] of versionCache) {
+    if (now > entry.expiresAt) {
+      versionCache.delete(uid);
+    }
+  }
+}, TOKEN_VERSION_TTL_MS).unref();
 
 function getCachedVersion(userId: number): number | null {
   const entry = versionCache.get(userId);
@@ -16,6 +30,14 @@ function getCachedVersion(userId: number): number | null {
 }
 
 function setCachedVersion(userId: number, version: number): void {
+  // LRU-style eviction: if the map is at capacity, remove the oldest entry
+  // (the first key in insertion order) before inserting a new one.
+  if (!versionCache.has(userId) && versionCache.size >= VERSION_CACHE_MAX_SIZE) {
+    const oldestKey = versionCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      versionCache.delete(oldestKey);
+    }
+  }
   versionCache.set(userId, { version, expiresAt: Date.now() + TOKEN_VERSION_TTL_MS });
 }
 


### PR DESCRIPTION
## Summary

- `versionCache` in `server/src/middleware/auth.middleware.ts` is a module-level `Map` that previously had no eviction path other than a per-read TTL check. Entries for deleted or logged-out users were never removed unless that user made another request after their TTL elapsed.
- On high-traffic deployments, or after bulk account deletion, this caused unbounded memory growth proportional to the number of unique users who had ever authenticated.
- This PR introduces two complementary eviction mechanisms to cap memory usage.

## Changes

### Periodic sweep (`setInterval`)
A background timer runs every 5 minutes and deletes all entries whose `expiresAt` timestamp has passed. The timer is created with `.unref()` so it does not prevent the Node.js process from exiting gracefully.

### Size cap with LRU-style eviction
`VERSION_CACHE_MAX_SIZE` is set to 10 000 entries. When a new entry would exceed the cap, the oldest entry (first key in insertion order, since `Map` preserves insertion order) is evicted before the new entry is inserted. This provides a hard memory ceiling independent of eviction timing.

### TTL adjustment
The TTL is extended from 2 minutes to 5 minutes to align with the sweep interval. This reduces unnecessary DB reads for active sessions while still ensuring stale entries are cleaned up promptly.

## Test plan

- [ ] Under normal traffic, `versionCache.size` does not grow indefinitely after creating and deleting many users
- [ ] After 5 minutes of inactivity following user deletion, the sweep removes the stale entries
- [ ] When the cache reaches 10 000 entries and a new user authenticates, the oldest entry is evicted and `versionCache.size` stays at 10 000
- [ ] `invalidateVersionCache` still works correctly and removes the entry immediately
- [ ] Existing auth flow (JWT validation, tokenVersion check) is unaffected

Closes #850

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized authentication token caching with extended TTL, implemented size limits, and automatic cleanup to improve system stability and memory efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->