### PR TITLE
Fix: verify next round exists before advancing application, return 404 if not found

### DIFF
--- a/server/src/module/recruiter/recruiter.controller.ts
+++ b/server/src/module/recruiter/recruiter.controller.ts
@@ -199,7 +199,7 @@ export class RecruiterController {
       return res.status(200).json({ message: "Application advanced to next round", application });
     } catch (error) {
       if (error instanceof Error) {
-        if (error.message === "Application not found") return res.status(404).json({ message: error.message });
+        if (error.message === "Application not found" || error.message === "Round not found") return res.status(404).json({ message: error.message });
         if (error.message === "Not authorized") return res.status(403).json({ message: error.message });
         if (error.message === "No rounds defined for this job") return res.status(400).json({ message: error.message });
       }

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -339,7 +339,8 @@ export class RecruiterService {
         });
       }
 
-      const nextRound = rounds[nextIndex]!;
+      const nextRound = rounds[nextIndex];
+      if (!nextRound) throw new Error("Round not found");
 
       // Create submission record for next round if not exists
       await tx.roundSubmission.upsert({


### PR DESCRIPTION
## What
Adds existence check for the next round before advancing an application, preventing unhandled Prisma foreign-key errors and returning a proper 404 response.

## Root cause
advanceApplication() used a non-null assertion on rounds[nextIndex] without verifying the round exists.

## Changes
- server/src/module/recruiter/recruiter.service.ts: replaced non-null assertion with explicit null check; throws Round not found if missing
- server/src/module/recruiter/recruiter.controller.ts: added Round not found to 404 handler

## Verification
If next round is missing, returns HTTP 404 with clear message instead of unhandled 500.

Closes #1165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the application advancement workflow to provide consistent HTTP 404 responses when required rounds or applications cannot be found
  * Enhanced validation when transitioning applications to the next round, ensuring proper error detection and messaging for unavailable rounds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->