### PR TITLE
fix: show error toast when deep-link repo fails to load (#1003)

### DIFF
--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -28,6 +28,7 @@ import api from "../../../lib/axios";
 import { useCopyToClipboard } from "../../../hooks/useCopyToClipboard";
 import { queryKeys } from "../../../lib/query-keys";
 import { SEO } from "../../../components/SEO";
+import toast from "../../../components/ui/toast";
 import { canonicalUrl } from "../../../lib/seo.utils";
 import { PaginationControls } from "../../../components/ui/PaginationControls";
 import type { OpenSourceRepo, Pagination, RepoRequest } from "../../../lib/types";
@@ -206,6 +207,7 @@ export default function RepoDiscoveryPage() {
 
   useEffect(() => {
     if (deepLinkError) {
+      toast.error("Could not load the linked repository. It may not exist or has been removed.");
       setSearchParams((prev) => {
         const params = new URLSearchParams(prev);
         params.delete("repo");


### PR DESCRIPTION
## Description\nShows an error toast notification when a deep-linked repo (via \`?repo=\` param) fails to load, instead of silently clearing the param.\n\n## Changes\n- Imported \`toast\` from the UI toast component\n- Added \`toast.error()\` call when the deep-link query fails\n\nCloses #1003