### PR TITLE
fix: add scope="col" to table headers in ApplicationsList for accessibility

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationsList.tsx
+++ b/client/src/module/recruiter/applications/ApplicationsList.tsx
@@ -133,11 +133,11 @@ export default function ApplicationsList() {
             <table className="w-full">
               <thead>
                 <tr className="border-b border-gray-100 dark:border-gray-800">
-                  <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-500 uppercase px-6 py-3">Candidate</th>
-                  <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-500 uppercase px-6 py-3">Status</th>
-                  <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-500 uppercase px-6 py-3">Rounds</th>
-                  <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-500 uppercase px-6 py-3">Applied</th>
-                  <th className="text-left text-xs font-medium text-gray-500 dark:text-gray-500 uppercase px-6 py-3">Actions</th>
+                  <th scope="col" className="text-left text-xs font-medium text-gray-500 dark:text-gray-500 uppercase px-6 py-3">Candidate</th>
+                  <th scope="col" className="text-left text-xs font-medium text-gray-500 dark:text-gray-500 uppercase px-6 py-3">Status</th>
+                  <th scope="col" className="text-left text-xs font-medium text-gray-500 dark:text-gray-500 uppercase px-6 py-3">Rounds</th>
+                  <th scope="col" className="text-left text-xs font-medium text-gray-500 dark:text-gray-500 uppercase px-6 py-3">Applied</th>
+                  <th scope="col" className="text-left text-xs font-medium text-gray-500 dark:text-gray-500 uppercase px-6 py-3">Actions</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-50 dark:divide-gray-800">


### PR DESCRIPTION
Closes #1155

## Contribution Type
GSSoC 2026

## Changes
- Added `scope="col"` to all 5 `<th>` elements in `client/src/module/recruiter/ApplicationsList.tsx`

## Why
Screen readers use the `scope` attribute to associate data cells with their column headers. Without it, assistive technology can't correctly navigate the table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved HTML accessibility standards in the applications list table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->