### PR TITLE
perf(client): add lazy loading to talent card profile pictures

### DIFF
--- a/client/src/module/recruiter/talent/TalentCard.tsx
+++ b/client/src/module/recruiter/talent/TalentCard.tsx
@@ -123,6 +123,7 @@ export default function TalentCard({ student, index = 0, saved = false }: Talent
             <img
               src={student.profilePic}
               alt={student.name}
+              loading="lazy"
               className="w-11 h-11 rounded-md object-cover shrink-0 border border-stone-200 dark:border-white/10"
               onError={(e) => {
                 e.currentTarget.style.display = "none";


### PR DESCRIPTION
# Pull Request

## Description
Added `loading="lazy"` to the profile picture `<img>` element inside `TalentCard.tsx`. This fixes the loading issue where 20+ image requests were being fired simultaneously when a recruiter navigated to the Talent Search page.

## Related Issue
Fixes #1128

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
- Verified `client/src/module/recruiter/talent/TalentCard.tsx` has the `loading="lazy"` attribute applied correctly.
- Confirmed no TypeScript or linting regressions.
- The browser will now natively defer loading off-screen images until they approach the viewport.

## Screenshots / Video



_No UI changes in this PR_ 

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [ ] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Enabled lazy loading for profile images in talent cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->