### PR TITLE
fix: remove redundant JD length validation toast

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -676,15 +676,7 @@ export default function AtsScorePage() {
                       </label>
                       <textarea
                         value={jobDescription}
-                        onChange={(e) => {
-                          const next = e.target.value.slice(0, JD_MAX_CHARS);
-                          if (e.target.value.length > JD_MAX_CHARS) {
-                            toast.error(
-                              `Job description capped at ${JD_MAX_CHARS.toLocaleString()} characters.`,
-                            );
-                          }
-                          setJobDescription(next);
-                        }}
+                        onChange={(e) => setJobDescription(e.target.value)}
                         maxLength={JD_MAX_CHARS}
                         placeholder="Paste the job description for tailored keyword analysis..."
                         rows={5}


### PR DESCRIPTION
This PR removes the redundant job description length validation toast from the ATS Score page.

## Changes Made

* Removed unnecessary `toast.error()` from the job description `onChange` handler.
* Removed manual `slice(0, JD_MAX_CHARS)` truncation.
* Kept the existing `maxLength={JD_MAX_CHARS}` browser-level validation.
* Retained the existing live character counter.

The textarea already uses `maxLength`, which prevents users from entering more than the allowed number of characters. As a result, the toast condition is effectively unreachable during normal typing and creates redundant validation logic.

## Result

* Cleaner code.
* Better user experience.
* No unnecessary error notifications.
* Character count feedback remains available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified job description input validation in the ATS score page by removing manual character limit enforcement and toast notifications while maintaining the character limit restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->