### PR TITLE
fix: prevent withdrawn applications from progressing workflow

### DIFF
--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -317,6 +317,12 @@ export class RecruiterService {
       if (!application) throw new Error("Application not found");
       if (application.job.recruiterId !== recruiterId) throw new Error("Not authorized");
 
+      if (application.status === "WITHDRAWN") {
+        throw new Error(
+          "Withdrawn applications cannot participate in the hiring process"
+        );
+      }
+
       const rounds = await tx.round.findMany({
         where: { jobId: application.jobId },
         orderBy: { orderIndex: "asc" },

--- a/server/src/module/student/student.service.ts
+++ b/server/src/module/student/student.service.ts
@@ -414,6 +414,13 @@ Rules:
     ]);
     if (!application) throw new Error("Application not found");
     if (application.studentId !== studentId) throw new Error("Not authorized");
+
+    if (application.status === "WITHDRAWN") {
+      throw new Error(
+        "Withdrawn applications cannot participate in the hiring process"
+      );
+    }
+
     if (!round || round.jobId !== application.jobId) throw new Error("Round not found");
 
     let submission;


### PR DESCRIPTION
## Summary

This PR fixes a workflow integrity issue where applications marked as `WITHDRAWN` could still participate in hiring activities.

### Changes

* Prevent assessment/round submissions for withdrawn applications.
* Prevent recruiters from advancing withdrawn applications through the hiring pipeline.
* Treat `WITHDRAWN` as a terminal workflow state.

### Issue

Closes #944

### Validation

Successfully ran the project test suite after implementing the fix.

Results:

* 15 test files passed
* 86 tests passed

### Result

Applications marked as `WITHDRAWN` can no longer:

* Submit assessment rounds
* Progress through recruiter workflow actions
* Re-enter active hiring stages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented recruiters from advancing withdrawn applications through hiring rounds
  * Blocked students from submitting responses for withdrawn applications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->