### PR TITLE
Fix: add deadline-in-the-future validation for job creation

### DIFF
--- a/client/src/module/recruiter/jobs/CreateJobPage.tsx
+++ b/client/src/module/recruiter/jobs/CreateJobPage.tsx
@@ -305,6 +305,7 @@ export default function CreateJobPage() {
                       type="date"
                       value={form.deadline}
                       onChange={(e) => setForm({ ...form, deadline: e.target.value })}
+                      min={new Date().toISOString().split("T")[0]}
                       className={inputClass()}
                     />
                   </Field>

--- a/server/src/module/job/job.controller.ts
+++ b/server/src/module/job/job.controller.ts
@@ -24,6 +24,9 @@ export class JobController {
       clearCache("jobs:list");
       return res.status(201).json({ message: "Job created successfully", job });
     } catch (error) {
+      if (error instanceof Error && error.message === "Deadline must be in the future") {
+        return res.status(422).json({ message: error.message });
+      }
       logger.error("Failed to create job", error);
       return res.status(500).json({ message: "Internal Server Error" });
     }

--- a/server/src/module/job/job.service.ts
+++ b/server/src/module/job/job.service.ts
@@ -33,6 +33,9 @@ type UpdateJobData = {
 
 export class JobService {
   async createJob(data: CreateJobData) {
+    if (data.deadline && new Date(data.deadline) < new Date(new Date().toDateString())) {
+      throw new Error("Deadline must be in the future");
+    }
     return prisma.job.create({
       data: {
         title: data.title,


### PR DESCRIPTION
## What
Adds client-side min date attribute and server-side validation to prevent selecting past dates for job deadlines.

## Root cause
The date input had no min constraint and the server accepted any date, allowing recruiters to create already-expired job listings.

## Changes
- client/src/module/recruiter/jobs/CreateJobPage.tsx: added min={today} to date input
- server/src/module/job/job.service.ts: added deadline must be in the future check
- server/src/module/job/job.controller.ts: return 422 for past deadlines

## Verification
Selecting yesterday.date and submitting returns HTTP 422 with Deadline must be in the future. Date picker greys out past dates.

Closes #1141