### PR TITLE
feat: add skeleton placeholder for recruiter dashboard (#1185)

### DIFF
--- a/client/src/module/recruiter/RecruiterDashboard.tsx
+++ b/client/src/module/recruiter/RecruiterDashboard.tsx
@@ -48,7 +48,7 @@ export default function RecruiterDashboard() {
       .catch(() => setLoading(false));
   }, []);
 
-  if (loading) return <LoadingScreen />;
+  if (loading) return <DashboardSkeleton />;
 
   if (!data) {
     return (
@@ -326,6 +326,75 @@ export default function RecruiterDashboard() {
             </ul>
           )}
         </motion.section>
+      </div>
+    </div>
+  );
+}
+
+function DashboardSkeleton() {
+  return (
+    <div className="relative text-stone-900 dark:text-stone-50 animate-pulse">
+      <div className="relative max-w-6xl mx-auto">
+        <div className="mt-6 mb-10 flex flex-wrap items-end justify-between gap-6 border-b border-stone-200 dark:border-white/10 pb-8">
+          <div className="space-y-3">
+            <div className="h-3 w-32 bg-stone-200 dark:bg-stone-800 rounded" />
+            <div className="h-8 w-64 bg-stone-200 dark:bg-stone-800 rounded" />
+            <div className="h-4 w-48 bg-stone-200 dark:bg-stone-800 rounded" />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-12">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md p-5 space-y-3">
+              <div className="h-3 w-20 bg-stone-200 dark:bg-stone-800 rounded" />
+              <div className="h-8 w-16 bg-stone-200 dark:bg-stone-800 rounded" />
+            </div>
+          ))}
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-12">
+          <div className="lg:col-span-2 bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md p-6 space-y-4">
+            <div className="h-3 w-32 bg-stone-200 dark:bg-stone-800 rounded" />
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="flex items-center justify-between py-3">
+                <div className="flex items-center gap-2.5">
+                  <div className="h-1.5 w-1.5 bg-stone-200 dark:bg-stone-800 rounded-full" />
+                  <div className="h-3 w-24 bg-stone-200 dark:bg-stone-800 rounded" />
+                </div>
+                <div className="h-3 w-6 bg-stone-200 dark:bg-stone-800 rounded" />
+              </div>
+            ))}
+          </div>
+          <div className="lg:col-span-3 bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md p-6 space-y-4">
+            <div className="h-3 w-32 bg-stone-200 dark:bg-stone-800 rounded" />
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="h-3 w-28 bg-stone-200 dark:bg-stone-800 rounded" />
+                  <div className="h-3 w-16 bg-stone-200 dark:bg-stone-800 rounded" />
+                </div>
+                <div className="h-1 bg-stone-200 dark:bg-stone-800 rounded-sm w-full" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-4 mb-12">
+          <div className="h-3 w-32 bg-stone-200 dark:bg-stone-800 rounded" />
+          <div className="h-5 w-40 bg-stone-200 dark:bg-stone-800 rounded" />
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="flex items-center justify-between gap-4 px-5 py-4 border-l border-r border-b border-stone-200 dark:border-white/10 bg-white dark:bg-stone-900">
+              <div className="flex items-center gap-3">
+                <div className="w-9 h-9 bg-stone-200 dark:bg-stone-800 rounded-md" />
+                <div className="space-y-1.5">
+                  <div className="h-3 w-32 bg-stone-200 dark:bg-stone-800 rounded" />
+                  <div className="h-2.5 w-20 bg-stone-200 dark:bg-stone-800 rounded" />
+                </div>
+              </div>
+              <div className="h-3 w-16 bg-stone-200 dark:bg-stone-800 rounded" />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #1185

Replaces the generic \<LoadingScreen />\ with a \DashboardSkeleton\ component that mirrors the dashboard layout — stat cards, status breakdown, skills chart, and recent applications list — with pulse animation matching the actual content shape.