### PR TITLE
feat: show question completion count chip with green checkmark per se…

### DIFF
--- a/client/src/module/student/interview-prep/InterviewLessonsPage.tsx
+++ b/client/src/module/student/interview-prep/InterviewLessonsPage.tsx
@@ -352,8 +352,8 @@ export default function InterviewLessonsPage() {
                 )}
 
                 <div className="flex flex-wrap gap-1.5">
-                  <MetaChip>
-                    {isLocked ? `${section.total} questions` : `${section.completed} / ${section.total} done`}
+                  <MetaChip className={isComplete ? "text-green-600 dark:text-green-400 border-green-300 dark:border-green-900/60" : ""}>
+                  {isLocked ? `${section.total} questions` : (<span className="inline-flex items-center gap-1"> {isComplete && <CheckCircle2 className="w-3 h-3" />}{section.completed} / {section.total} answered</span> )}
                   </MetaChip>
                   <MetaChip className={LEVEL_STYLE[section.level]}>{section.level}</MetaChip>
                 </div>


### PR DESCRIPTION
# Pull Request

## Description
Describe your changes.
On InterviewLessonsPage, the section card chip now shows completed / total answered count (e.g. "12 / 48 answered") with a green checkmark icon when all questions in the section are completed.
## Related Issue
Fixes #471 

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
1. Run `cd server && npm run dev` and `cd client && npm run dev`
2. Log in with aarav@example.com / Test@1234
3. Navigate to /learn/interview
4. Verify each section card shows "X / Y answered" chip
5. Complete all questions in a section — verify chip turns green with ✓ icon

## Screenshots / Video
<img width="482" height="323" alt="Screenshot 2026-06-04 202959" src="https://github.com/user-attachments/assets/9bd557ff-7b3e-4c57-9d0d-3a97e4bde48a" />
<img width="502" height="317" alt="Screenshot 2026-06-04 203015" src="https://github.com/user-attachments/assets/25971c58-9274-465a-9270-05da79a7a8e5" />

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interview prep sections now display a visual indicator when complete

* **Style**
  * Enhanced progress label with icon for answered questions, improving visual clarity in the lessons interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->