### PR TITLE
Fix: deduplicate tags before submission in CreateJobPage

### DIFF
--- a/client/src/module/recruiter/jobs/CreateJobPage.tsx
+++ b/client/src/module/recruiter/jobs/CreateJobPage.tsx
@@ -68,7 +68,7 @@ export default function CreateJobPage() {
         salary: form.salary,
         company: form.company,
         deadline: form.deadline ? new Date(form.deadline).toISOString() : undefined,
-        tags: form.tags.split(",").map((t) => t.trim()).filter(Boolean),
+        tags: [...new Set(form.tags.split(",").map((t) => t.trim()).filter(Boolean))],
         customFields,
         status: "DRAFT",
       });


### PR DESCRIPTION
## What
Wraps the tags array in a Set before submission to prevent duplicate tag entries.

## Root cause
form.tags.split() produces an array that is submitted as-is, so typing the same tag twice creates duplicates in the DB.

## Changes
- client/src/module/recruiter/jobs/CreateJobPage.tsx: wrapped with [...new Set(...)] to deduplicate

## Verification
Typing React, React now submits [React] instead of [React, React].

Closes #1140