### PR TITLE
fix: add aria-label to recruiter navigation for accessibility

### DIFF
--- a/client/src/module/recruiter/RecruiterLayout.tsx
+++ b/client/src/module/recruiter/RecruiterLayout.tsx
@@ -104,12 +104,10 @@ export default function RecruiterLayout() {
         title={collapsed ? item.label : undefined}
         onClick={() => setMobileOpen(false)}
         className={({ isActive }) =>
-          `relative flex items-center gap-3 rounded-md text-sm transition-colors no-underline ${
-            collapsed ? "justify-center px-2 py-2" : "px-3 py-2"
-          } ${
-            isActive
-              ? "bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 font-bold"
-              : "text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-900 hover:text-stone-900 dark:hover:text-stone-50 font-medium"
+          `relative flex items-center gap-3 rounded-md text-sm transition-colors no-underline ${collapsed ? "justify-center px-2 py-2" : "px-3 py-2"
+          } ${isActive
+            ? "bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 font-bold"
+            : "text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-900 hover:text-stone-900 dark:hover:text-stone-50 font-medium"
           }`
         }
       >
@@ -179,9 +177,8 @@ export default function RecruiterLayout() {
 
       {/* Sidebar */}
       <aside
-        className={`fixed top-0 left-0 h-screen bg-stone-50 dark:bg-stone-950 border-r border-stone-200 dark:border-white/10 flex flex-col transition-all duration-300 z-50 ${
-          collapsed ? "w-18" : "w-64"
-        } ${mobileOpen ? "translate-x-0" : "-translate-x-full"} lg:translate-x-0`}
+        className={`fixed top-0 left-0 h-screen bg-stone-50 dark:bg-stone-950 border-r border-stone-200 dark:border-white/10 flex flex-col transition-all duration-300 z-50 ${collapsed ? "w-18" : "w-64"
+          } ${mobileOpen ? "translate-x-0" : "-translate-x-full"} lg:translate-x-0`}
       >
         {/* Mobile close button */}
         <div className="flex items-center justify-end px-5 pt-4 pb-2 lg:hidden border-b border-stone-200 dark:border-white/10">
@@ -238,7 +235,10 @@ export default function RecruiterLayout() {
         )}
 
         {/* Nav groups */}
-        <nav className={`flex-1 overflow-y-auto ${collapsed ? "px-2 py-3" : "px-3 py-3"} space-y-4`}>
+        <nav
+          aria-label="Recruiter navigation"
+          className={`flex-1 overflow-y-auto ${collapsed ? "px-2 py-3" : "px-3 py-3"} space-y-4`}
+        >
           {/* Recruitment */}
           <div>
             {!collapsed ? (
@@ -302,9 +302,8 @@ export default function RecruiterLayout() {
           <button
             onClick={handleLogout}
             title={collapsed ? "Logout" : undefined}
-            className={`w-full flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-stone-600 dark:text-stone-400 hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-600 dark:hover:text-red-400 transition-colors border-0 bg-transparent cursor-pointer ${
-              collapsed ? "justify-center px-2" : ""
-            }`}
+            className={`w-full flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-stone-600 dark:text-stone-400 hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-600 dark:hover:text-red-400 transition-colors border-0 bg-transparent cursor-pointer ${collapsed ? "justify-center px-2" : ""
+              }`}
           >
             <LogOut className="w-4 h-4 shrink-0" />
             {!collapsed && <span className="truncate">Logout</span>}
@@ -314,9 +313,8 @@ export default function RecruiterLayout() {
 
       {/* Main Content */}
       <main
-        className={`pt-16 lg:pt-24 px-4 pb-8 sm:px-6 lg:px-8 transition-all duration-300 overflow-auto ${
-          collapsed ? "lg:ml-18" : "lg:ml-64"
-        }`}
+        className={`pt-16 lg:pt-24 px-4 pb-8 sm:px-6 lg:px-8 transition-all duration-300 overflow-auto ${collapsed ? "lg:ml-18" : "lg:ml-64"
+          }`}
       >
         <Suspense fallback={<RecruiterRouteLoader />}>
           <Outlet />


### PR DESCRIPTION
# Pull Request

## Description
Improves accessibility of recruiter sidebar navigation by adding an ARIA landmark label so screen readers can properly identify and jump to the navigation section.

## Related Issue
Fixes #1160

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
Verified manually in browser that:
- Sidebar navigation renders correctly
- No UI layout changes introduced
- Screen reader landmark can identify navigation region

## Screenshots / Video

_No visual UI change; only accessibility improvement._

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (verified sidebar + navigation works)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (not needed)
- [x] Screenshot or video attached for UI-related change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated recruiter navigation styling with improved code formatting across UI elements.

* **Accessibility**
  * Added aria-label to the recruiter navigation sidebar for better screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->