### PR TITLE
Feat: enhanced copy to clipboard and added copy functionality to inline code snippets

### DIFF
--- a/client/src/components/ui/CodeBlock.tsx
+++ b/client/src/components/ui/CodeBlock.tsx
@@ -15,6 +15,7 @@ import sql from "react-syntax-highlighter/dist/esm/languages/prism/sql";
 import { vscDarkPlus, prism } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { useThemeStore } from "../../lib/theme.store";
 import { Button } from "./button";
+import toast from "./toast";
 
 SyntaxHighlighter.registerLanguage("markup", markup);
 SyntaxHighlighter.registerLanguage("html", markup);
@@ -69,16 +70,34 @@ export function CodeBlock({ code, label, example, language = "javascript" }: Cod
     try {
       await navigator.clipboard.writeText(activeCode);
       setCopied(true);
+      toast.success("Copied to clipboard!");
     } catch (err) {
       console.error("Failed to copy code: ", err);
+      toast.error("Failed to copy code");
     }
   }, [activeCode]);
+
+  // Allow copying with Ctrl/Cmd + C when the code block is focused, even if no text is selected
+  const handleKeyDown = useCallback(async (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const selectedText = window.getSelection()?.toString();
+
+      // Allow normal copy behavior when text is selected
+      if (selectedText) return;
+
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "c") {
+        e.preventDefault();
+
+        await handleCopy();
+      }
+    },
+    [handleCopy]
+  );
 
   // Choose the syntax highlighting theme
   const syntaxTheme = theme === "dark" ? vscDarkPlus : prism;
 
   return (
-    <div className="rounded-md border border-stone-200 dark:border-white/10 overflow-hidden bg-white dark:bg-stone-900">
+    <div tabIndex={0} onKeyDown={handleKeyDown} className="rounded-md border border-stone-200 dark:border-white/10 overflow-hidden bg-white dark:bg-stone-900">
       {/* Code block header */}
       <div className="flex items-center justify-between px-4 py-2.5 bg-stone-50 dark:bg-stone-950/40 border-b border-stone-200 dark:border-white/10">
         <div className="flex items-center gap-2 min-w-0">
@@ -93,10 +112,10 @@ export function CodeBlock({ code, label, example, language = "javascript" }: Cod
           size="sm"
           onClick={handleCopy}
           aria-label={copied ? "Code copied" : "Copy code to clipboard"}
-          className="font-mono uppercase tracking-widest text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 shrink-0"
+          className="font-mono uppercase tracking-widest text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 shrink-0 min-h-[36px] px-2"
         >
           {copied ? <Check className="w-3 h-3 text-lime-500" /> : <Copy className="w-3 h-3" />}
-          {copied ? "copied" : "copy"}
+          {copied ? "Copied" : "Copy"}
         </Button>
       </div>
 

--- a/client/src/components/ui/InlineCodeText.tsx
+++ b/client/src/components/ui/InlineCodeText.tsx
@@ -1,0 +1,46 @@
+import { Fragment } from "react";
+import toast from "./toast";
+import { cn } from "@/lib/utils";
+
+interface InlineCodeTextProps {
+  text: string;
+}
+
+export function InlineCodeText({ text }: InlineCodeTextProps) {
+  const handleCopy = async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+
+      toast.success("Code copied!");
+    } catch (err) {
+      console.error("Failed to copy inline code:", err);
+
+      toast.error("Failed to copy code");
+    }
+  };
+
+  const parts = text.split(/(`[^`]+`)/g);
+
+  return (
+    <>
+      {parts.map((part, index) => {
+        if (part.startsWith("`") && part.endsWith("`")) {
+          const code = part.slice(1, -1);
+
+          return (
+            <code
+              key={index}
+              onClick={() => handleCopy(code)}
+              title="Click to copy"
+              className="mx-0.5 rounded px-1.5 py-0.5 font-mono text-[0.9em] bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-gray-700 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors active:scale-95 inline"
+            >
+              {code}
+            </code>
+          );
+        }
+
+        return <Fragment key={index}>{part}</Fragment>;
+      })}
+    </>
+  );
+}

--- a/client/src/module/student/opensource/components/GuideSectionPage.tsx
+++ b/client/src/module/student/opensource/components/GuideSectionPage.tsx
@@ -9,6 +9,7 @@ import { SEO } from "../../../../components/SEO";
 import { Button } from "../../../../components/ui/button";
 import { CodeBlock } from "../../../../components/ui/CodeBlock";
 import { canonicalUrl } from "../../../../lib/seo.utils";
+import { InlineCodeText } from "../../../../components/ui/InlineCodeText";
 
 interface Resource { title: string; url: string; type: string }
 interface Command { label: string; code: string }
@@ -194,7 +195,7 @@ const submitFeedback = async (
           >
             <h2 className="text-lg font-bold text-gray-950 dark:text-white mb-4">Explanation</h2>
             <div className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed whitespace-pre-line">
-              {step.mentor_guidance}
+              <InlineCodeText text={step.mentor_guidance} />
             </div>
           </motion.div>
         )}
@@ -228,9 +229,9 @@ const submitFeedback = async (
             </div>
             <ul className="space-y-3">
               {step.details.map((detail, i) => (
-                <li key={i} className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed flex items-start gap-2.5">
+                <li key={i} className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed list-disc">
                   <span className="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-gray-500 mt-2 shrink-0" />
-                  {detail}
+                  <InlineCodeText text={detail} />
                 </li>
               ))}
             </ul>
@@ -252,9 +253,9 @@ const submitFeedback = async (
             </div>
             <ul className="space-y-3">
               {step.tips.map((tip, i) => (
-                <li key={i} className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed flex items-start gap-2.5">
+                <li key={i} className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed list-disc">
                   <span className="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-gray-500 mt-2 shrink-0" />
-                  {tip}
+                  <InlineCodeText text={tip} />
                 </li>
               ))}
             </ul>
@@ -276,7 +277,7 @@ const submitFeedback = async (
             </div>
             <ul className="space-y-3">
               {step.resources.map((r, i) => (
-                <li key={i} className="flex items-start gap-2.5">
+                <li key={i} className="flex">
                   <span className="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-gray-500 mt-2 shrink-0" />
                   <a
                     href={r.url}


### PR DESCRIPTION
## Description

Improved guide section code-copy experience for both desktop and mobile users.

### Changes made:

* Made the `CodeBlock` copy button always visible on mobile devices instead of relying on hover states.
* Added success/error toast notifications when copying code snippets using the existing toast system.
* Added keyboard shortcut support (`Ctrl + C`) while focused on a code block.
* Added support for copying **inline code snippets** inside guide explanations, tips, and notes.
* Created reusable `InlineCodeText` component to detect backtick-wrapped inline code and allow one-click copying.
* Improved inline code styling to keep snippets naturally inline without breaking text flow.
* Updated guide content rendering to support interactive inline code snippets across:

  * mentor guidance
  * important notes
  * pro tips

## Related Issue

Fixes #1012

## Type of Change

* [x] Bug Fix
* [x] Enhancement

## Testing

Tested manually by:

1. Opening guide section pages locally.
2. Verifying copy button visibility on both desktop and mobile responsive mode.
3. Clicking copy buttons for:

   * code blocks
   * inline code snippets
4. Confirming success/error toast notifications appear correctly.
5. Verifying copied content is correctly pasted from clipboard.
6. Testing keyboard shortcut support (`Ctrl + C`) while focused on code blocks.
7. Confirming inline code snippets remain visually inline without layout breaking.

## Screenshots

### CodeBlock Changes
- Before 
<img width="519" height="1084" alt="image" src="https://github.com/user-attachments/assets/9117e2b5-e201-4920-94bf-f9d42ad7b62c" />

- After ( proper toast + `CTRL+C ` functionality added )
<img width="527" height="350" alt="image" src="https://github.com/user-attachments/assets/c72ce193-59fa-4863-b721-ba6cee78b8f5" />

### InlineCodeText UI Changes
- Before ( No inline code snippet copy )
<img width="940" height="413" alt="image" src="https://github.com/user-attachments/assets/85612daa-df3e-43b9-a339-d9c6b8ee319f" />

- After ( You can copy by clicking on that inline code snippet block )
<img width="940" height="397" alt="image" src="https://github.com/user-attachments/assets/0500fc5b-1282-4423-b95a-863f8a9317f6" />



## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [x] Docs updated (if needed)
* [x] Screenshot or video attached for every UI change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inline code snippets are now clickable to copy to clipboard.
  * Code blocks support keyboard shortcut (Ctrl/Cmd+C) for copying.
  * Copy actions now display success/error notifications.

* **Improvements**
  * Updated button labels and styling in code components.
  * Refined list styling and layout in guide sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->