### PR TITLE
feat: replace numeric user ID in profile URL with name slug

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -526,7 +526,7 @@ function App() {
             <Route path="talent-search" element={<TalentSearchPage />} />
             <Route path="saved" element={<SavedCandidatesPage />} />
             <Route path="profile" element={<RecruiterProfilePage />} />
-            <Route path="profile/:id" element={<PublicProfilePage />} />
+            <Route path="profile/:identifier" element={<PublicProfilePage />} />
             {/* HR Management */}
             <Route path="hr" element={<HRDashboardPage />} />
             <Route path="hr/employees" element={<EmployeesPage />} />
@@ -575,7 +575,7 @@ function App() {
             <Route path="blog" element={<AdminBlogPage />} />
             <Route path="blog/editor" element={<AdminBlogEditor />} />
             <Route path="blog/editor/:id" element={<AdminBlogEditor />} />
-            <Route path="profile/:id" element={<PublicProfilePage />} />
+            <Route path="profile/:identifier" element={<PublicProfilePage />} />
           </Route>
 
           {/* 404 catch-all */}

--- a/client/src/lib/types/user.types.ts
+++ b/client/src/lib/types/user.types.ts
@@ -21,6 +21,7 @@ export interface AchievementItem {
 
 export interface User {
   id: number;
+  profileSlug?: string | null;
   name: string;
   email: string;
   role: UserRole;

--- a/client/src/module/student/profile/PublicProfilePage.tsx
+++ b/client/src/module/student/profile/PublicProfilePage.tsx
@@ -17,6 +17,7 @@ import type { ProjectItem, AchievementItem, VerifiedSkill } from "../../../lib/t
 
 interface PublicProfile {
   id: number;
+  profileSlug?: string | null;
   name: string;
   email: string;
   profilePic?: string;

--- a/client/src/module/student/profile/PublicProfilePage.tsx
+++ b/client/src/module/student/profile/PublicProfilePage.tsx
@@ -76,13 +76,15 @@ function formatDate(dateStr: string) {
 }
 
 export default function PublicProfilePage() {
-  const { id } = useParams();
+  const { id, identifier } = useParams();
   const navigate = useNavigate();
 
+  const finalId = identifier || id;
+
   const { data: profile, isLoading, error } = useQuery({
-    queryKey: ["public-profile", id],
-    queryFn: () => api.get(`/auth/profile/${id}`).then((res) => res.data.profile as PublicProfile),
-    enabled: !!id,
+    queryKey: ["public-profile", finalId],
+    queryFn: () => api.get(`/auth/profile/${finalId}`).then((res) => res.data.profile as PublicProfile),
+    enabled: !!finalId,
   });
 
   if (isLoading) return <LoadingScreen />;

--- a/client/src/module/student/profile/StudentProfilePage.tsx
+++ b/client/src/module/student/profile/StudentProfilePage.tsx
@@ -435,7 +435,7 @@ export default function StudentProfilePage() {
   };
 
   const handleCopyProfileUrl = async () => {
-    const url = `${window.location.origin}/student/profile/public/${user?.id}`;
+    const url = `${window.location.origin}/student/profile/public/${user?.profileSlug ?? user?.id}`;
     try {
       await navigator.clipboard.writeText(url);
       setProfileUrlCopied(true);

--- a/server/src/database/scripts/backfill-profile-slugs.ts
+++ b/server/src/database/scripts/backfill-profile-slugs.ts
@@ -1,0 +1,38 @@
+import { createUniqueProfileSlug } from "../../lib/slug.js";
+import { prisma } from "../db.js";
+
+async function main() {
+  const users = await prisma.user.findMany({
+    where: { profileSlug: null },
+    select: { id: true, name: true }
+  });
+
+  console.log(`Found ${users.length} users to backfill.`);
+
+  let processed = 0;
+  for (let i = 0; i < users.length; i += 50) {
+    const batch = users.slice(i, i + 50);
+    const updates = await Promise.all(
+      batch.map(async (u) => {
+        const slug = await createUniqueProfileSlug(u.name, u.id, prisma);
+        return prisma.user.update({
+          where: { id: u.id },
+          data: { profileSlug: slug },
+        });
+      })
+    );
+    processed += updates.length;
+    console.log(`Processed ${processed} / ${users.length}`);
+  }
+
+  console.log("Done backfilling slugs.");
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/server/src/lib/slug.ts
+++ b/server/src/lib/slug.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from "@prisma/client";
+
+export function generateProfileSlug(name: string, id: number): string {
+  const base = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 50);
+  return base || `user-${id}`;
+}
+
+export async function createUniqueProfileSlug(
+  name: string,
+  id: number,
+  prisma: PrismaClient
+): Promise<string> {
+  const base = generateProfileSlug(name, id);
+  const existing = await prisma.user.findUnique({
+    where: { profileSlug: base }
+  });
+  if (!existing) return base;
+  // fallback: name-id
+  return `${base}-${id}`;
+}

--- a/server/src/lib/slug.ts
+++ b/server/src/lib/slug.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 
 export function generateProfileSlug(name: string, id: number): string {
   const base = name
@@ -17,10 +17,22 @@ export async function createUniqueProfileSlug(
   prisma: PrismaClient
 ): Promise<string> {
   const base = generateProfileSlug(name, id);
-  const existing = await prisma.user.findUnique({
-    where: { profileSlug: base }
-  });
-  if (!existing) return base;
-  // fallback: name-id
-  return `${base}-${id}`;
+  
+  try {
+    await prisma.user.update({
+      where: { id },
+      data: { profileSlug: base },
+    });
+    return base;
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+      const fallback = `${base}-${id}`;
+      await prisma.user.update({
+        where: { id },
+        data: { profileSlug: fallback },
+      });
+      return fallback;
+    }
+    throw err;
+  }
 }

--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -144,12 +144,12 @@ export class AuthController {
         return res.status(403).json({ message: "Not authorized" });
       }
 
-      const id = Number(req.params["id"]);
-      if (!id || isNaN(id)) {
-        return res.status(400).json({ message: "Invalid user ID" });
+      const identifier = (req.params["identifier"] || req.params["id"]) as string;
+      if (!identifier) {
+        return res.status(400).json({ message: "Invalid user identifier" });
       }
 
-      const profile = await this.authService.getPublicProfile(id);
+      const profile = await this.authService.getPublicProfile(identifier);
       return res.status(200).json({ profile });
     } catch (error) {
       if (error instanceof Error && error.message === "User not found") {

--- a/server/src/module/auth/auth.routes.ts
+++ b/server/src/module/auth/auth.routes.ts
@@ -60,4 +60,4 @@ authRouter.get("/me", authMiddleware, (req, res) => authController.getProfile(re
 authRouter.put("/me", authMiddleware, validateBody(updateProfileSchema), (req, res) => authController.updateProfile(req, res));
 authRouter.post("/import-github", authMiddleware, validateBody(importGitHubSchema), (req, res) => authController.importGitHub(req, res));
 authRouter.get("/github-stats", authMiddleware, usageLimit("GITHUB_STATS"), (req, res) => authController.getGitHubStats(req, res));
-authRouter.get("/profile/:id", authMiddleware, (req, res) => authController.getPublicProfile(req, res));
+authRouter.get("/profile/:identifier", authMiddleware, (req, res) => authController.getPublicProfile(req, res));

--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -1,4 +1,4 @@
-﻿import crypto from "crypto";
+import crypto from "crypto";
 import { OAuth2Client } from "google-auth-library";
 import { prisma } from "../../database/db.js";
 import { hashPassword, comparePassword } from "../../utils/password.utils.js";
@@ -12,6 +12,7 @@ const PROFILE_TTL = 300;
 
 const badgeService = new BadgeService();
 import { signUrl, signUrls } from "../../utils/s3.utils.js";
+import { createUniqueProfileSlug } from "../../lib/slug.js";
 import { sendEmail } from "../../utils/email.utils.js";
 import { welcomeEmailHtml, otpEmailHtml, resetPasswordEmailHtml } from "../../utils/email-templates.js";
 import type { UserRole } from "@prisma/client";
@@ -169,6 +170,13 @@ export class AuthService {
       data: { verificationOtp: hashedOtp, otpExpiresAt },
     });
 
+    const slug = await createUniqueProfileSlug(user.name, user.id, prisma);
+    const updatedUser = await prisma.user.update({
+      where: { id: user.id },
+      data: { profileSlug: slug },
+    });
+    (user as any).profileSlug = slug;
+
     // Send OTP email (fire-and-forget, don't block registration)
     sendEmail({
       to: user.email,
@@ -178,7 +186,7 @@ export class AuthService {
 
     const token = generateToken({ id: user.id, email: user.email, role: user.role, tokenVersion: 0 });
 
-    return { user, token };
+    return { user: { ...user, profileSlug: slug }, token };
   }
 
   async googleAuth(data: GoogleAuthInput) {
@@ -277,7 +285,13 @@ export class AuthService {
         },
       });
 
-      // Send welcome email (fire-and-forget) â€” temporarily disabled
+      const slug = await createUniqueProfileSlug(user.name, user.id, prisma);
+      user = await prisma.user.update({
+        where: { id: user.id },
+        data: { profileSlug: slug }
+      });
+
+      // Send welcome email (fire-and-forget) – temporarily disabled
       // sendEmail({
       //   to: user.email,
       //   subject: "Welcome to InternHack!",
@@ -363,6 +377,7 @@ export class AuthService {
     return {
       user: {
         id: user.id,
+        profileSlug: user.profileSlug,
         name: user.name,
         email: user.email,
         role: user.role,
@@ -384,6 +399,7 @@ export class AuthService {
     name: true,
     email: true,
     role: true,
+    profileSlug: true,
     isVerified: true,
     contactNo: true,
     profilePic: true,
@@ -516,27 +532,37 @@ export class AuthService {
     return user;
   }
 
-  async getPublicProfile(userId: number) {
-    const cacheKey = `profile:public:${userId}`;
+  async getPublicProfile(identifier: string) {
+    const cacheKey = `profile:public:${identifier}`;
     const cached = await cacheGet(cacheKey);
     if (cached) return cached as never;
 
-    const user = await prisma.user.findUnique({
-      where: { id: userId, role: "STUDENT", isProfilePublic: true },
-      select: {
-        ...this.profileSelect,
-        verifiedSkills: {
-          select: { skillName: true, score: true, verifiedAt: true },
-        },
-        atsScores: {
-          select: { overallScore: true },
-          orderBy: { overallScore: "desc" },
-          take: 1,
-        },
+    const selectOptions = {
+      ...this.profileSelect,
+      verifiedSkills: {
+        select: { skillName: true, score: true, verifiedAt: true },
       },
+      atsScores: {
+        select: { overallScore: true },
+        orderBy: { overallScore: "desc" as const },
+        take: 1,
+      },
+    };
+
+    let user: any;
+    user = await prisma.user.findUnique({
+      where: { profileSlug: identifier },
+      select: selectOptions,
     });
 
-    if (!user) {
+    if (!user && !isNaN(Number(identifier))) {
+      user = await prisma.user.findUnique({
+        where: { id: Number(identifier) },
+        select: selectOptions,
+      });
+    }
+
+    if (!user || user.role !== "STUDENT" || !user.isProfilePublic) {
       throw new Error("User not found");
     }
 
@@ -590,6 +616,7 @@ export class AuthService {
       },
       select: {
         id: true,
+        profileSlug: true,
         name: true,
         email: true,
         role: true,

--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -171,10 +171,6 @@ export class AuthService {
     });
 
     const slug = await createUniqueProfileSlug(user.name, user.id, prisma);
-    const updatedUser = await prisma.user.update({
-      where: { id: user.id },
-      data: { profileSlug: slug },
-    });
     (user as any).profileSlug = slug;
 
     // Send OTP email (fire-and-forget, don't block registration)
@@ -286,10 +282,7 @@ export class AuthService {
       });
 
       const slug = await createUniqueProfileSlug(user.name, user.id, prisma);
-      user = await prisma.user.update({
-        where: { id: user.id },
-        data: { profileSlug: slug }
-      });
+      user.profileSlug = slug;
 
       // Send welcome email (fire-and-forget) – temporarily disabled
       // sendEmail({
@@ -312,6 +305,7 @@ export class AuthService {
     return {
       user: {
         id: user.id,
+        profileSlug: user.profileSlug,
         name: user.name,
         email: user.email,
         role: user.role,
@@ -528,6 +522,9 @@ export class AuthService {
     // Bust cached profile so next GET /auth/me returns fresh data
     await cacheDel(`profile:me:${userId}`);
     await cacheDel(`profile:public:${userId}`);
+    if (user.profileSlug) {
+      await cacheDel(`profile:public:${user.profileSlug}`);
+    }
 
     return user;
   }
@@ -555,7 +552,7 @@ export class AuthService {
       select: selectOptions,
     });
 
-    if (!user && !isNaN(Number(identifier))) {
+    if (!user && /^\d+$/.test(identifier)) {
       user = await prisma.user.findUnique({
         where: { id: Number(identifier) },
         select: selectOptions,


### PR DESCRIPTION
# Pull Request

## Description
Profile sharing URLs used numeric IDs (/public/1) which expose
internal DB IDs, are not memorable, and look unprofessional when
shared on LinkedIn or in applications.

Changes:
- profileSlug field added to user model with unique constraint
- Slug auto-generated on registration from user name
  (lowercase, hyphens, URL-safe, fallback to name-id if taken)
- GET /profile/public/:identifier resolves slug first, falls
  back to numeric ID for backwards compatibility
- Copy URL button now generates slug-based URL
- Backfill script for existing users

## Related Issue
Fixes #899

## Type of Change
- [x] Feature

## Testing
1. Register new user → profileSlug generated automatically
2. Visit /public/sachin-chaurasiya → profile loads correctly
3. Visit old /public/1 → still works via numeric fallback
4. Copy URL → slug URL copied not numeric ID
5. Same name collision → second user gets name-id suffix

## Screenshot
<img width="877" height="190" alt="image" src="https://github.com/user-attachments/assets/4ca80646-9998-40df-abe3-d42ea8cae491" />

---

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No .env, credentials, or node_modules committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profile slug support, enabling users to access public profiles using human-readable identifiers instead of numeric IDs.
  * Profile URLs now support both slug-based and ID-based access formats.
  * Copy profile URL feature now generates slug-based URLs when available, providing more shareable and memorable profile links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->