### PR TITLE
fix : dynamically generate job status filters from enum

### DIFF
--- a/client/src/lib/types/jobs.types.ts
+++ b/client/src/lib/types/jobs.types.ts
@@ -1,6 +1,12 @@
 import type { UserRole, User } from "./user.types";
 
-export type JobStatus = "DRAFT" | "PUBLISHED" | "CLOSED" | "ARCHIVED";
+export const JobStatus = {
+  DRAFT: "DRAFT",
+  PUBLISHED: "PUBLISHED",
+  CLOSED: "CLOSED",
+  ARCHIVED: "ARCHIVED",
+} as const;
+export type JobStatus = (typeof JobStatus)[keyof typeof JobStatus];
 export type ApplicationStatus = "APPLIED" | "IN_PROGRESS" | "SHORTLISTED" | "REJECTED" | "HIRED" | "WITHDRAWN";
 export type RoundStatus = "PENDING" | "IN_PROGRESS" | "COMPLETED" | "SKIPPED";
 export type FieldType = "TEXT" | "TEXTAREA" | "DROPDOWN" | "MULTI_SELECT" | "FILE_UPLOAD" | "BOOLEAN" | "NUMERIC" | "DATE" | "EMAIL" | "URL";

--- a/client/src/module/recruiter/jobs/RecruiterJobsList.tsx
+++ b/client/src/module/recruiter/jobs/RecruiterJobsList.tsx
@@ -15,18 +15,19 @@ import {
 } from "lucide-react";
 import api from "../../../lib/axios";
 import toast from "../../../components/ui/toast";
+import { JobStatus } from "../../../lib/types";
 import type { Job } from "../../../lib/types";
 import { SEO } from "../../../components/SEO";
 import { Button } from "../../../components/ui/button";
 
-type StatusFilter = "ALL" | "DRAFT" | "PUBLISHED" | "CLOSED" | "ARCHIVED";
+type StatusFilter = "ALL" | JobStatus;
 
 const STATUS_TABS: { key: StatusFilter; label: string }[] = [
   { key: "ALL", label: "all" },
-  { key: "PUBLISHED", label: "published" },
-  { key: "DRAFT", label: "draft" },
-  { key: "CLOSED", label: "closed" },
-  { key: "ARCHIVED", label: "archived" },
+  ...Object.values(JobStatus).map((status) => ({
+    key: status as StatusFilter,
+    label: status.toLowerCase(),
+  })),
 ];
 
 export default function RecruiterJobsList() {
@@ -67,9 +68,15 @@ export default function RecruiterJobsList() {
   };
 
   const counts = useMemo(() => {
-    const base = { ALL: jobs.length, DRAFT: 0, PUBLISHED: 0, CLOSED: 0, ARCHIVED: 0 } as Record<StatusFilter, number>;
+    const base = { ALL: jobs.length } as Record<StatusFilter, number>;
+    for (const status of Object.values(JobStatus)) {
+      base[status] = 0;
+    }
     for (const j of jobs) {
-      if (j.status in base) base[j.status as StatusFilter]++;
+      const status = j.status as StatusFilter;
+      if (status in base) {
+        base[status]++;
+      }
     }
     return base;
   }, [jobs]);


### PR DESCRIPTION
# Pull Request

## Description
The job status filter was hardcoded to a static subset of options (omitting DRAFT and ARCHIVED), preventing recruiters from filtering by those statuses.

## Changes Made
**1. Replaced type union with a runtime `const` object & derived type**
In `jobs.types.ts`, replaced the type union for `JobStatus` with a runtime `const` object paired with a derived type

**2. Made status filters and counts dynamic**
In `RecruiterJobsList.tsx`: Generated filter options dynamically using `Object.values(JobStatus)`. This keeps tabs automatically synchronized with any schema additions

## Related Issue
Fixes #1190 

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Screenshots / Video
_No UI changes in this PR_ 

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved job status management by consolidating status definitions for more consistent handling across the recruiter dashboard. Job filtering and tab counts now derive from a unified source, enhancing maintainability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->