### PR TITLE
Validate S3 URLs in upload endpoints (issue #1277)

### DIFF
--- a/server/src/module/upload/upload.routes.ts
+++ b/server/src/module/upload/upload.routes.ts
@@ -21,7 +21,7 @@ const presignedUrlRateLimit = rateLimit({
   store: createRateLimitStore("upload"),
 });
 
-import { validateBody, presignRequestSchema } from "./upload.validation.js";
+import { validateBody, presignRequestSchema, uploadProfilePicSchema, uploadCoverImageSchema, uploadResumeSchema } from "./upload.validation.js";
 
 const presignedUsageLimit = (req: any, res: any, next: any) => {
   if (req.body && req.body.folder === "resumes") {
@@ -39,9 +39,24 @@ uploadRouter.post(
   (req, res) => uploadController.getPresignedUrl(req, res)
 );
 
-// UPDATED: Profile-specific endpoints (No more multer middleware!)
-// These now expect a JSON body like: { "fileUrl": "https://..." }
-uploadRouter.post("/profile-pic", (req, res) => uploadController.uploadProfilePic(req, res));
-uploadRouter.post("/cover-image", (req, res) => uploadController.uploadCoverImage(req, res));
-uploadRouter.post("/profile-resume", usageLimit("GENERATE_RESUME"), (req, res) => uploadController.uploadProfileResume(req, res));
+// UPDATED: Profile-specific endpoints with S3 URL validation
+// These expect a JSON body like: { "fileUrl": "https://authorized-bucket.s3..." }
+uploadRouter.post(
+  "/profile-pic",
+  validateBody(uploadProfilePicSchema),
+  (req, res) => uploadController.uploadProfilePic(req, res)
+);
+
+uploadRouter.post(
+  "/cover-image",
+  validateBody(uploadCoverImageSchema),
+  (req, res) => uploadController.uploadCoverImage(req, res)
+);
+
+uploadRouter.post(
+  "/profile-resume",
+  validateBody(uploadResumeSchema),
+  usageLimit("GENERATE_RESUME"),
+  (req, res) => uploadController.uploadProfileResume(req, res)
+);
 uploadRouter.delete("/profile-resume", (req, res) => uploadController.deleteProfileResume(req, res));

--- a/server/src/module/upload/upload.validation.ts
+++ b/server/src/module/upload/upload.validation.ts
@@ -1,6 +1,21 @@
 import { z } from "zod";
 import type { Request, Response, NextFunction } from "express";
 
+// Helper function to validate S3 URLs from authorized bucket
+const validateS3Url = (url: string): boolean => {
+  const allowedBucket = process.env.AWS_S3_BUCKET || "internhack-uploads";
+  const region = process.env.AWS_REGION || "us-east-1";
+
+  // Check if URL is from authorized S3 bucket
+  const validPatterns = [
+    `https://${allowedBucket}.s3.amazonaws.com/`,
+    `https://${allowedBucket}.s3.${region}.amazonaws.com/`,
+    `https://${allowedBucket}.s3-${region}.amazonaws.com/`,
+  ];
+
+  return validPatterns.some((pattern) => url.startsWith(pattern));
+};
+
 export const deleteResumeSchema = z.object({
   url: z.string().url("Valid resume URL is required"),
 });
@@ -11,6 +26,30 @@ export const presignRequestSchema = z.object({
   folder: z.enum(["resumes", "profile-pics", "cover-images", "company-logos"], {
     message: "Invalid or unauthorized folder. Allowed: resumes, profile-pics, cover-images, company-logos",
   }),
+});
+
+// Schema for uploading profile picture with S3 URL validation
+export const uploadProfilePicSchema = z.object({
+  fileUrl: z.string().url("Valid file URL required").refine(
+    validateS3Url,
+    "File must be from authorized S3 bucket"
+  ),
+});
+
+// Schema for uploading cover image with S3 URL validation
+export const uploadCoverImageSchema = z.object({
+  fileUrl: z.string().url("Valid file URL required").refine(
+    validateS3Url,
+    "File must be from authorized S3 bucket"
+  ),
+});
+
+// Schema for uploading resume with S3 URL validation
+export const uploadResumeSchema = z.object({
+  fileUrl: z.string().url("Valid file URL required").refine(
+    validateS3Url,
+    "File must be from authorized S3 bucket"
+  ),
 });
 
 export const validateBody = (schema: z.ZodSchema) => {


### PR DESCRIPTION
Fixes #1277: Upload endpoints now validate that file URLs come from authorized S3 buckets, preventing URL injection and unauthorized S3 access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Strengthened profile upload security with mandatory validation for profile pictures, cover images, and resume uploads. All files must now be verified to originate from authorized S3 buckets, preventing potentially unauthorized file sources and enhancing data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->