### PR TITLE
perf: add cache headers to opensource languages endpoint

### DIFF
--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -8,6 +8,10 @@ export class OpensourceController {
   async getLanguages(req: Request, res: Response, next: NextFunction) {
     try {
       const languages = await service.getLanguages();
+
+      // cache for 1 hour, allow stale data for 24 hours while revalidating
+      res.setHeader( "Cache-Control", "public, max-age=3600, stale-while-revalidate=86400" );
+
       res.json({ languages });
     } catch (err) {
       next(err);


### PR DESCRIPTION
## Description
Added HTTP cache headers to the `/api/opensource/languages` endpoint to improve browser/CDN caching and reduce unnecessary database requests.

Implemented:
```ts
Cache-Control: public, max-age=3600, stale-while-revalidate=86400
````

Also investigated the `/api/opensource/stats` endpoint mentioned in the issue, but it does not currently exist in the codebase and no frontend usage was found.

## Related Issue

Fixes #1031

## Type of Change

* [ ] Bug Fix
* [ ] Feature
* [x] Enhancement
* [ ] Documentation
* [x] Performance

## Testing

Tested manually by:

1. Running the backend server
2. Calling the endpoint using:

```bash
curl -I http://localhost:PORT/api/opensource/languages
```

3. Verified that the response contains:

```http
Cache-Control: public, max-age=3600, stale-while-revalidate=86400
```

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [x] Docs updated (if needed)
* [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized response caching for language data retrieval to improve performance and reduce server load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->