### PR TITLE
fix: add deterministic ordering for top verified skills

### DIFF
--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -439,7 +439,7 @@ export class RecruiterService {
         student: { applications: { some: { job: { recruiterId } } } },
       },
       _count: { id: true },
-      orderBy: { _count: { id: "desc" } },
+      orderBy: [{ _count: { id: "desc" } }, { skillName: "asc" }],
       take: 5,
     });
 


### PR DESCRIPTION
## Summary
Fix non-deterministic ordering in recruiter dashboard top skills statistics.

## Changes
- Updated `getDashboardStats()` in `server/src/module/recruiter/recruiter.service.ts`.
- Modified the `topVerifiedSkills` aggregation sort order:
  - Primary sort: `count` descending.
  - Secondary sort: `skillName` ascending.

## Why
Previously, skills with the same count were returned in an undefined order, causing the dashboard results to change between requests. Adding a secondary alphabetical sort ensures stable and predictable ordering while preserving the ranking by count.

## Result
Skills with identical counts now appear consistently in alphabetical order across requests.
Fixed Issue : #1202 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the sorting order of verified skills displayed on the recruiter dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->