### PR TITLE
feat: add 'new this week' badge and filter toggle to repo cards

### DIFF
--- a/client/src/module/student/opensource/RepoCard.tsx
+++ b/client/src/module/student/opensource/RepoCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { Star, GitFork, CircleDot, Flame, ArrowRight } from "lucide-react";
+import { Star, GitFork, CircleDot, Flame, ArrowRight, Zap } from "lucide-react";
 import type { OpenSourceRepo } from "../../../lib/types";
 import { LANGUAGE_COLORS } from "./reposData";
 import { formatCount, difficultyBadge } from "./_shared/repo-utils";
@@ -16,6 +16,7 @@ const MAX_STAGGER_INDEX = 8;
 export const RepoCard = React.memo(function RepoCard({ repo, index, onSelect }: RepoCardProps) {
   const badge = difficultyBadge(repo.difficulty);
   const delay = Math.min(index, MAX_STAGGER_INDEX) * 0.04;
+  const isNew = Date.now() - new Date(repo.createdAt).getTime() < 7 * 24 * 60 * 60 * 1000;
 
   return (
     <motion.div
@@ -34,6 +35,12 @@ export const RepoCard = React.memo(function RepoCard({ repo, index, onSelect }: 
           <div className="absolute -top-2 right-4 inline-flex items-center gap-1 rounded-md bg-stone-900 dark:bg-stone-50 px-2 py-0.5 text-[10px] font-mono uppercase tracking-widest text-lime-400">
             <Flame size={10} aria-hidden />
             trending
+          </div>
+        )}
+        {isNew && (
+          <div className="absolute -top-2 left-4 inline-flex items-center gap-1 rounded-md bg-lime-400 px-2 py-0.5 text-[10px] font-mono uppercase tracking-widest text-stone-950">
+            <Zap size={10} aria-hidden />
+            new
           </div>
         )}
 

--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -15,6 +15,7 @@ import {
   Code2,
   Wand2,
   Flame,
+  Zap,
   ArrowRight,
   BookOpen,
   AlertCircle,
@@ -54,6 +55,7 @@ export default function RepoDiscoveryPage() {
   const sortKey = searchParams.get("sort") || "stars";
   const page = Number(searchParams.get("page")) || 1;
   const trendingOnly = searchParams.get("trending") === "true";
+  const newThisWeek = searchParams.get("newThisWeek") === "true";
 
   // Debounced search state & ref
   const [inputValue, setInputValue] = useState(search);
@@ -187,7 +189,12 @@ export default function RepoDiscoveryPage() {
     return languagesData || (Object.keys(LANGUAGE_COLORS) as string[]);
   }, [languagesData]);
 
-  const repos = useMemo(() => data?.repos ?? [], [data?.repos]);
+  const repos = useMemo(() => {
+    const allRepos = data?.repos ?? [];
+    if (!newThisWeek) return allRepos;
+    const weekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    return allRepos.filter((r) => new Date(r.createdAt).getTime() > weekAgo);
+  }, [data?.repos, newThisWeek]);
   const pagination = data?.pagination;
 
   const stats = useMemo(() => {
@@ -403,6 +410,20 @@ export default function RepoDiscoveryPage() {
           >
             <Flame className="w-3 h-3" />
             Trending
+          </button>
+
+          {/* New this week toggle */}
+          <button
+            type="button"
+            onClick={() => updateFilter("newThisWeek", newThisWeek ? "" : "true")}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${
+              newThisWeek
+                ? "bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 border-lime-200 dark:border-lime-400/30"
+                : "text-stone-500 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25"
+            }`}
+          >
+            <Zap className="w-3 h-3" />
+            New this week
           </button>
 
           {/* More filters toggle */}


### PR DESCRIPTION
## Summary

Adds a **'New' badge** on repo cards created within the last 7 days, and a **'New this week' filter toggle** alongside the existing Trending toggle on the repo discovery page.

## Changes

- **RepoCard.tsx**: Added 'New' badge (lime background, Zap icon) displayed on repos with \createdAt\ within the last 7 days
- **RepoDiscoveryPage.tsx**: Added 'New this week' filter toggle button; repos are filtered client-side when active

Closes #1023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repositories created within the past week are now highlighted with a visual indicator
  * Added a "New this week" filter option to browse only recently created repositories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->