### PR TITLE
roundSubmissions update

### DIFF
--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -235,7 +235,8 @@ export class RecruiterService {
           student: { select: { id: true, name: true, email: true, profilePic: true, resumes: true } },
           roundSubmissions: {
             include: { round: { select: { id: true, name: true, orderIndex: true } } },
-            orderBy: { round: { orderIndex: "asc" } },
+            orderBy: { createdAt: "desc" },
+            take: 5,
           },
         },
       }),


### PR DESCRIPTION
## Description
Optimized the `getApplications` query within the recruiter service. Previously, `roundSubmissions` was fetching all rows unconditionally for every application, leading to severe N+1 performance degradation and massive payload responses on high-volume jobs. 

This PR restricts the returned submissions payload to a maximum depth of 5 and updates the sorting strategy to surface the most recent submissions first.

## Related Issue
Fixes #1172

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [x] Enhancement
- [ ] Documentation

## Testing
- Manually verified that the Prisma client generates the corrected query structure.
- Confirmed that the payload size drops significantly for applications containing extensive round history logs.
- Ensured that `server/src/module/recruiter/recruiter.service.ts` still compiles seamlessly with valid TypeScript types.

## Screenshots / Video
_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Updated the ordering of round submissions displayed in the applications list. Round submissions are now sorted by creation date (newest first) and limited to the 5 most recent submissions per application, replacing the previous round-based ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->