### PR TITLE
Fix: add aria-valuetext to evaluation slider for screen reader accessibility

### DIFF
--- a/client/src/module/recruiter/applications/EvaluationForm.tsx
+++ b/client/src/module/recruiter/applications/EvaluationForm.tsx
@@ -64,6 +64,7 @@ export function EvaluationForm({ applicationId, roundId, criteria, onComplete }:
               max={crit.maxScore}
               value={scores[crit.id]?.score || 0}
               onChange={(e) => setScores({ ...scores, [crit.id]: { ...scores[crit.id]!, score: Number(e.target.value) } })}
+              aria-valuetext={`${scores[crit.id]?.score || 0} out of ${crit.maxScore}`}
               className="flex-1"
             />
             <span className="text-sm font-bold w-10 text-right dark:text-white">{scores[crit.id]?.score || 0}</span>


### PR DESCRIPTION
## What
Adds aria-valuetext attribute to the score slider so screen readers announce the full scale context instead of just the raw number.

## Root cause
The range input set aria-valuenow but not aria-valuetext, making it inaccessible for visually impaired users.

## Changes
- client/src/module/recruiter/applications/EvaluationForm.tsx: added aria-valuetext to the range input

## Verification
Screen reader announces out of instead of just a raw number.

Closes #1163