### PR TITLE
Fix scroll position preservation on route navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { ProtectedRoute } from "./components/ProtectedRoute";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { LoadingScreen } from "./components/LoadingScreen";
 import BackToTopButton from "./components/common/BackToTopButton";
+import ScrollToTop from "./components/common/ScrollToTop";
 const ContributorsPage = lazyWithRetry(() => import("./module/contributors/ContributorsPage"));
 
 function lazyWithRetry(factory: () => Promise<{ default: ComponentType<unknown> }>) {
@@ -309,6 +310,7 @@ function AuthExpiredRedirect() {
 function App() {
   return (
     <>
+      <ScrollToTop />
       <AuthExpiredRedirect />
       <Toaster />
       <ErrorBoundary>

--- a/client/src/components/common/ScrollToTop.tsx
+++ b/client/src/components/common/ScrollToTop.tsx
@@ -2,8 +2,8 @@ import { useEffect } from "react";
 import { useLocation } from "react-router";
 
 /**
- * Scrolls the window to the top on every route change.
- * Place this once inside <BrowserRouter> (already done in App.tsx).
+ * ScrollToTop — scrolls the window to the top on every route change.
+ * Place this once inside your Router context (already done in App.tsx).
  * It renders nothing — it only runs the side-effect.
  */
 export default function ScrollToTop() {

--- a/client/src/components/common/ScrollToTop.tsx
+++ b/client/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+/**
+ * Scrolls the window to the top on every route change.
+ * Place this once inside <BrowserRouter> (already done in App.tsx).
+ * It renders nothing — it only runs the side-effect.
+ */
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes an issue where the scroll position was preserved when navigating between routes.

React Router's client-side navigation doesn't trigger a full page reload, so the browser retains the previous scroll position by default. This caused users to land mid-page after route transitions instead of starting at the top of the new page.

### Changes Made

- Added a ScrollToTop component (ScrollToTop.tsx) that watches useLocation().pathname and calls window.scrollTo(0, 0) on every route change.
- Mounted <ScrollToTop /> near the top of App.tsx so the behavior applies consistently across all route transitions.

## Related Issue
Fixes #927  

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing

1. Opening a page with sufficient content to scroll.
2. Scrolling down the page.
3. Navigating to another route using the application's navigation.
4. Verifying that the new page starts at the top instead of preserving the previous scroll position.
5. Repeating the test across multiple route transitions.

## Screenshots
https://github.com/user-attachments/assets/098be608-4dd2-4b2b-9e02-cbdcd381f453

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [ ] Screenshots added for UI changes (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic scroll-to-top when navigating between routes for a smoother browsing experience. This behavior is now applied globally within the app so each route change resets the viewport to the top.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->