### PR TITLE
Add status update handling with loading state

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationsList.tsx
+++ b/client/src/module/recruiter/applications/ApplicationsList.tsx
@@ -16,6 +16,7 @@ export default function ApplicationsList() {
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
   const [page, setPage] = useState(1);
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Debounce search input
@@ -48,14 +49,18 @@ export default function ApplicationsList() {
     fetchApplications();
   }, [jobId, page, statusFilter, debouncedSearch]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleStatusChange = async (appId: number, status: string) => {
-    try {
-      await api.patch(`/recruiter/applications/${appId}/status`, { status });
-      fetchApplications();
-    } catch {
-      alert("Failed to update status");
-    }
-  };
+const handleStatusChange = async (appId: number, status: string) => {
+  if (updatingId === appId) return;
+  setUpdatingId(appId);
+  try {
+    await api.patch(`/recruiter/applications/${appId}/status`, { status });
+    fetchApplications();
+  } catch {
+    alert("Failed to update status");
+  } finally {
+    setUpdatingId(null);
+  }
+};
 
   const handleAdvance = async (appId: number) => {
     try {
@@ -150,16 +155,27 @@ export default function ApplicationsList() {
                         <p className="text-sm text-gray-500 dark:text-gray-500">{app.student?.email}</p>
                       </Link>
                     </td>
-                    <td className="px-6 py-4">
-                      <select value={app.status} onChange={(e) => handleStatusChange(app.id, e.target.value)}
-                        className={`text-xs px-2.5 py-1 rounded-full font-medium border-0 ${getStatusColor(app.status)}`}>
-                        <option value="APPLIED">Applied</option>
-                        <option value="IN_PROGRESS">In Progress</option>
-                        <option value="SHORTLISTED">Shortlisted</option>
-                        <option value="REJECTED">Rejected</option>
-                        <option value="HIRED">Hired</option>
-                      </select>
-                    </td>
+                   <td className="px-6 py-4">
+  <div className="relative inline-flex items-center">
+    <select
+      value={app.status}
+      disabled={updatingId === app.id}
+      onChange={(e) => handleStatusChange(app.id, e.target.value)}
+      className={`text-xs px-2.5 py-1 rounded-full font-medium border-0 ${getStatusColor(app.status)} ${updatingId === app.id ? "opacity-50 cursor-not-allowed" : ""}`}>
+      <option value="APPLIED">Applied</option>
+      <option value="IN_PROGRESS">In Progress</option>
+      <option value="SHORTLISTED">Shortlisted</option>
+      <option value="REJECTED">Rejected</option>
+      <option value="HIRED">Hired</option>
+    </select>
+    {updatingId === app.id && (
+      <svg className="animate-spin ml-1.5 h-3 w-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 12 0 12 12H4z" />
+      </svg>
+    )}
+  </div>
+</td>
                     <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-500">
                       {app.roundSubmissions?.length || 0} completed
                     </td>


### PR DESCRIPTION
Title:
fix: disable status dropdown and show spinner during update [#1203]

Description:
Fixes #1203

## Problem
When a recruiter changed an application status, the dropdown stayed 
active during the API call. This allowed a second status change to be 
triggered before the first one completed, causing conflicting updates.

## Changes Made
File: `src/recruiter/applications/ApplicationsList.tsx`

- Added `updatingId` state to track which application is being updated
- Added `finally` block to `handleStatusChange` to always clear the 
  loading state (even on error)
- Disabled the status dropdown while its mutation is pending
- Added a spinner next to the dropdown during the update
- Added an early return guard to prevent duplicate calls

## Behavior After Fix
- Dropdown is disabled while the API call is in progress
- A spinner appears next to the dropdown as visual feedback
- Once the request completes (success or failure), the dropdown 
  re-enables automatically

## Type of Change
- [x] Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate requests when updating application statuses

* **Improvements**
  * Application status updates now display a loading indicator
  * Status selection is disabled while an update is in progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->