### PR TITLE
fix: avoid non-finite conversion rate in job analytics

### DIFF
--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -486,6 +486,9 @@ export class RecruiterService {
       statusCounts[s.status] = s._count.id;
     }
 
+    const hiredCount = statusCounts["HIRED"] ?? 0;
+    const conversionRate = totalApplications === 0 ? 0 : (hiredCount / totalApplications) * 100;
+
     const roundAnalytics = rounds.map((round) => {
       const completed = round.roundSubmissions.filter((s) => s.status === "COMPLETED").length;
       const inProgress = round.roundSubmissions.filter((s) => s.status === "IN_PROGRESS").length;
@@ -506,6 +509,8 @@ export class RecruiterService {
       jobId,
       jobTitle: job.title,
       totalApplications,
+      hiredCount,
+      conversionRate,
       statusBreakdown: statusCounts,
       roundAnalytics,
     };


### PR DESCRIPTION
## What\nPrevent non-finite conversion rate values in job analytics response.\n\n## Root cause\nWhen totalApplications is 0, derived conversion rate calculations can become non-finite and serialize to null in JSON.\n\n## Changes\n- server/src/module/recruiter/recruiter.service.ts: return hiredCount + conversionRate (0 when totalApplications is 0)\n\n## Verification\n- npx prisma generate --schema=src/database/prisma/schema\n- npx tsc --noEmit\n- npm test\n\nCloses #1195\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced job analytics with new metrics: hired count and conversion rate. The conversion rate displays the percentage of total applications that resulted in hires, providing improved visibility into recruitment performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->