### PR TITLE
fix: add submit-time score range validation (#1200)

### DIFF
--- a/client/src/module/recruiter/applications/EvaluationForm.tsx
+++ b/client/src/module/recruiter/applications/EvaluationForm.tsx
@@ -18,6 +18,15 @@ export function EvaluationForm({ applicationId, roundId, criteria, onComplete }:
   const [loading, setLoading] = useState(false);
 
   const handleSubmit = async () => {
+    const outOfRange = criteria.filter((c) => {
+      const s = scores[c.id]?.score ?? 0;
+      return s < 0 || s > c.maxScore;
+    });
+    if (outOfRange.length > 0) {
+      toast.error(`Scores out of range: ${outOfRange.map((c) => c.criterion).join(", ")}`);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     try {
       await api.put(`/recruiter/applications/${applicationId}/rounds/${roundId}/evaluate`, {


### PR DESCRIPTION
﻿## Description
Adds client-side validation in the submit handler to ensure all scores are within their allowed range before sending the evaluation.

## Changes
- Added range check in handleSubmit for each criterion score against c.maxScore
- Shows toast error listing out-of-range criteria instead of submitting invalid data

Closes #1200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation forms now validate all criteria scores before submission. Scores outside the acceptable range (below 0 or above the maximum allowed) are flagged with an error message, preventing invalid form submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->