### PR TITLE
[BUG]: sendEmailBatch does not respect RESEND_TEST_TO in development / sandbox environments

### DIFF
--- a/server/src/utils/email.utils.ts
+++ b/server/src/utils/email.utils.ts
@@ -80,7 +80,16 @@ export async function sendEmailBatch(
   }
   if (emails.length > 100) throw new Error("Resend batch supports max 100 emails per call");
 
-  const payload = emails.map((e) => ({ from: FROM(), to: e.to, subject: e.subject, html: e.html }));
+  const from = FROM();
+  const isSandboxDev = from === TEST_FROM && process.env.NODE_ENV !== "production";
+  const testTo = process.env.RESEND_TEST_TO || DEFAULT_TEST_TO;
+
+  const payload = emails.map((e) => ({
+    from,
+    to: isSandboxDev ? testTo : e.to,
+    subject: e.subject,
+    html: e.html,
+  }));
   const maxRetries = opts.maxRetries ?? 4;
 
   const parseRetryAfter = (err: unknown): number | null => {


### PR DESCRIPTION
Resolves #1212

This PR implements the fix proposed in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced batch email sending to consistently apply sender information and sandbox-mode recipient overrides across all emails in the batch, improving efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->