### PR TITLE
fix(recruiter): add loading indicator to advance button in applicatio…

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationDetail.tsx
+++ b/client/src/module/recruiter/applications/ApplicationDetail.tsx
@@ -11,6 +11,7 @@ import {
   Clock,
   FileText,
   ShieldCheck,
+  Loader2,
 } from "lucide-react";
 import { motion } from "framer-motion";
 import api, { SERVER_URL } from "../../../lib/axios";
@@ -99,6 +100,7 @@ export default function ApplicationDetail() {
     null,
   );
   const [verifiedSkills, setVerifiedSkills] = useState<VerifiedSkill[]>([]);
+  const [isAdvancing, setIsAdvancing] = useState(false);
 
 const fetchDetail = useCallback(async (signal) => {
     try {
@@ -162,11 +164,14 @@ const fetchDetail = useCallback(async (signal) => {
 
   const handleAdvance = async () => {
     try {
+      setIsAdvancing(true);
       await api.patch(`/recruiter/applications/${applicationId}/advance`);
       await loadData();
       toast.success("Application advanced");
     } catch {
       toast.error("Failed to advance");
+    } finally {
+      setIsAdvancing(false);
     }
   };
 
@@ -246,9 +251,15 @@ const fetchDetail = useCallback(async (signal) => {
             </select>
             <Button
               onClick={handleAdvance}
-              className="px-4 py-1.5 bg-black dark:bg-white text-white dark:text-gray-950 text-sm font-semibold rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200"
+              disabled={isAdvancing}
+              className={`flex items-center gap-2 px-4 py-1.5 text-sm font-semibold rounded-lg transition-colors ${
+                isAdvancing 
+                  ? "bg-black/50 dark:bg-white/50 text-white dark:text-gray-950 cursor-not-allowed" 
+                  : "bg-black dark:bg-white text-white dark:text-gray-950 hover:bg-gray-800 dark:hover:bg-gray-200"
+              }`}
             >
-              Advance
+              {isAdvancing && <Loader2 className="w-4 h-4 animate-spin" />}
+              {isAdvancing ? "Advancing..." : "Advance"}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Description
Added a loading state (`isAdvancing`), disable state, and a loading spinner (using `Loader2` from `lucide-react`) to the "Advance" button in the Recruiter's application detail view. This prevents double submissions and provides immediate UI feedback while the API request is in flight. 


## Related Issue
Fixes #1132

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
- Verified that the codebase compiles with no TypeScript warnings or errors.
- Handled the Prisma Client generation locally to align with updated schema attributes.

## Screenshots / Video


https://github.com/user-attachments/assets/b3041d03-0be5-4dca-86e3-feef9bae66e9


## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Advance" action now disables the button, displays a spinner with "Advancing...", updates styling while processing, and refreshes application details on success.
  * Success notification shown after a successful advance.

* **Bug Fixes**
  * Error notification shown if advance fails; UI state is reliably reset after the attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->