### PR TITLE
fix: return 404 on unsave candidate with no match (#1171)

### DIFF
--- a/server/src/module/recruiter/recruiter.controller.ts
+++ b/server/src/module/recruiter/recruiter.controller.ts
@@ -359,7 +359,8 @@ export class RecruiterController {
       const studentId = parseInt(String(req.params["studentId"]), 10);
       if (isNaN(studentId)) return res.status(400).json({ message: "Invalid student ID" });
 
-      await this.recruiterService.unsaveCandidate(req.user.id, studentId);
+      const count = await this.recruiterService.unsaveCandidate(req.user.id, studentId);
+      if (count === 0) return res.status(404).json({ message: "Candidate not found in saved list" });
       return res.status(200).json({ message: "Candidate removed" });
     } catch (error) {
       logger.error("Failed to unsave candidate", error);

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -681,12 +681,9 @@ export class RecruiterService {
   }
 
   async unsaveCandidate(recruiterId: number, studentId: number) {
-    const existing = await prisma.savedCandidate.findUnique({
-      where: { recruiterId_studentId: { recruiterId, studentId } },
+    const { count } = await prisma.savedCandidate.deleteMany({
+      where: { recruiterId, studentId },
     });
-    if (!existing) return;
-    await prisma.savedCandidate.delete({
-      where: { recruiterId_studentId: { recruiterId, studentId } },
-    });
+    return count;
   }
 }


### PR DESCRIPTION
﻿{"title":"fix: return 404 on unsave candidate with no match (#1171)","body":"Closes #1171\n\nChanges the unsaveCandidate resolver from \findUnique+delete to deleteMany, returning { count } — only one DB call and gracefully handles missing saves.","head":"Xenon010101:feat/unsave-candidate-404-1171","base":"main"}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved the unsave candidate feature to correctly return a 404 error when attempting to remove a candidate that isn't in the saved list, ensuring more accurate API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->