### PR TITLE
Fix: do not issue JWT before email verification on register

### DIFF
--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -25,8 +25,7 @@ export class AuthController {
       }
 
       const data = await this.authService.register(result.data);
-      setTokenCookie(res, data.token);
-      return res.status(201).json({ message: "Registration successful", ...data });
+      return res.status(201).json({ message: "Registration successful. Please verify your email.", ...data });
     } catch (error) {
       if (error instanceof Error && error.message === "Email already registered") {
         return res.status(409).json({ message: error.message });

--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -180,9 +180,7 @@ export class AuthService {
       html: otpEmailHtml(user.name, otp),
     }).catch((err) => console.error("Failed to send OTP email:", err));
 
-    const token = generateToken({ id: user.id, email: user.email, role: user.role, tokenVersion: 0 });
-
-    return { user: { ...user, profileSlug: slug }, token };
+    return { user: { ...user, profileSlug: slug } };
   }
 
   async googleAuth(data: GoogleAuthInput) {


### PR DESCRIPTION
## What
Registration endpoint issues a JWT token before email verification, allowing unverified users to access authenticated endpoints.

## Root cause
`auth.service.ts::register()` generates and returns a JWT immediately after user creation, before the user has verified their email via OTP.

## Changes
- [server/src/module/auth/auth.service.ts] — Remove token generation from register; only return user data
- [server/src/module/auth/auth.controller.ts] — Remove setTokenCookie call after registration; update success message to prompt email verification

## Verification
- [ ] Bug reproduced before fix
- [ ] Fix verified locally
- [ ] No unrelated files changed
- [ ] Tests pass (if applicable)
- [ ] Screenshots attached (if UI changed)

## CI failures (if any)
[pre-existing CI infrastructure not set up in the clone]

## Before / After
N/A — backend logic only

Closes #1326


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated registration flow to require email verification before authentication tokens are issued
  * Registration success message now instructs users to confirm their email address
  * Authentication tokens no longer issued immediately upon registration; email verification is now a prerequisite for obtaining credentials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->