### PR TITLE
fix: resolve issue #1391 - Validate Rating Bounds in Interview Feedback

### DIFF
--- a/server/src/module/interview/interview.service.ts
+++ b/server/src/module/interview/interview.service.ts
@@ -134,6 +134,10 @@ export class InterviewService {
       throw new Error("Cannot add feedback to a cancelled or no-show interview");
     }
 
+    if (feedback.rating < 1 || feedback.rating > 5) {
+      throw new Error("Rating must be between 1 and 5");
+    }
+
     const existingFeedback = (interview.feedback as Record<string, unknown>[]) ?? [];
     // Replace existing feedback from same interviewer or append
     const filtered = existingFeedback.filter((f) => (f as { interviewerId?: number }).interviewerId !== feedback.interviewerId);


### PR DESCRIPTION
Closes #1391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Interview feedback ratings are now validated to ensure values fall within the 1-5 range before being saved, preventing invalid data entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->