### PR TITLE
fix: reset pagination to page 1 when status filter changes (#1183)

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationsList.tsx
+++ b/client/src/module/recruiter/applications/ApplicationsList.tsx
@@ -30,6 +30,11 @@ export default function ApplicationsList() {
     };
   }, [search]);
 
+  // Reset to page 1 when filter changes
+  useEffect(() => {
+    setPage(1);
+  }, [statusFilter]);
+
   const fetchApplications = () => {
     setLoading(true);
     const params = new URLSearchParams({ page: String(page), limit: "10" });


### PR DESCRIPTION
Closes #1183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination to reset to the first page when filtering the applications list by different statuses, ensuring a consistent browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->