### PR TITLE
fix: sanitized recruiter custom field labels and placeholders

### DIFF
--- a/server/src/module/recruiter/recruiter.validation.ts
+++ b/server/src/module/recruiter/recruiter.validation.ts
@@ -5,7 +5,10 @@ const sanitizeText = (value: string) => value.replace(/<[^>]*>?/gm, "").trim();
 
 const customFieldDefinitionSchema = z.object({
   id: z.string(),
-  label: z.string().min(1).transform((value) => sanitizeText(value)),
+  label: z
+    .string()
+    .transform((value) => sanitizeText(value))
+    .refine((value) => value.length > 0, { message: "Label is required" }),
   fieldType: z.enum(["TEXT", "TEXTAREA", "DROPDOWN", "MULTI_SELECT", "FILE_UPLOAD", "BOOLEAN", "NUMERIC", "DATE", "EMAIL", "URL"]),
   required: z.boolean(),
   placeholder: z.string().optional().transform((value) => value ? sanitizeText(value) : value),

--- a/server/src/module/recruiter/recruiter.validation.ts
+++ b/server/src/module/recruiter/recruiter.validation.ts
@@ -1,11 +1,14 @@
 import { z } from "zod";
 
+// sanitization function
+const sanitizeText = (value: string) => value.replace(/<[^>]*>?/gm, "").trim();
+
 const customFieldDefinitionSchema = z.object({
   id: z.string(),
-  label: z.string(),
+  label: z.string().min(1).transform((value) => sanitizeText(value)),
   fieldType: z.enum(["TEXT", "TEXTAREA", "DROPDOWN", "MULTI_SELECT", "FILE_UPLOAD", "BOOLEAN", "NUMERIC", "DATE", "EMAIL", "URL"]),
   required: z.boolean(),
-  placeholder: z.string().optional(),
+  placeholder: z.string().optional().transform((value) => value ? sanitizeText(value) : value),
   options: z.array(z.string()).optional(),
   validation: z.object({
     min: z.number().optional(),


### PR DESCRIPTION
## Description

Implemented input sanitization for recruiter custom field definitions in `recruiter.validation.ts` to prevent HTML/script injection through `customFields[].label` and `customFields[].placeholder`.

## Changes made:

* Added sanitization logic using Zod `.trim().transform()` for:

  * `customFields[].label`
  * `customFields[].placeholder`
* Stripped potentially dangerous HTML tags before persistence.
* Ensured recruiter-provided form metadata is stored safely before rendering in applicant forms.
* Preserved normal text formatting while blocking malicious script injections.

This fixes the issue where raw HTML/script content could be stored and later rendered in the UI.

## Related Issue

Fixes #1108 

## Type of Change

* [x] Bug Fix
* [ ] Feature
* [x] Enhancement
* [ ] Documentation
* [x] Security

## Testing

Manually tested validation by sending custom field payloads containing:

* `<script>alert(1)</script>`
* `<img src=x onerror=alert(1)>`
* HTML tags inside labels/placeholders

Verified that:

* Dangerous HTML tags are stripped before persistence.
* Plain text values continue working correctly.
* Existing schema validation behavior remains unaffected.

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [ ] Docs updated (if needed)
* [x] Screenshot or video attached for every UI change (not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input sanitization for custom field labels and placeholders by removing HTML-like tags and excess whitespace
  * Enforced stricter validation requirements for custom field labels, ensuring they contain at least 1 character

<!-- end of auto-generated comment: release notes by coderabbit.ai -->