### PR TITLE
fix(recruiter): prevent duplicate emails on same-status update (#1111)

### DIFF
--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -276,14 +276,19 @@ export class RecruiterService {
     if (!application) throw new Error("Application not found");
     if (application.job.recruiterId !== recruiterId) throw new Error("Not authorized");
 
-    const previousStatus = application.status;
+    // FIX: Early return if the status is exactly the same
+    // This completely bypasses the DB update and prevents the duplicate email spam
+    if (application.status === status) {
+      return application;
+    }
 
     const updated = await prisma.application.update({
       where: { id: applicationId },
       data: { status },
     });
 
-    if (previousStatus !== status && isEmailableStatus(status) && application.student.email) {
+    // We no longer need `previousStatus !== status` here because the early return guarantees they are different
+    if (isEmailableStatus(status) && application.student.email) {
       const clientUrl = process.env["CLIENT_URL"] || "https://www.internhack.xyz";
       const html = applicationStatusEmailHtml({
         studentName: application.student.name,


### PR DESCRIPTION
## Description
This PR resolves the issue where duplicate email notifications were being sent to students if a recruiter updated an application to its exact current status. 

I added an early return check in the `updateApplicationStatus` method inside `RecruiterService`. If the incoming `status` matches the `application.status`, the function returns the application immediately, bypassing the unnecessary database update and preventing the redundant email from being triggered.

## Related Issue
Fixes #1111

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
1. Created/located a test application with an emailable status.
2. Triggered the `updateApplicationStatus` endpoint with the exact same status.
3. Verified via logs/email testing tools that no duplicate email was sent and the database update was safely skipped.

## Screenshots / Video

> **REQUIRED for any UI change.** PRs that modify visible UI (layout, components, styles, pages) will be rejected without this.

_No UI changes in this PR_ 

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [ ] **Screenshot or video attached for every UI change** (PR will be rejected if missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary status notification emails being sent when application status remains unchanged.
  * Improved performance by preventing redundant database operations for unchanged status requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->