### PR TITLE
fix(recruiter): exclude WITHDRAWN applications by default

### DIFF
--- a/server/src/module/recruiter/recruiter.service.test.ts
+++ b/server/src/module/recruiter/recruiter.service.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    job: {
+      findUnique: vi.fn(),
+    },
+    application: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+  s3Utils: {
+    signUrl: vi.fn().mockImplementation((url) => Promise.resolve(url)),
+  },
+}));
+
+vi.mock("../../database/db.js", () => ({
+  prisma: mocks.prisma,
+}));
+
+vi.mock("../../utils/s3.utils.js", () => ({
+  signUrl: mocks.s3Utils.signUrl,
+  signUrls: vi.fn().mockImplementation((urls) => Promise.resolve(urls)),
+}));
+
+const { RecruiterService } = await import("./recruiter.service.js");
+
+describe("RecruiterService - getApplications", () => {
+  const service = new RecruiterService();
+  const jobId = 1;
+  const recruiterId = 10;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should throw 'Job not found' if job does not exist", async () => {
+    mocks.prisma.job.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.getApplications(jobId, recruiterId, { page: 1, limit: 10 })
+    ).rejects.toThrow("Job not found");
+
+    expect(mocks.prisma.job.findUnique).toHaveBeenCalledWith({
+      where: { id: jobId },
+    });
+  });
+
+  it("should throw 'Not authorized' if job belongs to a different recruiter", async () => {
+    mocks.prisma.job.findUnique.mockResolvedValue({
+      id: jobId,
+      recruiterId: 999, // different recruiter
+    });
+
+    await expect(
+      service.getApplications(jobId, recruiterId, { page: 1, limit: 10 })
+    ).rejects.toThrow("Not authorized");
+  });
+
+  it("should exclude WITHDRAWN applications by default when status filter is not passed", async () => {
+    mocks.prisma.job.findUnique.mockResolvedValue({
+      id: jobId,
+      recruiterId: recruiterId,
+    });
+    mocks.prisma.application.findMany.mockResolvedValue([]);
+    mocks.prisma.application.count.mockResolvedValue(0);
+
+    const result = await service.getApplications(jobId, recruiterId, {
+      page: 1,
+      limit: 10,
+    });
+
+    expect(result.applications).toEqual([]);
+    expect(result.pagination.total).toBe(0);
+
+    // Verify findMany was called with status: { not: "WITHDRAWN" }
+    expect(mocks.prisma.application.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          jobId,
+          status: { not: "WITHDRAWN" },
+        }),
+      })
+    );
+
+    // Verify count was called with status: { not: "WITHDRAWN" }
+    expect(mocks.prisma.application.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          jobId,
+          status: { not: "WITHDRAWN" },
+        }),
+      })
+    );
+  });
+
+  it("should explicitly filter by status when status filter is passed", async () => {
+    mocks.prisma.job.findUnique.mockResolvedValue({
+      id: jobId,
+      recruiterId: recruiterId,
+    });
+    mocks.prisma.application.findMany.mockResolvedValue([]);
+    mocks.prisma.application.count.mockResolvedValue(0);
+
+    // Explicitly filter for WITHDRAWN status
+    await service.getApplications(jobId, recruiterId, {
+      page: 1,
+      limit: 10,
+      status: "WITHDRAWN",
+    });
+
+    expect(mocks.prisma.application.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          jobId,
+          status: "WITHDRAWN",
+        }),
+      })
+    );
+
+    // Explicitly filter for APPLIED status
+    await service.getApplications(jobId, recruiterId, {
+      page: 1,
+      limit: 10,
+      status: "APPLIED",
+    });
+
+    expect(mocks.prisma.application.findMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          jobId,
+          status: "APPLIED",
+        }),
+      })
+    );
+  });
+});

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -180,6 +180,8 @@ export class RecruiterService {
 
     if (filter.status) {
       where.status = filter.status as ApplicationStatus;
+    } else {
+      where.status = { not: "WITHDRAWN" };
     }
 
     if (filter.search) {


### PR DESCRIPTION
## Description
Modified `getApplications()` in `RecruiterService` to exclude `WITHDRAWN` applications by default. When no status filter is passed, the Prisma query now applies `where.status = { not: 'WITHDRAWN' }`. If a recruiter explicitly passes a status filter (including `WITHDRAWN`), it overrides the default.

## Related Issue
Fixes #1194

## Type of Change
- [x] Bug Fix

## Testing
Added `recruiter.service.test.ts` with 4 unit tests:
- Fails if job not found
- Fails if recruiter not authorized
- Default query excludes WITHDRAWN (`where.status = { not: 'WITHDRAWN' }`)
- Explicit status filter overrides default correctly

Results:
- `recruiter.service.test.ts`: 4 tests passed
- Full suite: 16 test files, 90 tests passed
- `npm run lint`: clean, 0 errors

## Screenshots / Video
_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] Screenshot or video attached for every UI change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application listings now exclude withdrawn applications by default when no specific status filter is applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sachinchaurasiya360/InternHack/pull/1240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->