### PR TITLE
fix: avoid non-finite conversion rate in job analytics

### DIFF
--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -583,6 +583,9 @@ export class RecruiterService {
       statusCounts[s.status] = s._count.id;
     }
 
+    const hiredCount = statusCounts["HIRED"] || 0;
+    const conversionRate = totalApplications === 0 ? 0 : (hiredCount / totalApplications) * 100;
+
     const roundAnalytics = rounds.map((round) => {
       const completed = round.roundSubmissions.filter((s) => s.status === "COMPLETED").length;
       const inProgress = round.roundSubmissions.filter((s) => s.status === "IN_PROGRESS").length;
@@ -605,6 +608,8 @@ export class RecruiterService {
       totalApplications,
       statusBreakdown: statusCounts,
       roundAnalytics,
+      hiredCount,
+      conversionRate,
     };
   }
 


### PR DESCRIPTION
# Pull Request

## Description
This PR resolves an issue in the job analytics dashboard where the Conversion Rate returned `null` instead of `0` when a job had `0` total applications.

## Related Issue
Fixes #1195 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
Explain how you tested it.

## Screenshots / Video
_No UI changes in this PR_ (delete this line if you are making UI changes)

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recruitment analytics now display hired candidate count and conversion rate percentage, providing enhanced insights into job posting performance and hiring success metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->