### PR TITLE
fix: add missing dark mode variants to status icons in ApplicationDetail (#1182)

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationDetail.tsx
+++ b/client/src/module/recruiter/applications/ApplicationDetail.tsx
@@ -112,7 +112,7 @@ export default function ApplicationDetail() {
         <div className="bg-white dark:bg-gray-900 p-6 rounded-xl border border-gray-100 dark:border-gray-800 shadow-sm mb-6">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold dark:text-white flex items-center gap-2">
-              <ShieldCheck className="w-5 h-5 text-green-500" /> Verified Skills
+              <ShieldCheck className="w-5 h-5 text-green-500 dark:text-green-400" /> Verified Skills
             </h2>
             {application.job?.tags && application.job.tags.length > 0 && (() => {
               const verifiedNames = new Set(verifiedSkills.map((v) => v.skillName.toLowerCase()));
@@ -214,10 +214,10 @@ export default function ApplicationDetail() {
 
 function getStatusIcon(status: string) {
   switch (status) {
-    case "COMPLETED": return <CheckCircle className="w-4 h-4 text-green-500" />;
-    case "IN_PROGRESS": return <Clock className="w-4 h-4 text-yellow-500" />;
-    case "PENDING": return <Clock className="w-4 h-4 text-gray-400" />;
-    default: return <XCircle className="w-4 h-4 text-red-500" />;
+    case "COMPLETED": return <CheckCircle className="w-4 h-4 text-green-500 dark:text-green-400" />;
+    case "IN_PROGRESS": return <Clock className="w-4 h-4 text-yellow-500 dark:text-yellow-400" />;
+    case "PENDING": return <Clock className="w-4 h-4 text-gray-400 dark:text-gray-500" />;
+    default: return <XCircle className="w-4 h-4 text-red-500 dark:text-red-400" />;
   }
 }
 


### PR DESCRIPTION
﻿## Description
Adds missing dark mode variants (dark:text-green-400, dark:text-yellow-400, dark:text-gray-500, dark:text-red-400) to status icons in the Application Detail component's getStatusIcon function. Also adds dark:text-green-400 to the ShieldCheck icon in the Verified Skills section.

Previously, these icons used static colors (	ext-green-500, 	ext-yellow-500, 	ext-gray-400, 	ext-red-500) without dark: equivalents, which could cause poor contrast in dark mode.

Closes #1182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark-mode styling for the Application Detail view. Status icons for verified skills and workflow states (completed, in-progress, pending, error) now display with appropriate dark-mode colors to improve visibility and maintain visual consistency across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->