### PR TITLE
Fix: add pass rate per round with zero-submission guard in JobAnalyticsPage

### DIFF
--- a/client/src/module/recruiter/analytics/JobAnalyticsPage.tsx
+++ b/client/src/module/recruiter/analytics/JobAnalyticsPage.tsx
@@ -79,6 +79,7 @@ export default function JobAnalyticsPage() {
 
             {data.roundAnalytics.map((round, i) => {
               const pct = (round.totalSubmissions / maxSubmissions) * 100;
+              const passRate = round.totalSubmissions > 0 ? ((round.completed / round.totalSubmissions) * 100).toFixed(1) : "0";
               const dropRate = i === 0
                 ? data.totalApplications > 0 ? ((data.totalApplications - round.totalSubmissions) / data.totalApplications * 100).toFixed(0) : "0"
                 : data.roundAnalytics[i - 1]!.totalSubmissions > 0
@@ -103,6 +104,7 @@ export default function JobAnalyticsPage() {
                     <span>{round.completed} completed</span>
                     <span>{round.inProgress} in progress</span>
                     <span>{round.pending} pending</span>
+                    <span className="text-green-600 dark:text-green-400 font-medium">{passRate}% pass rate</span>
                   </div>
                 </div>
               );


### PR DESCRIPTION
## What
Adds pass rate display per round in recruitment funnel analytics, guarded against division by zero when a round has no submissions.

## Root cause
Pass-rate calculation divides by criteria/submissions which produces NaN/Infinity when zero.

## Changes
- client/src/module/recruiter/analytics/JobAnalyticsPage.tsx - added passRate calculation with 	otalSubmissions > 0 guard; displays pass rate per round

## Verification
Guard ensures 	otalSubmissions > 0 before division; defaults to % when no submissions exist.

Closes #1166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Recruitment funnel analytics now display per-round pass rates, calculated as the ratio of completed submissions to total submissions. Each round's details section includes the new pass rate metric alongside existing completion, in-progress, and pending metrics for enhanced recruitment performance visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->