### PR TITLE
fix: validate round ownership in evaluateSubmission to prevent cross-job evaluations

### DIFF
--- a/server/src/module/recruiter/recruiter.controller.ts
+++ b/server/src/module/recruiter/recruiter.controller.ts
@@ -251,7 +251,7 @@ export class RecruiterController {
       return res.status(200).json({ message: "Submission evaluated successfully", submission });
     } catch (error) {
       if (error instanceof Error) {
-        if (error.message === "Application not found") return res.status(404).json({ message: error.message });
+        if (error.message === "Application not found" || error.message === "Round not found") return res.status(404).json({ message: error.message });
         if (error.message === "Not authorized") return res.status(403).json({ message: error.message });
       }
       logger.error("Failed to evaluate submission", error);

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -391,7 +391,14 @@ export class RecruiterService {
 
     if (!application) throw new Error("Application not found");
     if (application.job.recruiterId !== recruiterId) throw new Error("Not authorized");
+    // checking round ownership
+    const round = await prisma.round.findUnique({
+      where: { id: roundId },
+      select: { jobId: true },
+    });
 
+    if (!round || round.jobId !== application.jobId) throw new Error("Round not found");
+    
     return prisma.roundSubmission.update({
       where: { applicationId_roundId: { applicationId, roundId } },
       data: {


### PR DESCRIPTION
## Description

Added validation to ensure the round being evaluated belongs to the same job as the application in `evaluateSubmission()`.

### Changes made:

* Added round ownership validation inside `evaluateSubmission()`
* Verified that the submitted `roundId` belongs to the application's job
* Prevented cross-job evaluation tampering between recruiters
* Added proper `Round not found` handling
* Updated controller error responses to return `404` for invalid round references

This strengthens recruiter authorization checks and prevents evaluation submissions using unrelated or foreign round IDs.

## Related Issue

Fixes #1110

## Type of Change

* [x] Bug Fix
* [ ] Feature
* [ ] Enhancement
* [ ] Documentation
* [x] Security 

## Testing

* Manually tested valid evaluation submissions for owned job rounds
* Tested invalid round IDs from unrelated jobs
* Verified unauthorized round evaluations now fail with proper error responses
* Confirmed existing evaluation flow continues working normally


## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [ ] Docs updated (if needed)
* [x] Screenshot or video attached for every UI change (not applicable)
