### PR TITLE
fix: pause exam prep timer when browser tab loses focus

### DIFF
--- a/client/src/module/student/exam-prep/ExamRunnerPage.tsx
+++ b/client/src/module/student/exam-prep/ExamRunnerPage.tsx
@@ -47,7 +47,9 @@ export default function ExamRunnerPage({ mode }: { mode: Mode }) {
   const [flagged, setFlagged] = useState<Set<string>>(new Set());
   const [submitted, setSubmitted] = useState(false);
   const [remaining, setRemaining] = useState(durationSec);
-  const [paused, setPaused] = useState(false);
+  const [paused, setPaused] = useState(
+    () => (typeof document !== "undefined" ? document.hidden : false),
+  );
   const [tabSwitches, setTabSwitches] = useState(0);
 
   useEffect(() => {

--- a/client/src/module/student/exam-prep/ExamRunnerPage.tsx
+++ b/client/src/module/student/exam-prep/ExamRunnerPage.tsx
@@ -47,6 +47,25 @@ export default function ExamRunnerPage({ mode }: { mode: Mode }) {
   const [flagged, setFlagged] = useState<Set<string>>(new Set());
   const [submitted, setSubmitted] = useState(false);
   const [remaining, setRemaining] = useState(durationSec);
+  const [paused, setPaused] = useState(false);
+  const [tabSwitches, setTabSwitches] = useState(0);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        setPaused(true);
+        setTabSwitches((prev) => prev + 1);
+      } else {
+        setPaused(false);
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -54,7 +73,7 @@ export default function ExamRunnerPage({ mode }: { mode: Mode }) {
   }, [durationSec]);
 
   useEffect(() => {
-    if (submitted || !questions.length) return;
+    if (submitted || !questions.length || paused) return;
     const t = setInterval(() => {
       setRemaining((r) => {
         if (r <= 1) {
@@ -271,6 +290,11 @@ export default function ExamRunnerPage({ mode }: { mode: Mode }) {
         <div className="h-1 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden mt-3">
           <motion.div className="h-full bg-indigo-500" animate={{ width: `${pct}%` }} />
         </div>
+        {tabSwitches > 0 && (
+          <div className="mt-3 text-xs text-amber-600 dark:text-amber-400 font-medium">
+            Tab switch detected ({tabSwitches}/3). In real exams this may disqualify you.
+          </div>
+        )}
       </div>
 
       <AnimatePresence mode="wait">


### PR DESCRIPTION
## Description

Added tab visibility detection to the exam prep mock test timer.

The timer now pauses automatically when the browser tab loses focus or the screen becomes inactive. A warning message is also shown whenever a tab switch is detected to better simulate real exam environments.

## Related Issue

Fixes #1060 

## Type of Change

* [x] Bug Fix
* [ ] Feature
* [x] Enhancement
* [ ] Documentation

## Testing

Tested manually by:

1. Starting a mock exam
2. Switching browser tabs / minimizing the window
3. Confirming the timer pauses while the tab is inactive
4. Returning to the tab and verifying the timer resumes correctly
5. Confirming the tab switch warning appears correctly

## Screenshot

<img width="1915" height="841" alt="image" src="https://github.com/user-attachments/assets/525b2e12-2104-4e53-901e-70c92e4fd544" />

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [x] Docs updated (if needed)
* [x] Screenshot or video attached for every UI change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser tab switching detection during exams. A warning banner displays when users switch tabs, and the exam timer pauses when the page is not actively viewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->