### PR TITLE
fix: use Intl.DateTimeFormat with explicit locale in RecruiterLayout (#1189)

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationsList.tsx
+++ b/client/src/module/recruiter/applications/ApplicationsList.tsx
@@ -164,7 +164,7 @@ export default function ApplicationsList() {
                       {app.roundSubmissions?.length || 0} completed
                     </td>
                     <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-500">
-                      {new Date(app.createdAt).toLocaleDateString()}
+                      {new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", day: "numeric", timeZone: "UTC" }).format(new Date(app.createdAt))}
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex items-center gap-2">


### PR DESCRIPTION
Closes #1189

Uses Intl.DateTimeFormat with 'en-US' locale instead of relying on the default locale, ensuring consistent date formatting.