### PR TITLE
[Bug Fix] : Talent search stale time too short — same filter set re-fetches data on every tab focus

### DIFF
--- a/client/src/module/recruiter/talent/TalentSearchPage.tsx
+++ b/client/src/module/recruiter/talent/TalentSearchPage.tsx
@@ -72,7 +72,7 @@ export default function TalentSearchPage() {
       const res = await api.get("/recruiter/saved-candidates/ids");
       return (res.data?.ids ?? []) as number[];
     },
-    staleTime: 1000 * 60,
+    staleTime: 1000 * 60 * 5,
   });
 
   const savedSet = useMemo(() => new Set(savedIdsData ?? []), [savedIdsData]);
@@ -95,6 +95,7 @@ export default function TalentSearchPage() {
       return res.data as TalentSearchResponse;
     },
     placeholderData: keepPreviousData,
+    staleTime: 1000 * 60 * 5,
   });
 
   const applyFilters = useCallback(() => {


### PR DESCRIPTION
# Pull Request

## Description

Fixed the issue by increasing staleTime to at least 5 minutes for talent search results

## Related Issue
Fixes #1130 

## Type of Change
- [✅] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
Tested it by searching for talent-search at filter option in network tab and then going to a different browser, then coming back again to ensure no redundant API calls have emerged.

## Screenshots / Video

> **REQUIRED for any UI change.** PRs that modify visible UI (layout, components, styles, pages) will be rejected without this.

<!-- Add a screenshot or screen recording below. Drag and drop images/GIFs here, or paste a video link. -->

_No UI changes in this PR_ (delete this line if you are making UI changes)

## Checklist
- [✅] Code follows project guidelines
- [✅] No new compile/type errors
- [✅] Tested manually (include steps above)
- [✅] No `.env`, credentials, or `node_modules` committed
- [✅] Docs updated (if needed)
- [✅] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized caching performance for talent search and candidate queries to reduce API calls and improve responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->