### PR TITLE
Fix: guard CreateJobPage submit against double-click with early loading check

### DIFF
--- a/client/src/module/recruiter/jobs/CreateJobPage.tsx
+++ b/client/src/module/recruiter/jobs/CreateJobPage.tsx
@@ -57,6 +57,7 @@ export default function CreateJobPage() {
   const canAdvance = stepIdx === 0 ? basicsComplete : true;
 
   const handleSubmit = async () => {
+    if (loading) return;
     setError("");
     setLoading(true);
 


### PR DESCRIPTION
## What
Adds early return guard in handleSubmit to prevent concurrent submissions on double-click.

## Root cause
disabled depends on loading state, but double-click fires before state update propagates.

## Changes
- client/src/module/recruiter/jobs/CreateJobPage.tsx: added if (loading) return

## Verification
Double-clicking Create job only triggers one POST.

Closes #1139