### PR TITLE
add aria-labels to pagination buttons

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationsList.tsx
+++ b/client/src/module/recruiter/applications/ApplicationsList.tsx
@@ -219,9 +219,11 @@ const handleStatusChange = async (appId: number, status: string) => {
           {pagination && pagination.totalPages > 1 && (
             <div className="flex items-center justify-center gap-2 mt-6">
               <button onClick={() => setPage(Math.max(1, page - 1))} disabled={page === 1}
+                aria-label="Go to previous page"
                 className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg disabled:opacity-30 dark:text-gray-300">Prev</button>
               <span className="text-sm text-gray-500 dark:text-gray-500">Page {page} of {pagination.totalPages}</span>
               <button onClick={() => setPage(Math.min(pagination.totalPages, page + 1))} disabled={page === pagination.totalPages}
+                aria-label={`Go to next page, page ${page + 1}`}
                 className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg disabled:opacity-30 dark:text-gray-300">Next</button>
             </div>
           )}


### PR DESCRIPTION
# Pull Request

## Description
Added aria-labels to pagination buttons in `client/src/module/recruiter/ApplicationsList.tsx` 
- **Prev button :** `aria-label="Go to previous page"`
- **Next button :** `aria-label={`Go to next page, page ${page + 1}`}`

## Related Issue
Fixes #1156 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Screenshots / Video
_No UI changes in this PR_ (delete this line if you are making UI changes)

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility for pagination controls in the applications list with improved button labeling, enabling better navigation support for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->