### PR TITLE
fix: add dark mode styling to EvaluationForm range input (#1181)

### DIFF
--- a/client/src/module/recruiter/applications/EvaluationForm.tsx
+++ b/client/src/module/recruiter/applications/EvaluationForm.tsx
@@ -74,7 +74,7 @@ export function EvaluationForm({ applicationId, roundId, criteria, onComplete }:
               value={scores[crit.id]?.score || 0}
               onChange={(e) => setScores({ ...scores, [crit.id]: { ...scores[crit.id]!, score: Number(e.target.value) } })}
               aria-valuetext={`${scores[crit.id]?.score || 0} out of ${crit.maxScore}`}
-              className="flex-1"
+              className="flex-1 h-1.5 bg-gray-200 dark:bg-gray-700 rounded appearance-none cursor-pointer accent-blue-600"
             />
             <span className="text-sm font-bold w-10 text-right dark:text-white">{scores[crit.id]?.score || 0}</span>
           </div>


### PR DESCRIPTION
﻿## Changes
- Added dark mode styling to the range/slider input in EvaluationForm — previously used only lex-1 with no track styling, making it invisible in dark mode browsers
- Now uses g-gray-200 dark:bg-gray-700 track with ccent-blue-600 thumb

Closes #1181


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced the visual design of the evaluation form's range sliders with improved styling, including refined layout, better color support for light and dark themes, and improved cross-browser compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->