### PR TITLE
Add repo discovery sort parameter support

### DIFF
--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -153,7 +153,7 @@ export default function RepoDiscoveryPage() {
   };
 
   const queryParams = useMemo(() => {
-    const params: Record<string, string | number> = { page, limit: 12, sortBy: sortKey, sortOrder: "desc" };
+    const params: Record<string, string | number> = { page, limit: 12, sort: sortKey, sortOrder: "desc" };
 
     if (search.trim()) params.search = search.trim();
     if (selectedDomain !== "ALL") params.domain = selectedDomain;

--- a/client/src/module/student/opensource/reposData.ts
+++ b/client/src/module/student/opensource/reposData.ts
@@ -23,6 +23,7 @@ export const SORT_OPTIONS = [
   { key: "stars", label: "Most Stars", order: "desc" },
   { key: "forks", label: "Most Forks", order: "desc" },
   { key: "openIssues", label: "Most Open Issues", order: "desc" },
+  { key: "createdAt", label: "Newest", order: "desc" },
   { key: "lastUpdated", label: "Recently Updated", order: "desc" },
   { key: "name", label: "Name A–Z", order: "asc" },
 ] as const;

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+const opensourceSortFields = ["stars", "forks", "name", "createdAt", "openIssues", "lastUpdated"] as const;
+
 export const opensourceListQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),
@@ -7,10 +9,14 @@ export const opensourceListQuerySchema = z.object({
   language: z.string().optional(),
   difficulty: z.string().optional(),
   domain: z.string().optional(),
-  sortBy: z.enum(["stars", "forks", "name", "createdAt", "openIssues", "lastUpdated"]).default("stars"),
+  sort: z.enum(opensourceSortFields).optional(),
+  sortBy: z.enum(opensourceSortFields).optional(),
   sortOrder: z.enum(["asc", "desc"]).default("desc"),
   trending: z.enum(["true", "false"]).optional(),
-});
+}).transform((query) => ({
+  ...query,
+  sortBy: query.sort ?? query.sortBy ?? "stars",
+}));
 
 export const repoIdSchema = z.object({
   id: z.coerce.number().int().positive("Invalid repo ID"),

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -13,9 +13,9 @@ export const opensourceListQuerySchema = z.object({
   sortBy: z.enum(opensourceSortFields).optional(),
   sortOrder: z.enum(["asc", "desc"]).default("desc"),
   trending: z.enum(["true", "false"]).optional(),
-}).transform((query) => ({
+}).transform(({ sort, ...query }) => ({
   ...query,
-  sortBy: query.sort ?? query.sortBy ?? "stars",
+  sortBy: sort ?? query.sortBy ?? "stars",
 }));
 
 export const repoIdSchema = z.object({


### PR DESCRIPTION
## Summary
- add `Newest` to the repo discovery sort options
- send the selected sort as the `sort` query parameter from the discovery page
- keep backwards compatibility with the existing `sortBy` query parameter on the server
- map either `sort` or `sortBy` into the Prisma `orderBy` field after validation

## Why
Issue #489 asks for repo discovery sorting by stars, forks, open issues, and newest. The page already had most sort options wired through `sortBy`; this update aligns the client with the requested `sort` query parameter and adds the missing `Newest` option.

## Validation
- `git diff --check`
- `npm --prefix server run typecheck` with bundled Node v24.14.0 after `prisma:generate`
- `npm --prefix client run lint -- src/module/student/opensource/RepoDiscoveryPage.tsx src/module/student/opensource/reposData.ts`

Notes:
- `npm --prefix client run typecheck` currently fails on an existing duplicate `ownerUserId` declaration in `src/lib/types/roadmap.types.ts`, unrelated to this PR.
- Initial installs with local Node v20.2.0 hit project engine constraints, so validation used the Codex bundled Node v24.14.0.

Closes #489


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Newest" sorting option to repository discovery to sort by creation date (newest first).
* **Bug Fixes / Enhancements**
  * Improved handling of repository list sort parameters so the selected sort is recognized reliably and falls back to "Stars" when unspecified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->