### PR TITLE
fix: validate recruiter evaluation scores

### DIFF
--- a/server/src/module/recruiter/recruiter.controller.ts
+++ b/server/src/module/recruiter/recruiter.controller.ts
@@ -254,6 +254,7 @@ export class RecruiterController {
       if (error instanceof Error) {
         if (error.message === "Application not found" || error.message === "Round not found") return res.status(404).json({ message: error.message });
         if (error.message === "Not authorized") return res.status(403).json({ message: error.message });
+        if (error.message.startsWith("Evaluation score")) return res.status(400).json({ message: error.message });
       }
       logger.error("Failed to evaluate submission", error);
       return res.status(500).json({ message: "Internal Server Error" });

--- a/server/src/module/recruiter/recruiter.service.test.ts
+++ b/server/src/module/recruiter/recruiter.service.test.ts
@@ -6,8 +6,15 @@ const mocks = vi.hoisted(() => ({
       findUnique: vi.fn(),
     },
     application: {
+      findUnique: vi.fn(),
       findMany: vi.fn(),
       count: vi.fn(),
+    },
+    round: {
+      findUnique: vi.fn(),
+    },
+    roundSubmission: {
+      update: vi.fn(),
     },
   },
   s3Utils: {
@@ -131,6 +138,73 @@ describe("RecruiterService - getApplications", () => {
         where: expect.objectContaining({
           jobId,
           status: "APPLIED",
+        }),
+      })
+    );
+  });
+});
+
+describe("RecruiterService - evaluateSubmission", () => {
+  const service = new RecruiterService();
+  const applicationId = 100;
+  const roundId = 200;
+  const recruiterId = 10;
+  const jobId = 300;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.prisma.application.findUnique.mockResolvedValue({
+      id: applicationId,
+      jobId,
+      job: { recruiterId },
+    });
+    mocks.prisma.round.findUnique.mockResolvedValue({
+      jobId,
+      evaluationCriteria: [
+        { id: "communication", criterion: "Communication", maxScore: 10 },
+        { id: "technical", criterion: "Technical", maxScore: 20 },
+      ],
+    });
+    mocks.prisma.roundSubmission.update.mockResolvedValue({
+      id: 1,
+      applicationId,
+      roundId,
+      status: "COMPLETED",
+    });
+  });
+
+  it("rejects evaluation scores above the criterion maxScore", async () => {
+    await expect(
+      service.evaluateSubmission(applicationId, roundId, recruiterId, {
+        communication: { score: 11 },
+      })
+    ).rejects.toThrow("Evaluation score for communication cannot exceed maxScore 10");
+
+    expect(mocks.prisma.roundSubmission.update).not.toHaveBeenCalled();
+  });
+
+  it("allows evaluation scores equal to the criterion maxScore", async () => {
+    await service.evaluateSubmission(
+      applicationId,
+      roundId,
+      recruiterId,
+      {
+        communication: { score: 10, comment: "Clear answers" },
+        technical: { score: 20 },
+      },
+      "Strong candidate"
+    );
+
+    expect(mocks.prisma.roundSubmission.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { applicationId_roundId: { applicationId, roundId } },
+        data: expect.objectContaining({
+          evaluationScores: {
+            communication: { score: 10, comment: "Clear answers" },
+            technical: { score: 20 },
+          },
+          recruiterNotes: "Strong candidate",
+          status: "COMPLETED",
         }),
       })
     );

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -64,6 +64,44 @@ interface ApplicationFilter {
   search?: string | undefined;
 }
 
+interface EvaluationCriterion {
+  id: string;
+  maxScore: number;
+}
+
+function getEvaluationCriteriaById(criteria: unknown): Map<string, EvaluationCriterion> {
+  if (!Array.isArray(criteria)) return new Map();
+
+  const criteriaById = new Map<string, EvaluationCriterion>();
+  for (const criterion of criteria) {
+    if (
+      typeof criterion === "object" &&
+      criterion !== null &&
+      "id" in criterion &&
+      "maxScore" in criterion &&
+      typeof criterion.id === "string" &&
+      typeof criterion.maxScore === "number"
+    ) {
+      criteriaById.set(criterion.id, { id: criterion.id, maxScore: criterion.maxScore });
+    }
+  }
+
+  return criteriaById;
+}
+
+function validateEvaluationScores(
+  evaluationScores: Record<string, { score: number; comment?: string | undefined }>,
+  evaluationCriteria: unknown,
+) {
+  const criteriaById = getEvaluationCriteriaById(evaluationCriteria);
+
+  for (const [criterionId, evaluation] of Object.entries(evaluationScores)) {
+    const criterion = criteriaById.get(criterionId);
+    if (criterion && evaluation.score > criterion.maxScore) {
+      throw new Error(`Evaluation score for ${criterionId} cannot exceed maxScore ${criterion.maxScore}`);
+    }
+  }
+}
 
 type UpdateRoundData = {
   [K in keyof CreateRoundData]?: CreateRoundData[K] | undefined;
@@ -437,10 +475,11 @@ export class RecruiterService {
     // checking round ownership
     const round = await prisma.round.findUnique({
       where: { id: roundId },
-      select: { jobId: true },
+      select: { jobId: true, evaluationCriteria: true },
     });
 
     if (!round || round.jobId !== application.jobId) throw new Error("Round not found");
+    validateEvaluationScores(evaluationScores, round.evaluationCriteria);
     
     return prisma.roundSubmission.update({
       where: { applicationId_roundId: { applicationId, roundId } },


### PR DESCRIPTION
## Description\nAdds API-level validation so recruiter evaluation scores cannot exceed the matching round criterion maxScore before the submission is persisted. The controller now returns a 400 validation response for this case, and the recruiter service tests cover both over-limit rejection and at-limit acceptance.\n\n## Related Issue\nFixes #1120\n\n## Type of Change\n- [x] Bug Fix\n- [ ] Feature\n- [ ] Enhancement\n- [ ] Documentation\n\n## Testing\n- `npm ci` in `server`\n- `npm test -- recruiter.service.test.ts` (6 passed)\n- `npx eslint src/module/recruiter/recruiter.service.ts src/module/recruiter/recruiter.controller.ts src/module/recruiter/recruiter.service.test.ts --max-warnings=0`\n- `git diff --check`\n\nI also ran `npm run typecheck -- --pretty false`, but the full repo typecheck is currently blocked by existing baseline Prisma/type errors outside this change, including missing generated Prisma exports such as `UsageAction`, `PrismaClient`, and `ApplicationStatus`.\n\n## Screenshots / Video\n\n_No UI changes in this PR_\n\n## Checklist\n- [x] Code follows project guidelines\n- [x] No new compile/type errors in touched test path\n- [x] Tested manually (include steps above)\n- [x] No `.env`, credentials, or `node_modules` committed\n- [x] Docs updated (if needed)\n- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced evaluation submission validation to prevent scores from exceeding maximum allowed values per criterion. Invalid submissions now return a clear error message instead of being persisted.

* **Tests**
  * Added test coverage for evaluation score validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->