### PR TITLE
fix(recruiter): lowercase candidate skills in search filter to prevent fragmentation

### DIFF
--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -538,7 +538,7 @@ export class RecruiterService {
       if (filter.graduationYearMax) where.graduationYear.lte = filter.graduationYearMax;
     }
     if (filter.skills) {
-      const skillList = filter.skills.split(",").map((s) => s.trim()).filter(Boolean);
+      const skillList = filter.skills.split(",").map((s) => s.toLowerCase().trim()).filter(Boolean);
       if (skillList.length > 0) {
         where.skills = { hasSome: skillList };
       }

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -538,7 +538,7 @@ export class RecruiterService {
       if (filter.graduationYearMax) where.graduationYear.lte = filter.graduationYearMax;
     }
     if (filter.skills) {
-      const skillList = filter.skills.split(",").map((s) => s.toLowerCase().trim()).filter(Boolean);
+      const skillList = filter.skills.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
       if (skillList.length > 0) {
         where.skills = { hasSome: skillList };
       }


### PR DESCRIPTION
# Pull Request

## Description
Modified `searchTalent` in `recruiter.service.ts` to normalise skills. Mapped `.trim().toLowerCase()` on the array, preventing filter fragmentation caused by case-sensitive inputs (e.g., treating "React", "REACT", and "react" as distinct skills), as outlined by @Sachinchaurasiya360 .

## Related Issue
Fixes #1193

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
- Verified `recruiter.service.ts` correctly processes the string array via `.trim().toLowerCase()`.
- Successfully compiled the TypeScript server (`npx tsc --noEmit`) to ensure no downstream type errors with the Prisma client. 
- Reviewed the final query execution logic to confirm case-insensitive filtering happens before Prisma database access.

## Screenshots / Video

_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [ ] **Screenshot or video attached for every UI change** (PR will be rejected if missing)
