### PR TITLE
fix: prevent stale fetch updates on ApplicationDetail unmount

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationDetail.tsx
+++ b/client/src/module/recruiter/applications/ApplicationDetail.tsx
@@ -16,20 +16,57 @@ export default function ApplicationDetail() {
   const [evaluatingRoundId, setEvaluatingRoundId] = useState<number | null>(null);
   const [verifiedSkills, setVerifiedSkills] = useState<VerifiedSkill[]>([]);
 
-  const fetchDetail = useCallback(() => {
-    api.get(`/recruiter/applications/${applicationId}`).then((res) => {
+  const fetchDetail = useCallback(async () => {
+    try {
+      const res = await api.get(
+        `/recruiter/applications/${applicationId}`
+      );
       setApplication(res.data.application);
-      setLoading(false);
-    }).catch(() => setLoading(false));
+    } catch (err: any) {
+      console.error(err);
+    }
   }, [applicationId]);
 
-  useEffect(() => { fetchDetail(); }, [fetchDetail]);
+  useEffect(() => {
+    const controller = new AbortController();
+    let isMounted = true;
+
+    const load = async () => {
+      try {
+        setLoading(true);
+
+        const res = await api.get(
+          `/recruiter/applications/${applicationId}`,
+          { signal: controller.signal }
+        );
+
+        if (isMounted) {
+          setApplication(res.data.application);
+        }
+      } catch (err: any) {
+        if (err.name !== "CanceledError" && err.name !== "AbortError") {
+          console.error(err);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [applicationId]);
 
   useEffect(() => {
     if (application?.student?.id) {
       api.get(`/skill-tests/verified/${application.student.id}`)
         .then((res) => setVerifiedSkills(res.data.verifiedSkills || []))
-        .catch(() => {});
+        .catch(() => { });
     }
   }, [application?.student?.id]);
 


### PR DESCRIPTION
# Pull Request

## Description
Fix stale fetch updates in ApplicationDetail page when recruiter navigates away before API request completes.  
Added AbortController and mounted-state guard to prevent setting state on unmounted components and avoid React warnings.

## Related Issue
Fixes #1127

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
- Opened ApplicationDetail page
- Navigated away quickly before API response returned
- Verified no React "setState on unmounted component" warning in console
- Verified data still loads correctly when staying on page

## Screenshots / Video

_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (navigation away before fetch completes)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] Screenshot or video attached for every UI change (not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request handling for application detail loading to prevent stale state and improve error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->