### PR TITLE
fix(accessibility): add aria-label to applicant search input

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationsList.tsx
+++ b/client/src/module/recruiter/applications/ApplicationsList.tsx
@@ -79,9 +79,14 @@ export default function ApplicationsList() {
       <div className="flex items-center gap-3 mb-6">
         <div className="flex-1 relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-gray-500" />
-          <input type="text" value={search} onChange={(e) => setSearch(e.target.value)}
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search applicants"
             className="w-full pl-10 pr-4 py-2.5 border border-gray-300 dark:border-gray-600 rounded-xl focus:outline-none focus:ring-2 focus:ring-black/20 dark:focus:ring-white/20 text-sm dark:bg-gray-800 dark:text-white dark:placeholder-gray-500"
-            placeholder="Search by name or email..." />
+            placeholder="Search by name or email..."
+          />
         </div>
         <div className="flex items-center gap-2">
           <Filter className="w-4 h-4 text-gray-400 dark:text-gray-500" />


### PR DESCRIPTION
# Pull Request

## Description

Added an accessible label to the applicant search input in `ApplicationsList.tsx`.

The search field previously relied only on placeholder text, which is not sufficient for screen readers and does not meet WCAG 2.1 SC 1.3.1 accessibility requirements.

This fix adds `aria-label="Search applicants"` to ensure the input is properly announced by assistive technologies while preserving the existing UI and functionality.

## Related Issue

Fixes #1154

## Type of Change

* [x] Bug Fix
* [ ] Feature
* [ ] Enhancement
* [ ] Documentation

## Testing

Tested manually:

1. Opened the recruiter Applications page.
2. Verified the search input renders correctly.
3. Confirmed search functionality works as before.
4. Verified the input now contains `aria-label="Search applicants"` for accessibility support.
5. Confirmed no UI or layout changes were introduced.

## Screenshots / Video

*No UI changes in this PR*

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [ ] Docs updated (not required)
* [x] Screenshot or video attached for every UI change (Not applicable — no UI changes)
