### PR TITLE
fix: validate round ownership in reorder rounds endpoint

### DIFF
--- a/server/src/module/recruiter/recruiter.controller.ts
+++ b/server/src/module/recruiter/recruiter.controller.ts
@@ -119,6 +119,7 @@ export class RecruiterController {
       if (error instanceof Error) {
         if (error.message === "Job not found") return res.status(404).json({ message: error.message });
         if (error.message === "Not authorized") return res.status(403).json({ message: error.message });
+        if (error.message === "Invalid round IDs") return res.status(400).json({ message: error.message });
       }
       logger.error("Failed to reorder rounds", error);
       return res.status(500).json({ message: "Internal Server Error" });

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -144,6 +144,18 @@ export class RecruiterService {
     const job = await prisma.job.findUnique({ where: { id: jobId } });
     if (!job) throw new Error("Job not found");
     if (job.recruiterId !== recruiterId) throw new Error("Not authorized");
+    
+    const existingRounds = await prisma.round.findMany({
+      where: {
+        id: { in: rounds.map((r) => r.roundId) },
+        jobId,
+      },
+      select: { id: true },
+    });
+
+    if (existingRounds.length !== rounds.length) {
+      throw new Error("Invalid round IDs");
+    }
 
     // Use a transaction with temporary high indices to avoid unique constraint conflicts
     await prisma.$transaction(async (tx) => {


### PR DESCRIPTION
## Description

Added validation to the round reorder endpoint to ensure all submitted `roundIds` belong to the specified `jobId` before performing updates.

This prevents recruiters from reordering rounds belonging to other jobs by sending foreign round IDs in the reorder request payload.

## Changes Made

* Added validation in `recruiter.service.ts` to verify ownership of all submitted round IDs.
* Added error handling for invalid round IDs in `recruiter.controller.ts`.
* Prevented cross-job round manipulation during reorder operations.

## Related Issue

Fixes #1104 

## Type of Change

* [x] Bug Fix
* [ ] Feature
* [ ] Enhancement
* [ ] Documentation
* [x] Security

## Testing

* Tested valid reorder requests with rounds belonging to the same job.
* Tested invalid reorder requests using round IDs from another job.
* Confirmed API now returns `400 Bad Request` for invalid round ownership attempts.
* Verified normal reorder functionality still works correctly.

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved round reorder validation to verify round IDs before processing. Invalid round IDs now return clear error messages, preventing failed operations and providing better feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->