### PR TITLE
fix: adjust stats grid to use responsive 2-/4-column layout (#998)

### DIFF
--- a/client/src/module/student/opensource/components/GuideListPage.tsx
+++ b/client/src/module/student/opensource/components/GuideListPage.tsx
@@ -97,7 +97,7 @@ export default function GuideListPage({
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, delay: 0.1 }}
-        className="grid grid-cols-3 gap-4 mb-8"
+        className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8"
       >
         {[
           { icon: Icon, value: totalSteps, label: "Sections", iconColor },


### PR DESCRIPTION
## Description\nFixes the stats grid in GuideListPage showing 4 stat cards in a \`grid-cols-3\` layout, causing the 4th card to wrap awkwardly on the next line.\n\n## Changes\n- Changed \`grid-cols-3\` to \`grid-cols-2 md:grid-cols-4\` so stats display in 2 columns on mobile and 4 columns on desktop\n\nCloses #998