### PR TITLE
fix: prevent evaluation of withdrawn applications

### DIFF
--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -434,6 +434,13 @@ export class RecruiterService {
 
     if (!application) throw new Error("Application not found");
     if (application.job.recruiterId !== recruiterId) throw new Error("Not authorized");
+
+    if (application.status === "WITHDRAWN") {
+      throw new Error(
+        "Withdrawn applications cannot participate in the hiring process"
+      );
+    }
+    
     // checking round ownership
     const round = await prisma.round.findUnique({
       where: { id: roundId },


### PR DESCRIPTION
## Summary

Fixes a workflow integrity issue where recruiters could continue evaluating round submissions after a candidate had withdrawn their application.

## Problem

Applications marked as `WITHDRAWN` are already treated as terminal states in several workflow paths:

* Students cannot submit additional round responses.
* Recruiters cannot advance withdrawn applications through hiring rounds.

However, the recruiter evaluation flow did not enforce the same restriction. As a result, recruiters could still evaluate and complete round submissions associated with withdrawn applications.

This created inconsistent workflow behavior and allowed withdrawn candidates to continue participating in parts of the hiring process.

## Changes

* Added a validation check in `RecruiterService.evaluateSubmission()`.
* Prevent evaluation requests when the associated application status is `WITHDRAWN`.
* Return a clear error message indicating that withdrawn applications cannot participate in the hiring process.

## Impact

After this change, withdrawn applications are consistently treated as terminal workflow states across recruiter and student actions.

The following actions are now blocked for withdrawn applications:

* Round submission by students
* Application advancement by recruiters
* Submission evaluation by recruiters

This improves workflow consistency and prevents unintended modifications to withdrawn candidates.

## Testing

* Verified that recruiter evaluation requests are rejected when the application status is `WITHDRAWN`.
* Verified that evaluation behavior for active applications remains unchanged.

Fixes #1259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented withdrawn applications from being evaluated, protecting application data integrity and preventing unintended changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->