### PR TITLE
fix: enforce external job application usage limit

### DIFF
--- a/server/src/module/student/student.controller.ts
+++ b/server/src/module/student/student.controller.ts
@@ -163,7 +163,11 @@ export class StudentController {
       if (isNaN(adminJobId)) return res.status(400).json({ message: "Invalid job ID" });
 
       const application = await this.studentService.applyToExternalJob(req.user.id, adminJobId);
-      return res.status(201).json({ message: "Applied successfully", application });
+
+      await prisma.usageLog.create({ data: { userId: req.user.id, action: "JOB_APPLICATION" } });
+      const usage = req.usageInfo ? { used: req.usageInfo.used + 1, limit: req.usageInfo.limit } : undefined;
+
+      return res.status(201).json({ message: "Applied successfully", application, usage });
     } catch (error) {
       if (error instanceof Error) {
         if (error.message === "External job not found") return res.status(404).json({ message: error.message });

--- a/server/src/module/student/student.controller.ts
+++ b/server/src/module/student/student.controller.ts
@@ -163,8 +163,6 @@ export class StudentController {
       if (isNaN(adminJobId)) return res.status(400).json({ message: "Invalid job ID" });
 
       const application = await this.studentService.applyToExternalJob(req.user.id, adminJobId);
-
-      await prisma.usageLog.create({ data: { userId: req.user.id, action: "JOB_APPLICATION" } });
       const usage = req.usageInfo ? { used: req.usageInfo.used + 1, limit: req.usageInfo.limit } : undefined;
 
       return res.status(201).json({ message: "Applied successfully", application, usage });

--- a/server/src/module/student/student.external-application.service.test.ts
+++ b/server/src/module/student/student.external-application.service.test.ts
@@ -13,6 +13,14 @@ const mocks = vi.hoisted(() => ({
       create: vi.fn(),
     },
   },
+  tx: {
+    externalJobApplication: {
+      create: vi.fn(),
+    },
+    usageLog: {
+      create: vi.fn(),
+    },
+  },
   badgeService: {
     checkAndAwardBadges: vi.fn().mockResolvedValue(undefined),
   },
@@ -30,7 +38,9 @@ vi.mock("../badge/badge.service.js", () => ({
 
 const { StudentService } = await import("./student.service.js");
 
-vi.spyOn(StudentService.prototype as any, "checkApplicationMilestone").mockResolvedValue(undefined);
+const checkApplicationMilestoneSpy = vi
+  .spyOn(StudentService.prototype as any, "checkApplicationMilestone")
+  .mockResolvedValue(undefined);
 
 describe("StudentService.applyToExternalJob", () => {
   const service = new StudentService();
@@ -51,18 +61,18 @@ describe("StudentService.applyToExternalJob", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.prisma.$transaction.mockImplementation(async (callback) => callback(mocks.prisma));
+    mocks.prisma.$transaction.mockImplementation(async (callback) => callback(mocks.tx));
   });
 
   it("creates the application and usage log in one transaction", async () => {
     mocks.prisma.adminJob.findUnique.mockResolvedValue(activeJob);
-    mocks.prisma.externalJobApplication.create.mockResolvedValue(createdApplication);
-    mocks.prisma.usageLog.create.mockResolvedValue({ id: 401 });
+    mocks.tx.externalJobApplication.create.mockResolvedValue(createdApplication);
+    mocks.tx.usageLog.create.mockResolvedValue({ id: 401 });
 
     await expect(service.applyToExternalJob(44, 23)).resolves.toEqual(createdApplication);
 
     expect(mocks.prisma.$transaction).toHaveBeenCalledOnce();
-    expect(mocks.prisma.externalJobApplication.create).toHaveBeenCalledWith({
+    expect(mocks.tx.externalJobApplication.create).toHaveBeenCalledWith({
       data: { studentId: 44, adminJobId: 23 },
       include: {
         adminJob: {
@@ -70,17 +80,20 @@ describe("StudentService.applyToExternalJob", () => {
         },
       },
     });
-    expect(mocks.prisma.usageLog.create).toHaveBeenCalledWith({
+    expect(mocks.tx.usageLog.create).toHaveBeenCalledWith({
       data: { userId: 44, action: "JOB_APPLICATION" },
     });
+    expect(mocks.prisma.externalJobApplication.create).not.toHaveBeenCalled();
+    expect(mocks.prisma.usageLog.create).not.toHaveBeenCalled();
   });
 
   it("does not run post-commit work when usage logging fails", async () => {
     mocks.prisma.adminJob.findUnique.mockResolvedValue(activeJob);
-    mocks.prisma.externalJobApplication.create.mockResolvedValue(createdApplication);
-    mocks.prisma.usageLog.create.mockRejectedValue(new Error("Usage log unavailable"));
+    mocks.tx.externalJobApplication.create.mockResolvedValue(createdApplication);
+    mocks.tx.usageLog.create.mockRejectedValue(new Error("Usage log unavailable"));
 
     await expect(service.applyToExternalJob(44, 23)).rejects.toThrow("Usage log unavailable");
     expect(mocks.badgeService.checkAndAwardBadges).not.toHaveBeenCalled();
+    expect(checkApplicationMilestoneSpy).not.toHaveBeenCalled();
   });
 });

--- a/server/src/module/student/student.external-application.service.test.ts
+++ b/server/src/module/student/student.external-application.service.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    $transaction: vi.fn(),
+    adminJob: {
+      findUnique: vi.fn(),
+    },
+    externalJobApplication: {
+      create: vi.fn(),
+    },
+    usageLog: {
+      create: vi.fn(),
+    },
+  },
+  badgeService: {
+    checkAndAwardBadges: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("../../database/db.js", () => ({
+  prisma: mocks.prisma,
+}));
+
+vi.mock("../badge/badge.service.js", () => ({
+  BadgeService: class {
+    checkAndAwardBadges = mocks.badgeService.checkAndAwardBadges;
+  },
+}));
+
+const { StudentService } = await import("./student.service.js");
+
+vi.spyOn(StudentService.prototype as any, "checkApplicationMilestone").mockResolvedValue(undefined);
+
+describe("StudentService.applyToExternalJob", () => {
+  const service = new StudentService();
+  const activeJob = {
+    id: 23,
+    isActive: true,
+    expiresAt: new Date(Date.now() + 60_000),
+  };
+  const createdApplication = {
+    id: 301,
+    adminJob: {
+      id: 23,
+      slug: "frontend-intern",
+      company: "InternHack",
+      role: "Frontend Intern",
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.prisma.$transaction.mockImplementation(async (callback) => callback(mocks.prisma));
+  });
+
+  it("creates the application and usage log in one transaction", async () => {
+    mocks.prisma.adminJob.findUnique.mockResolvedValue(activeJob);
+    mocks.prisma.externalJobApplication.create.mockResolvedValue(createdApplication);
+    mocks.prisma.usageLog.create.mockResolvedValue({ id: 401 });
+
+    await expect(service.applyToExternalJob(44, 23)).resolves.toEqual(createdApplication);
+
+    expect(mocks.prisma.$transaction).toHaveBeenCalledOnce();
+    expect(mocks.prisma.externalJobApplication.create).toHaveBeenCalledWith({
+      data: { studentId: 44, adminJobId: 23 },
+      include: {
+        adminJob: {
+          select: { id: true, slug: true, company: true, role: true },
+        },
+      },
+    });
+    expect(mocks.prisma.usageLog.create).toHaveBeenCalledWith({
+      data: { userId: 44, action: "JOB_APPLICATION" },
+    });
+  });
+
+  it("does not run post-commit work when usage logging fails", async () => {
+    mocks.prisma.adminJob.findUnique.mockResolvedValue(activeJob);
+    mocks.prisma.externalJobApplication.create.mockResolvedValue(createdApplication);
+    mocks.prisma.usageLog.create.mockRejectedValue(new Error("Usage log unavailable"));
+
+    await expect(service.applyToExternalJob(44, 23)).rejects.toThrow("Usage log unavailable");
+    expect(mocks.badgeService.checkAndAwardBadges).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/module/student/student.routes.ts
+++ b/server/src/module/student/student.routes.ts
@@ -23,7 +23,7 @@ studentRouter.get("/applications/:applicationId/calendar.ics", (req, res) => stu
 studentRouter.delete("/applications/:applicationId", (req, res) => studentController.withdrawApplication(req, res));
 
 // External job applications
-studentRouter.post("/external-jobs/:adminJobId/apply", (req, res) => studentController.applyToExternalJob(req, res));
+studentRouter.post("/external-jobs/:adminJobId/apply", usageLimit("JOB_APPLICATION"), (req, res) => studentController.applyToExternalJob(req, res));
 studentRouter.get("/external-jobs/:adminJobId/status", (req, res) => studentController.getExternalApplicationStatus(req, res));
 studentRouter.patch("/external-applications/:applicationId/notes", (req, res) => studentController.updateExternalApplicationNotes(req, res));
 studentRouter.delete("/external-applications/:applicationId", (req, res) => studentController.deleteExternalApplication(req, res));
@@ -37,4 +37,3 @@ studentRouter.put("/applications/:applicationId/rounds/:roundId/submit", (req, r
 studentRouter.get("/mock-interview", (req, res, next) => studentController.getMockInterviewInfo(req, res, next));
 studentRouter.post("/mock-interview/book", (req, res, next) => studentController.bookMockInterview(req, res, next));
 studentRouter.post("/mock-interview/feedback", (req, res) => studentController.generateMockInterviewFeedback(req, res));
-

--- a/server/src/module/student/student.service.ts
+++ b/server/src/module/student/student.service.ts
@@ -255,14 +255,21 @@ Rules:
     if (!job.isActive || job.expiresAt < new Date()) throw new Error("This job has expired");
 
     try {
-      const application = await prisma.externalJobApplication.create({
-        data: { studentId, adminJobId },
-        include: {
-          adminJob: {
-            select: { id: true, slug: true, company: true, role: true },
+      const application = await prisma.$transaction(async (tx) => {
+        const createdApplication = await tx.externalJobApplication.create({
+          data: { studentId, adminJobId },
+          include: {
+            adminJob: {
+              select: { id: true, slug: true, company: true, role: true },
+            },
           },
-        },
+        });
+        await tx.usageLog.create({
+          data: { userId: studentId, action: "JOB_APPLICATION" },
+        });
+        return createdApplication;
       });
+
       // Check application badges (fire-and-forget)
       badgeService.checkAndAwardBadges(studentId, "first_application").catch(() => {});
       badgeService.checkAndAwardBadges(studentId, "job_apply").catch(() => {});


### PR DESCRIPTION
## Summary

- apply the existing `JOB_APPLICATION` quota middleware to external job applications
- record successful external applications in the shared usage log
- return updated usage metadata while leaving failed or duplicate attempts uncounted

Closes #858

## Validation

- `node node_modules/eslint/bin/eslint.js src --quiet`
- `git diff --check upstream/main...HEAD`

Full server typecheck currently fails on existing upstream errors in the open-source routes, student notes schema usage, and missing `pino` types. The local test command is blocked before Vitest by an incomplete Prisma install (`prisma_schema_build_bg.wasm` is missing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job application submissions now enforce usage limits.
  * Application responses include updated usage info showing quota consumption.
  * Application processing now records usage activity alongside submission.
* **Tests**
  * Added tests covering application submission, usage logging, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->