### PR TITLE
Fix: add refresh button and auto-refresh on focus to dashboard stats

### DIFF
--- a/client/src/module/recruiter/RecruiterDashboard.tsx
+++ b/client/src/module/recruiter/RecruiterDashboard.tsx
@@ -47,6 +47,7 @@ function RecruiterDashboardInner() {
   const [loading, setLoading] = useState(true);
 
   const fetchDashboard = useCallback(async () => {
+    setLoading(true);
     try {
       const res = await api.get("/recruiter/dashboard");
       setData(res.data);

--- a/client/src/module/recruiter/RecruiterDashboard.tsx
+++ b/client/src/module/recruiter/RecruiterDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router";
 import { motion } from "framer-motion";
 import {
@@ -16,6 +16,7 @@ import {
   CircleDashed,
   UserCheck,
   MinusCircle,
+  RefreshCw,
 } from "lucide-react";
 import api from "../../lib/axios";
 import { LoadingScreen } from "../../components/LoadingScreen";
@@ -45,15 +46,26 @@ function RecruiterDashboardInner() {
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const fetchDashboard = useCallback(async () => {
+    try {
+      const res = await api.get("/recruiter/dashboard");
+      setData(res.data);
+    } catch {
+      if (!data) setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [data]);
+
   useEffect(() => {
-    api
-      .get("/recruiter/dashboard")
-      .then((res) => {
-        setData(res.data);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
-  }, []);
+    fetchDashboard();
+  }, [fetchDashboard]);
+
+  useEffect(() => {
+    const onFocus = () => fetchDashboard();
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [fetchDashboard]);
 
   if (loading) return <DashboardSkeleton />;
 
@@ -121,6 +133,9 @@ function RecruiterDashboardInner() {
           </div>
 
           <div className="flex items-center gap-3">
+            <Button variant="secondary" size="md" onClick={fetchDashboard} aria-label="Refresh dashboard">
+              <RefreshCw className="w-3.5 h-3.5" />
+            </Button>
             <Button asChild variant="secondary" size="md">
               <Link to="/recruiters/jobs" className="no-underline">
                 My jobs

--- a/client/src/module/recruiter/RecruiterDashboard.tsx
+++ b/client/src/module/recruiter/RecruiterDashboard.tsx
@@ -51,11 +51,11 @@ function RecruiterDashboardInner() {
       const res = await api.get("/recruiter/dashboard");
       setData(res.data);
     } catch {
-      if (!data) setData(null);
+      setData(prev => prev ?? null);
     } finally {
       setLoading(false);
     }
-  }, [data]);
+  }, []);
 
   useEffect(() => {
     fetchDashboard();
@@ -334,7 +334,7 @@ function RecruiterDashboardInner() {
                     </div>
                     <div className="flex items-center gap-4 shrink-0">
                       <span className="hidden sm:inline-flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-widest text-stone-600 dark:text-stone-400">
-                        {renderStatusIcon(status)}
+                        {renderStatusIcon(app.status)}
                         {humanizeStatus(app.status)}
                       </span>
                       <span className="text-[11px] font-mono text-stone-400 tabular-nums">


### PR DESCRIPTION
## What
Adds manual refresh button and auto-refresh on window focus to prevent stale dashboard statistics.

## Root cause
Dashboard stats were fetched once on mount and never invalidated after mutating actions.

## Changes
- client/src/module/recruiter/RecruiterDashboard.tsx: extracted fetchDashboard as reusable callback, added window focus listener, added refresh button in header

## Verification
Clicking the refresh button refetches dashboard data. Switching away and back to the tab also refreshes.

Closes #1137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Refresh dashboard" button for manual dashboard updates.
  * Dashboard auto-refreshes when the browser window regains focus.

* **Bug Fixes**
  * Improved dashboard fetch logic to avoid redundant requests and retain existing data on errors.
  * Fixed recent applications status icon so each application shows its correct status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->