### PR TITLE
fix: wrap dashboard in error boundary to prevent blank screen (#1201)

### DIFF
--- a/client/src/module/recruiter/RecruiterDashboard.tsx
+++ b/client/src/module/recruiter/RecruiterDashboard.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import api from "../../lib/axios";
 import { LoadingScreen } from "../../components/LoadingScreen";
+import { ErrorBoundary } from "../../components/ErrorBoundary";
 import { SEO } from "../../components/SEO";
 import { Button } from "../../components/ui/button";
 import { useAuthStore } from "../../lib/auth.store";
@@ -33,7 +34,7 @@ interface DashboardData {
   }[];
 }
 
-export default function RecruiterDashboard() {
+function RecruiterDashboardInner() {
   const { user } = useAuthStore();
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -350,6 +351,14 @@ function humanizeStatus(status: string) {
 function formatDate(iso: string) {
   const d = new Date(iso);
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export default function RecruiterDashboard() {
+  return (
+    <ErrorBoundary>
+      <RecruiterDashboardInner />
+    </ErrorBoundary>
+  );
 }
 
 function getStatusDot(status: string) {


### PR DESCRIPTION
﻿## Description
Wraps RecruiterDashboard in the existing ErrorBoundary component to catch rendering errors and prevent a blank white screen.

## Changes
- Imported ErrorBoundary from @/components/ErrorBoundary
- Renamed component to RecruiterDashboardInner
- Added new default export wrapping inner component with <ErrorBoundary>

Closes #1201
