### PR TITLE
[Bug Fix] : Round activation date accepts dates in the past without warning bug fix

### DIFF
--- a/server/src/module/recruiter/recruiter.validation.ts
+++ b/server/src/module/recruiter/recruiter.validation.ts
@@ -45,7 +45,14 @@ export const createRoundSchema = z.object({
   })).default([]),
   timeLimitSecs: z.number().int().positive().nullable().optional(),
   autoGrade: z.boolean().default(false),
-  activateAt: z.coerce.date().min(new Date(), { message: "Activation date must be in the future" }).nullable().optional(),
+  activateAt: z
+  .string()
+  .datetime()
+  .refine((dateString) => new Date(dateString) > new Date(), {
+    message: "Activation date must be in the future",
+  })
+  .nullable()
+  .optional(),
 });
 
 export const updateRoundSchema = z.object({
@@ -63,7 +70,14 @@ export const updateRoundSchema = z.object({
   })).optional(),
   timeLimitSecs: z.number().int().positive().nullable().optional(),
   autoGrade: z.boolean().optional(),
-  activateAt: z.coerce.date().min(new Date(), { message: "Activation date must be in the future" }).nullable().optional(),
+  activateAt: z
+  .string()
+  .datetime()
+  .refine((dateString) => new Date(dateString) > new Date(), {
+    message: "Activation date must be in the future",
+  })
+  .nullable()
+  .optional(),
 });
 
 export const reorderRoundsSchema = z.object({

--- a/server/src/module/recruiter/recruiter.validation.ts
+++ b/server/src/module/recruiter/recruiter.validation.ts
@@ -45,7 +45,7 @@ export const createRoundSchema = z.object({
   })).default([]),
   timeLimitSecs: z.number().int().positive().nullable().optional(),
   autoGrade: z.boolean().default(false),
-  activateAt: z.string().datetime().nullable().optional(),
+  activateAt: z.coerce.date().min(new Date(), { message: "Activation date must be in the future" }).nullable().optional(),
 });
 
 export const updateRoundSchema = z.object({
@@ -63,7 +63,7 @@ export const updateRoundSchema = z.object({
   })).optional(),
   timeLimitSecs: z.number().int().positive().nullable().optional(),
   autoGrade: z.boolean().optional(),
-  activateAt: z.string().datetime().nullable().optional(),
+  activateAt: z.coerce.date().min(new Date(), { message: "Activation date must be in the future" }).nullable().optional(),
 });
 
 export const reorderRoundsSchema = z.object({


### PR DESCRIPTION
# Pull Request

## Description

Fixed the "Round activation date accepts dates in the past without warning" issue by implementing expected change of z.coerce.date().min(new Date(), { message: 'Activation date must be in the future' }) in the 
File: server/src/module/recruiter/recruiter.validation.ts

## Related Issue
Fixes #1121 

## Type of Change
- [✅] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
I tested it by validating it through Postman by creating a new API request and then verifying the failure case.

## Screenshots / Video

> **REQUIRED for any UI change.** PRs that modify visible UI (layout, components, styles, pages) will be rejected without this.

<!-- Add a screenshot or screen recording below. Drag and drop images/GIFs here, or paste a video link. -->

_No UI changes in this PR_ (delete this line if you are making UI changes)

## Checklist
- [✅] Code follows project guidelines
- [✅] No new compile/type errors
- [✅] Tested manually (include steps above)
- [✅] No `.env`, credentials, or `node_modules` committed
- [✅] Docs updated (if needed)
- [ ] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for recruitment round activation dates: the system now requires activation dates to be in the future and shows a clearer error message when users enter past or invalid dates while creating or updating rounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->