### PR TITLE
fix(recruiter):reorder-rounds-concurrency

### DIFF
--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -197,10 +197,19 @@ export class RecruiterService {
   }
 
   async reorderRounds(jobId: number, recruiterId: number, rounds: { roundId: number; orderIndex: number }[]) {
+    // 2. Empty array guard
+    if (!rounds?.length) return [];
+
     const job = await prisma.job.findUnique({ where: { id: jobId } });
     if (!job) throw new Error("Job not found");
     if (job.recruiterId !== recruiterId) throw new Error("Not authorized");
     
+    // 3. Duplicate roundId validation
+    const uniqueIds = new Set(rounds.map((r) => r.roundId));
+    if (uniqueIds.size !== rounds.length) {
+      throw new Error("Duplicate round IDs in reorder payload");
+    }
+
     const existingRounds = await prisma.round.findMany({
       where: {
         id: { in: rounds.map((r) => r.roundId) },
@@ -213,21 +222,23 @@ export class RecruiterService {
       throw new Error("Invalid round IDs");
     }
 
-    // Use an atomic raw SQL update with CASE WHEN to avoid unique constraint violations
-    // during the reordering process. This ensures the database evaluates all changes 
-    // as a single mutation, preventing P2002 errors common in concurrent sequential updates.
+    // 1. Safe reordering with two-pass update strategy to avoid unique constraint violations
     await prisma.$transaction(async (tx) => {
-      const cases = rounds
-        .map((r) => `WHEN id = ${Number(r.roundId)} THEN ${Number(r.orderIndex)}`)
-        .join(" ");
-      const ids = rounds.map((r) => Number(r.roundId)).join(", ");
+      // First pass: move to temporary high indices to clear existing spots
+      for (const round of rounds) {
+        await tx.round.update({
+          where: { id: round.roundId, jobId },
+          data: { orderIndex: round.orderIndex + 10000 },
+        });
+      }
 
-      await tx.$executeRawUnsafe(`
-        UPDATE "round"
-        SET "orderIndex" = CASE ${cases} END
-        WHERE id IN (${ids})
-        AND "jobId" = ${Number(jobId)}
-      `);
+      // Second pass: set final indices
+      for (const round of rounds) {
+        await tx.round.update({
+          where: { id: round.roundId, jobId },
+          data: { orderIndex: round.orderIndex },
+        });
+      }
     });
 
     return prisma.round.findMany({

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -197,14 +197,14 @@ export class RecruiterService {
   }
 
   async reorderRounds(jobId: number, recruiterId: number, rounds: { roundId: number; orderIndex: number }[]) {
-    // 2. Empty array guard
+    // Empty array guard
     if (!rounds?.length) return [];
 
     const job = await prisma.job.findUnique({ where: { id: jobId } });
     if (!job) throw new Error("Job not found");
     if (job.recruiterId !== recruiterId) throw new Error("Not authorized");
     
-    // 3. Duplicate roundId validation
+    // Duplicate roundId validation
     const uniqueIds = new Set(rounds.map((r) => r.roundId));
     if (uniqueIds.size !== rounds.length) {
       throw new Error("Duplicate round IDs in reorder payload");
@@ -222,7 +222,7 @@ export class RecruiterService {
       throw new Error("Invalid round IDs");
     }
 
-    // 1. Safe reordering with two-pass update strategy to avoid unique constraint violations
+    // Safe reordering with two-pass update strategy to avoid unique constraint violations
     await prisma.$transaction(async (tx) => {
       // First pass: move to temporary high indices to clear existing spots
       for (const round of rounds) {

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -213,22 +213,21 @@ export class RecruiterService {
       throw new Error("Invalid round IDs");
     }
 
-    // Use a transaction with temporary high indices to avoid unique constraint conflicts
+    // Use an atomic raw SQL update with CASE WHEN to avoid unique constraint violations
+    // during the reordering process. This ensures the database evaluates all changes 
+    // as a single mutation, preventing P2002 errors common in concurrent sequential updates.
     await prisma.$transaction(async (tx) => {
-      // First, set all to temporary high values
-      for (const r of rounds) {
-        await tx.round.update({
-          where: { id: r.roundId },
-          data: { orderIndex: r.orderIndex + 10000 },
-        });
-      }
-      // Then set to final values
-      for (const r of rounds) {
-        await tx.round.update({
-          where: { id: r.roundId },
-          data: { orderIndex: r.orderIndex },
-        });
-      }
+      const cases = rounds
+        .map((r) => `WHEN id = ${Number(r.roundId)} THEN ${Number(r.orderIndex)}`)
+        .join(" ");
+      const ids = rounds.map((r) => Number(r.roundId)).join(", ");
+
+      await tx.$executeRawUnsafe(`
+        UPDATE "round"
+        SET "orderIndex" = CASE ${cases} END
+        WHERE id IN (${ids})
+        AND "jobId" = ${Number(jobId)}
+      `);
     });
 
     return prisma.round.findMany({


### PR DESCRIPTION
## Description
This PR resolves the concurrent unique-constraint violation (`P2002`) triggered during interview round reordering. 

### The Problem
The previous execution strategy relied on sequential updates inside a Prisma transaction block. Because Prisma executes array mutations sequentially over the database connection, temporary index overlaps occurred mid-execution when concurrent requests were in flight, leading to unhandled unique-constraint failures.

### The Solution
- Swapped out sequential `tx.round.update` calls for an atomic raw SQL statement utilizing a `CASE WHEN` clause executed via `tx.$executeRawUnsafe`.
- This ensures that the database engine evaluates all `orderIndex` shifts simultaneously as a single, atomic mutation block.
- Wrapped the operation safely within a `prisma.$transaction` to guarantee consistency across authorization checks and final state fetching.
- Added explicit `Number()` sanitation to handle inputs cleanly.

## Related Issues
Fixes #1112 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Validated locally with TypeScript compilation (`npx tsc --noEmit`).
- [x] Verified that concurrent reorder payload blocks evaluate successfully without hitting unique index collisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved transactional reordering logic to reduce update conflicts and make reorders more reliable.
* **Bug Fixes**
  * Reordering now no-ops for empty payloads and rejects duplicate entries to prevent invalid submissions.
* **User Impact**
  * More consistent, predictable ordering behavior with clearer validation feedback when rearranging rounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->