### PR TITLE
fix: close mobile sidebar on route change in RecruiterLayout (#1180)

### DIFF
--- a/client/src/module/recruiter/RecruiterLayout.tsx
+++ b/client/src/module/recruiter/RecruiterLayout.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { NavLink, Link, Outlet, useNavigate, useLocation } from "react-router";
 import { LayoutDashboard, Briefcase, Search, LogOut, ChevronsLeft, ChevronsRight, Users, User, Menu, X, ChevronDown, BarChart3, Building2, CalendarDays, Clock, Video, CheckSquare, Award, Wallet, Receipt, UserPlus, ShieldCheck, GitBranch, Key, UserCircle, Bookmark } from "lucide-react";
 import { useAuthStore } from "../../lib/auth.store";
@@ -51,6 +51,8 @@ export default function RecruiterLayout() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [hrExpanded, setHrExpanded] = useState(() => localStorage.getItem("recruiter-hr-expanded") !== "false");
   const [imgError, setImgError] = useState(false);
+
+  useEffect(() => { setMobileOpen(false); }, [location.pathname]);
 
   const isHRActive = location.pathname.startsWith("/recruiters/hr");
 

--- a/client/src/module/recruiter/applications/ApplicationDetail.tsx
+++ b/client/src/module/recruiter/applications/ApplicationDetail.tsx
@@ -112,7 +112,7 @@ export default function ApplicationDetail() {
         <div className="bg-white dark:bg-gray-900 p-6 rounded-xl border border-gray-100 dark:border-gray-800 shadow-sm mb-6">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold dark:text-white flex items-center gap-2">
-              <ShieldCheck className="w-5 h-5 text-green-500" /> Verified Skills
+              <ShieldCheck className="w-5 h-5 text-green-500 dark:text-green-400" /> Verified Skills
             </h2>
             {application.job?.tags && application.job.tags.length > 0 && (() => {
               const verifiedNames = new Set(verifiedSkills.map((v) => v.skillName.toLowerCase()));
@@ -214,10 +214,10 @@ export default function ApplicationDetail() {
 
 function getStatusIcon(status: string) {
   switch (status) {
-    case "COMPLETED": return <CheckCircle className="w-4 h-4 text-green-500" />;
-    case "IN_PROGRESS": return <Clock className="w-4 h-4 text-yellow-500" />;
-    case "PENDING": return <Clock className="w-4 h-4 text-gray-400" />;
-    default: return <XCircle className="w-4 h-4 text-red-500" />;
+    case "COMPLETED": return <CheckCircle className="w-4 h-4 text-green-500 dark:text-green-400" />;
+    case "IN_PROGRESS": return <Clock className="w-4 h-4 text-yellow-500 dark:text-yellow-400" />;
+    case "PENDING": return <Clock className="w-4 h-4 text-gray-400 dark:text-gray-500" />;
+    default: return <XCircle className="w-4 h-4 text-red-500 dark:text-red-400" />;
   }
 }
 


### PR DESCRIPTION
﻿## Description
The mobile sidebar remained open after programmatic navigation (e.g., clicking the logo/home link) because there was no route-change listener. This adds a useEffect that watches location.pathname and closes the mobile sidebar on any route change.

## Changes
- Added useEffect import
- Added useEffect(() => { setMobileOpen(false); }, [location.pathname]) to close the mobile sidebar whenever the route changes

Closes #1180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile sidebar now automatically closes when navigating between pages.

* **Bug Fixes**
  * Enhanced dark mode icon visibility for status indicators and verified skills section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->