### PR TITLE
feat: show remaining estimated time on guide list pages

### DIFF
--- a/client/src/module/student/opensource/FirstPRRoadmapPage.tsx
+++ b/client/src/module/student/opensource/FirstPRRoadmapPage.tsx
@@ -49,6 +49,10 @@ export default function FirstPRRoadmapPage() {
   const totalEstimatedMinutes = STEPS.reduce((sum, step) => sum + (step.estimatedMinutes || 0), 0);
   const currentStep =
     STEPS.find((s) => !completed.has(s.id))?.id;
+  const completedMinutes = STEPS
+    .filter((s) => completed.has(s.id))
+    .reduce((sum, s) => sum + (s.estimatedMinutes || 0), 0);
+  const remainingMinutes = totalEstimatedMinutes - completedMinutes;
 
   return (
     <div className="relative pb-12">
@@ -98,7 +102,7 @@ export default function FirstPRRoadmapPage() {
           { icon: GitPullRequest, value: totalSteps, label: "Steps", iconColor: "text-indigo-500" },
           { icon: CheckCircle2, value: completed.size, label: "Completed", iconColor: "text-green-500" },
           { icon: Trophy, value: `${pct}%`, label: "Progress", iconColor: "text-amber-500" },
-          { icon: ArrowRight, value: `${totalEstimatedMinutes} min`, label: "Est. Time", iconColor: "text-indigo-500" },
+          { icon: ArrowRight, value: allDone ? "Done!" : completed.size > 0 ? `${remainingMinutes} min left` : `${totalEstimatedMinutes} min total`, label: "Est. Time", iconColor: "text-indigo-500" },
         ].map((stat, i) => (
           <motion.div
             key={stat.label}

--- a/client/src/module/student/opensource/GSoCProposalPage.tsx
+++ b/client/src/module/student/opensource/GSoCProposalPage.tsx
@@ -67,6 +67,10 @@ export default function GSoCProposalPage() {
   const pct = Math.round((completed.size / totalSteps) * 100);
   const allDone = completed.size === totalSteps;
   const totalEstimatedMinutes = STEPS.reduce((sum, step) => sum + (step.estimatedMinutes || 0), 0);
+  const completedMinutes = STEPS
+    .filter((s) => completed.has(s.id))
+    .reduce((sum, s) => sum + (s.estimatedMinutes || 0), 0);
+  const remainingMinutes = totalEstimatedMinutes - completedMinutes;
   return (
     <div className="relative pb-12">
       <SEO
@@ -115,7 +119,7 @@ export default function GSoCProposalPage() {
           { icon: Award, value: totalSteps, label: "Steps", iconColor: "text-red-500" },
           { icon: CheckCircle2, value: completed.size, label: "Completed", iconColor: "text-green-500" },
           { icon: Trophy, value: `${pct}%`, label: "Progress", iconColor: "text-amber-500" },
-          { icon: Clock, value: `${totalEstimatedMinutes} min`, label: "Est. Time", iconColor: "text-indigo-500" },
+          { icon: Clock, value: allDone ? "Done!" : completed.size > 0 ? `${remainingMinutes} min left` : `${totalEstimatedMinutes} min total`, label: "Est. Time", iconColor: "text-indigo-500" },
         ].map((stat, i) => (
           <motion.div
             key={stat.label}

--- a/client/src/module/student/opensource/components/GuideListPage.tsx
+++ b/client/src/module/student/opensource/components/GuideListPage.tsx
@@ -47,6 +47,10 @@ export default function GuideListPage({
   const pct = Math.round((completed.size / totalSteps) * 100);
   const allDone = completed.size === totalSteps;
   const totalEstimatedTime = steps.reduce((sum, step) => sum + (step.estimatedMinutes || 0), 0);
+  const completedMinutes = steps
+    .filter((s) => completed.has(s.id))
+    .reduce((sum, s) => sum + (s.estimatedMinutes || 0), 0);
+  const remainingMinutes = totalEstimatedTime - completedMinutes;
 
   // Split title around accent word
   const titleBefore = title.replace(titleAccent, "").trim();
@@ -99,7 +103,7 @@ export default function GuideListPage({
           { icon: Icon, value: totalSteps, label: "Sections", iconColor },
           { icon: CheckCircle2, value: completed.size, label: "Completed", iconColor: "text-green-500" },
           { icon: Trophy, value: `${pct}%`, label: "Progress", iconColor: "text-amber-500" },
-          { icon: ArrowRight, value: `${totalEstimatedTime} min`, label: "Estimated Time", iconColor: "text-indigo-500" },
+          { icon: ArrowRight, value: allDone ? "Done!" : completed.size > 0 ? `${remainingMinutes} min left` : `${totalEstimatedTime} min total`, label: "Est. Time", iconColor: "text-indigo-500" },
         ].map((stat, i) => (
           <motion.div
             key={stat.label}


### PR DESCRIPTION
## Summary

Updates the 'Est. Time' stat across all guide list pages to show remaining minutes when the guide is in progress, instead of always displaying the total.

## Changes

- **GuideListPage.tsx**: Shows '35 min left' when in progress, '90 min total' when not started, 'Done!' when complete
- **FirstPRRoadmapPage.tsx**: Same behavior
- **GSoCProposalPage.tsx**: Same behavior

Closes #1011