### PR TITLE
Fix: return 422 with clear message when advancing application with zero rounds configured

### DIFF
--- a/server/src/module/recruiter/recruiter.controller.ts
+++ b/server/src/module/recruiter/recruiter.controller.ts
@@ -201,7 +201,7 @@ export class RecruiterController {
       if (error instanceof Error) {
         if (error.message === "Application not found") return res.status(404).json({ message: error.message });
         if (error.message === "Not authorized") return res.status(403).json({ message: error.message });
-        if (error.message === "No rounds defined for this job") return res.status(400).json({ message: error.message });
+        if (error.message === "No rounds are configured for this job. Please add at least one round before advancing applicants.") return res.status(422).json({ message: error.message });
       }
       logger.error("Failed to advance application", error);
       return res.status(500).json({ message: "Internal Server Error" });

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -322,7 +322,7 @@ export class RecruiterService {
         orderBy: { orderIndex: "asc" },
       });
 
-      if (rounds.length === 0) throw new Error("No rounds defined for this job");
+      if (rounds.length === 0) throw new Error("No rounds are configured for this job. Please add at least one round before advancing applicants.");
 
       // Find current round index
       let currentIndex = -1;


### PR DESCRIPTION
## What
Returns HTTP 422 with a clear actionable message when a recruiter tries to advance an application for a job that has zero rounds configured.

## Root cause
advanceApplication() threw a generic error (currently mapped to 400) without explaining what the recruiter should do.

## Changes
- server/src/module/recruiter/recruiter.service.ts: updated error message to explain how to fix
- server/src/module/recruiter/recruiter.controller.ts: changed status from 400 to 422, updated message match

## Verification
Advancing an application on a job with no rounds now returns HTTP 422 with the message: No rounds are configured for this job. Please add at least one round before advancing applicants.

Closes #1164