### PR TITLE
fix: bound recruiter evaluation max scores

### DIFF
--- a/client/src/lib/types/ai.types.ts
+++ b/client/src/lib/types/ai.types.ts
@@ -1,5 +1,11 @@
 export type AIProviderType = "GEMINI" | "GROQ" | "OPENROUTER" | "CODESTRAL" | "CLAUDE";
-export type AIServiceType = "ATS_SCORE" | "COVER_LETTER" | "RESUME_GEN" | "LATEX_CHAT" | "EMAIL_CHAT";
+export type AIServiceType =
+  | "ATS_SCORE"
+  | "COVER_LETTER"
+  | "RESUME_GEN"
+  | "LATEX_CHAT"
+  | "EMAIL_CHAT"
+  | "AI_ROADMAP_GENERATION";
 
 export interface AIServiceConfig {
   id: number;

--- a/client/src/module/admin/ai/AdminAIProvidersPage.tsx
+++ b/client/src/module/admin/ai/AdminAIProvidersPage.tsx
@@ -13,6 +13,7 @@ const SERVICE_LABELS: Record<AIServiceType, string> = {
   RESUME_GEN: "LaTeX Resume Generation",
   LATEX_CHAT: "LaTeX Chat Assistant",
   EMAIL_CHAT: "Email Chat Assistant",
+  AI_ROADMAP_GENERATION: "AI Roadmap Generation",
 };
 
 const PROVIDER_INFO: Record<AIProviderType, { label: string; color: string; models: string[] }> = {

--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -986,6 +986,34 @@ model savedCandidate {
   @@index([studentId])
 }
 
+model aiServiceConfig {
+  id          Int            @id @default(autoincrement())
+  service     AIServiceType  @unique
+  provider    AIProviderType @default(GEMINI)
+  modelName   String         @default("gemini-2.5-flash-lite")
+  updatedAt   DateTime       @updatedAt
+  requestLogs aiRequestLog[]
+}
+
+model aiRequestLog {
+  id              Int             @id @default(autoincrement())
+  serviceConfigId Int
+  service         AIServiceType
+  providerName    AIProviderType
+  modelName       String
+  latencyMs       Int
+  inputTokens     Int?
+  outputTokens    Int?
+  success         Boolean         @default(true)
+  errorMessage    String?
+  userId          Int?
+  createdAt       DateTime        @default(now())
+  serviceConfig   aiServiceConfig @relation(fields: [serviceConfigId], references: [id], onDelete: Cascade)
+
+  @@index([providerName, createdAt])
+  @@index([service, createdAt])
+  @@index([createdAt])
+}
 
 model adminJob {
   id           Int                      @id @default(autoincrement())
@@ -1149,6 +1177,23 @@ enum SubscriptionStatus {
   ACTIVE
   EXPIRED
   CANCELLED
+}
+
+enum AIProviderType {
+  GEMINI
+  GROQ
+  OPENROUTER
+  CODESTRAL
+  CLAUDE
+}
+
+enum AIServiceType {
+  ATS_SCORE
+  COVER_LETTER
+  RESUME_GEN
+  LATEX_CHAT
+  EMAIL_CHAT
+  AI_ROADMAP_GENERATION
 }
 
 enum BadgeCategory {
@@ -1389,4 +1434,3 @@ model guideFeedback {
   @@index([guideId])
   @@index([stepId])
   }
-

--- a/server/src/module/opensource/opensource.routes.ts
+++ b/server/src/module/opensource/opensource.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { OpensourceController } from "./opensource.controller.js";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
 import { requireRole } from "../../middleware/role.middleware.js";
+import { prisma } from "../../database/db.js";
 
 export const opensourceRouter = Router();
 const controller = new OpensourceController();

--- a/server/src/module/recruiter/recruiter.validation.test.ts
+++ b/server/src/module/recruiter/recruiter.validation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { createRoundSchema, updateRoundSchema } from "./recruiter.validation.js";
+
+const validCriterion = {
+  id: "technical-depth",
+  criterion: "Technical depth",
+  maxScore: 100,
+};
+
+const validRound = {
+  name: "Technical Interview",
+  orderIndex: 0,
+  evaluationCriteria: [validCriterion],
+};
+
+describe("recruiter.validation", () => {
+  describe("evaluation criteria maxScore", () => {
+    it("accepts positive scores up to 100 when creating a round", () => {
+      const result = createRoundSchema.safeParse(validRound);
+
+      expect(result.success).toBe(true);
+    });
+
+    it.each([0, -5])("rejects non-positive maxScore value %s", (maxScore) => {
+      const result = createRoundSchema.safeParse({
+        ...validRound,
+        evaluationCriteria: [{ ...validCriterion, maxScore }],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0]?.path).toEqual(["evaluationCriteria", 0, "maxScore"]);
+    });
+
+    it("rejects maxScore values above 100 when creating a round", () => {
+      const result = createRoundSchema.safeParse({
+        ...validRound,
+        evaluationCriteria: [{ ...validCriterion, maxScore: 101 }],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0]?.message).toBe("Maximum score cannot exceed 100");
+    });
+
+    it("applies the same maxScore bound when updating a round", () => {
+      const result = updateRoundSchema.safeParse({
+        evaluationCriteria: [{ ...validCriterion, maxScore: 250 }],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0]?.path).toEqual(["evaluationCriteria", 0, "maxScore"]);
+    });
+  });
+});

--- a/server/src/module/recruiter/recruiter.validation.ts
+++ b/server/src/module/recruiter/recruiter.validation.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 // sanitization function
 const sanitizeText = (value: string) => value.replace(/<[^>]*>?/gm, "").trim();
+const MAX_EVALUATION_CRITERION_SCORE = 100;
 
 const customFieldDefinitionSchema = z.object({
   id: z.string(),
@@ -25,7 +26,10 @@ const customFieldDefinitionSchema = z.object({
 const evaluationCriterionSchema = z.object({
   id: z.string(),
   criterion: z.string(),
-  maxScore: z.number().positive(),
+  maxScore: z
+    .number()
+    .positive("Maximum score must be greater than 0")
+    .max(MAX_EVALUATION_CRITERION_SCORE, `Maximum score cannot exceed ${MAX_EVALUATION_CRITERION_SCORE}`),
   weight: z.number().positive().optional(),
 });
 


### PR DESCRIPTION
## Summary
- add a 100-point upper bound to recruiter evaluation criteria `maxScore`
- keep existing positive validation, with clearer validation messages for non-positive and over-limit values
- add regression coverage for create/update round schemas
- restore missing Prisma AI service declarations from the repo schema backup and add the missing `prisma` import so server typecheck can complete

Closes #1119

## Validation
- npm test -- --run src/module/recruiter/recruiter.validation.test.ts
- npm run lint -- src/module/recruiter/recruiter.validation.ts src/module/recruiter/recruiter.validation.test.ts src/module/opensource/opensource.routes.ts
- npx prisma generate --schema=src/database/prisma/schema
- npm run typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation tests for evaluation criteria scoring rules.

* **Bug Fixes**
  * Evaluation criterion max scores must be greater than 0 and are now capped at 100 with clearer error messages.

* **New Features**
  * Added support for AI service configuration and request logging (provider/model metadata, latency, token counts, success/error details).

* **UI**
  * Updated admin UI to show a friendly label for the roadmap-generation AI service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->