### PR TITLE
fix: replace window.confirm with ConfirmDialog component (#997)

### DIFF
--- a/client/src/module/student/opensource/FirstPRRoadmapPage.tsx
+++ b/client/src/module/student/opensource/FirstPRRoadmapPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import { ConfirmDialog } from "../../../components/ui/ConfirmDialog";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   CheckCircle2, GitPullRequest, ArrowRight,
@@ -25,6 +26,7 @@ const STORAGE_KEY = "first-pr-roadmap-completed";
 
 // ─── Page ──────────────────────────────────────────────────────
 export default function FirstPRRoadmapPage() {
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [completed, setCompleted] = useState<Set<string>>(() => {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
@@ -153,16 +155,24 @@ export default function FirstPRRoadmapPage() {
                   Discover repos to contribute to
                 </Link>
                 <button
-                  onClick={() => {
-                    if (window.confirm("Reset all steps?")) {
-                      setCompleted(new Set());
-                      try { localStorage.removeItem(STORAGE_KEY); } catch { /**/ }
-                    }
-                  }}
+                  onClick={() => setShowResetConfirm(true)}
                   className="text-sm text-lime-700 dark:text-lime-400 border border-lime-400 px-3 py-0.5 rounded-lg font-medium"
                 >
                   Start over
                 </button>
+                <ConfirmDialog
+                  open={showResetConfirm}
+                  title="Reset all steps?"
+                  description="This will remove your progress and reset all completed steps."
+                  confirmLabel="Reset"
+                  cancelLabel="Cancel"
+                  onConfirm={() => {
+                    setCompleted(new Set());
+                    try { localStorage.removeItem(STORAGE_KEY); } catch { /**/ }
+                    setShowResetConfirm(false);
+                  }}
+                  onCancel={() => setShowResetConfirm(false)}
+                />
               </div>
             </div>
           </motion.div>


### PR DESCRIPTION
## Description\nReplaces \`window.confirm\` with the existing \`ConfirmDialog\` component for a consistent design experience when resetting the roadmap.\n\n## Changes\n- Added \`showResetConfirm\` state to control dialog visibility\n- Imported \`ConfirmDialog\` component\n- Removed native \`window.confirm\` call\n\nCloses #997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the confirmation experience when resetting roadmap progress with an improved dialog interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->