### PR TITLE
fix: append notes with timestamp in saveCandidate (#1170)

### DIFF
--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -673,6 +673,18 @@ export class RecruiterService {
     const student = await prisma.user.findUnique({ where: { id: studentId } });
     if (!student || student.role !== "STUDENT") throw new Error("Student not found");
 
+    if (notes) {
+      const existing = await prisma.savedCandidate.findUnique({
+        where: { recruiterId_studentId: { recruiterId, studentId } },
+        select: { notes: true },
+      });
+
+      if (existing?.notes) {
+        const timestamp = new Date().toISOString();
+        notes = `${existing.notes}\n--- ${timestamp} ---\n${notes}`;
+      }
+    }
+
     return prisma.savedCandidate.upsert({
       where: { recruiterId_studentId: { recruiterId, studentId } },
       update: { notes: notes ?? null },


### PR DESCRIPTION
Closes #1170

Changes the saveCandidate resolver to append new notes with an ISO timestamp separator instead of silently overwriting existing recruiter notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Candidate notes are now preserved and appended with timestamps instead of being overwritten when updating candidate records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->