### PR TITLE
fix: resolve issue #1403 - Validate Start and End Date Order for Hackathons

### DIFF
--- a/server/src/module/admin/admin.validation.ts
+++ b/server/src/module/admin/admin.validation.ts
@@ -268,7 +268,13 @@ export const createHackathonSchema = z.object({
   status: z.enum(["upcoming", "ongoing", "past"]).default("upcoming"),
   ecosystem: z.string().max(200),
   highlights: z.array(z.string()).default([]),
-});
+}).refine(
+  (data) => new Date(data.startDate) <= new Date(data.endDate),
+  {
+    message: "End date cannot be before start date",
+    path: ["endDate"],
+  }
+);
 
 export const updateHackathonSchema = createHackathonSchema.partial();
 

--- a/server/src/module/ats/__tests__/ats.service.test.ts
+++ b/server/src/module/ats/__tests__/ats.service.test.ts
@@ -106,11 +106,12 @@ function mockCacheMiss() {
 
 function mockValidPdf(text = VALID_RESUME_TEXT) {
   vi.mocked(PDFParse).mockImplementation(
-    () =>
-      ({
+    function () {
+      return {
         getText: vi.fn().mockResolvedValue({ text }),
         destroy: vi.fn().mockResolvedValue(undefined),
-      }) as any,
+      } as any;
+    }
   );
 }
 
@@ -183,11 +184,12 @@ describe("AtsService", () => {
       mockUserOwnsResume();
       mockCacheMiss();
       vi.mocked(PDFParse).mockImplementation(
-        () =>
-          ({
+        function () {
+          return {
             getText: vi.fn().mockResolvedValue({ text: "too short" }),
             destroy: vi.fn().mockResolvedValue(undefined),
-          }) as any,
+          } as any;
+        }
       );
 
       await expect(
@@ -466,11 +468,12 @@ describe("AtsService", () => {
     it("throws when PDF text extraction yields insufficient content", async () => {
       mockUserOwnsResume();
       vi.mocked(PDFParse).mockImplementation(
-        () =>
-          ({
+        function () {
+          return {
             getText: vi.fn().mockResolvedValue({ text: "tiny" }),
             destroy: vi.fn().mockResolvedValue(undefined),
-          }) as any,
+          } as any;
+        }
       );
 
       await expect(


### PR DESCRIPTION
Closes #1403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced hackathon creation validation to prevent end dates from being set earlier than start dates, avoiding invalid scheduling configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->