### PR TITLE
fix: reject future dates in attendance regularization (#1340)

### DIFF
--- a/server/src/module/attendance/attendance.controller.ts
+++ b/server/src/module/attendance/attendance.controller.ts
@@ -91,6 +91,11 @@ export class AttendanceController {
       const record = await this.attendanceService.regularize(result.data);
       return res.json({ message: "Attendance regularized", record });
     } catch (error) {
+      if (error instanceof Error) {
+        const msg = error.message;
+        if (msg.includes("must be after") || msg.includes("must not exceed") || msg.includes("Cannot regularize") || msg.includes("cannot be in the future"))
+          return res.status(400).json({ message: msg });
+      }
       console.error(error);
       return res.status(500).json({ message: "Internal Server Error" });
     }

--- a/server/src/module/attendance/attendance.service.ts
+++ b/server/src/module/attendance/attendance.service.ts
@@ -138,9 +138,13 @@ export class AttendanceService {
 
     const checkIn = new Date(data.checkIn);
     const checkOut = new Date(data.checkOut);
+    const now = new Date();
+    if (checkIn > now) throw new Error("Check-in time cannot be in the future");
+    if (checkOut > now) throw new Error("Check-out time cannot be in the future");
     if (checkOut <= checkIn) {
       throw new Error("Check-out time must be after check-in time");
     }
+
     const workHours = (checkOut.getTime() - checkIn.getTime()) / 3600000;
 
     return prisma.attendanceRecord.upsert({


### PR DESCRIPTION
fix: reject future dates in attendance regularization (#1340)

## Description
Rejects attendance regularization requests where date, checkIn, or checkOut are in the future.

## Changes
- Added Zod `.refine()` to `regularizeSchema`: ensures `date`, `checkIn`, and `checkOut` are not in the future
- Added runtime guard in `regularize()` service method
- Prevents scheduling regularization for dates that haven't occurred yet

## Testing
- Future date → validation error
- Future check-in time → validation error
- Future check-out time → validation error
- Past/present dates → proceeds as before

Closes #1340


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attendance regularization now rejects future dates and future check-in/check-out times, preventing future entries.
  * Validation runs earlier to catch timing issues before record persistence.
  * Error handling returns clear 400 responses for timing/validation failures instead of generic server errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->