### PR TITLE
fix: add success toast after job creation (#1198)

### DIFF
--- a/client/src/module/recruiter/jobs/CreateJobPage.tsx
+++ b/client/src/module/recruiter/jobs/CreateJobPage.tsx
@@ -9,6 +9,7 @@ import { RoundsManager } from "../rounds/RoundsManager";
 import type { CustomFieldDefinition } from "../../../lib/types";
 import { SEO } from "../../../components/SEO";
 import { Button } from "../../../components/ui/button";
+import toast from "../../../components/ui/toast";
 
 interface RoundInput {
   name: string;
@@ -88,6 +89,7 @@ export default function CreateJobPage() {
         });
       }
 
+      toast.success("Job created successfully");
       navigate("/recruiters/jobs");
     } catch (err: unknown) {
       const error = err as { response?: { data?: { message?: string; errors?: { fieldErrors?: Record<string, string[]> } } } };


### PR DESCRIPTION
﻿## Description
Adds success toast notification after job creation so the user gets feedback before being redirected.

## Changes
- Imported 	oast from @/components/ui/toast
- Added 	oast.success("Job created successfully") before navigation

Closes #1198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added success confirmation message displayed upon job creation, providing immediate visual feedback to users before returning to the jobs list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->