### PR TITLE
fix: make GSoC orgs year filter dynamic

### DIFF
--- a/client/src/module/student/opensource/GSoCReposPage.tsx
+++ b/client/src/module/student/opensource/GSoCReposPage.tsx
@@ -147,7 +147,9 @@ function FilterDropdown({
 }
 
 const ParticipationBar = ({ participatedYears }: { participatedYears: number[] }) => {
-  const yearsRange = Array.from({ length: 10 }, (_, i) => 2016 + i);
+  // Show participation from 2016 to current year
+  const currentYear = new Date().getFullYear();
+  const yearsRange = Array.from({ length: currentYear - 2015 }, (_, i) => 2016 + i);
 
   return (
     <div className="mb-4 flex items-center gap-1" aria-label="GSoC Participation History (2016-2025)">

--- a/client/src/module/student/opensource/GSoCReposPage.tsx
+++ b/client/src/module/student/opensource/GSoCReposPage.tsx
@@ -152,7 +152,7 @@ const ParticipationBar = ({ participatedYears }: { participatedYears: number[] }
   const yearsRange = Array.from({ length: currentYear - 2015 }, (_, i) => 2016 + i);
 
   return (
-    <div className="mb-4 flex items-center gap-1" aria-label="GSoC Participation History (2016-2025)">
+    <div className="mb-4 flex items-center gap-1" aria-label={`GSoC Participation History (2016-${currentYear})`}>
       {yearsRange.map((year) => {
         const participated = participatedYears.includes(year);
         return (


### PR DESCRIPTION
## Description
Replaced the hardcoded GSoC year filter range with a dynamic year range based on the current year.

Previously, the filter was limited to `2016–2025`, which would become stale in future years and miss newer participation data.

Now the year range updates automatically each year.

## Related Issue
Fixes #1001 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
Tested manually by:
1. Running the frontend application
2. Navigating to the GSoC orgs page
3. Verifying that the year filter includes the current year dynamically


## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the participation timeline to dynamically track through the current year instead of using a fixed year range, ensuring data remains current and accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->