### PR TITLE
feat: improve recently viewed repo history

### DIFF
--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect } from "react";
+import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { Link, useSearchParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { motion, AnimatePresence } from "framer-motion";
@@ -199,7 +199,13 @@ export default function RepoDiscoveryPage() {
     return Array.from(langs);
   }, [user]);
 
-  const { recentlyViewed, addRepo } = useRecentlyViewedRepos();
+  const handleRecentlyViewedOverflow = useCallback(() => {
+    toast.success("Oldest repo removed from recently viewed");
+  }, []);
+
+  const { recentlyViewed, addRepo, clearHistory } = useRecentlyViewedRepos({
+    onRepoRemoved: handleRecentlyViewedOverflow,
+  });
 
   const handleOpenRepo = (repo: OpenSourceRepo) => {
     addRepo(repo);
@@ -634,7 +640,7 @@ export default function RepoDiscoveryPage() {
         <GuidanceCards />
 
         {/* Recently viewed & recommended */}
-        <RecentlyViewedSection repos={recentlyViewed} onSelect={handleOpenRepo} />
+        <RecentlyViewedSection repos={recentlyViewed} onSelect={handleOpenRepo} onClear={clearHistory} />
 
         {user?.role === "STUDENT" && (
           <RecommendedSection onSelect={handleOpenRepo} />

--- a/client/src/module/student/opensource/_shared/RecentlyViewedSection.tsx
+++ b/client/src/module/student/opensource/_shared/RecentlyViewedSection.tsx
@@ -3,41 +3,63 @@ import type { OpenSourceRepo } from "../../../../lib/types";
 interface RecentlyViewedSectionProps {
   repos: OpenSourceRepo[];
   onSelect: (repo: OpenSourceRepo) => void;
+  onClear: () => void;
 }
 
-export function RecentlyViewedSection({ repos, onSelect }: RecentlyViewedSectionProps) {
-  if (repos.length === 0) {
-    return null;
-  }
+export function RecentlyViewedSection({ repos, onSelect, onClear }: RecentlyViewedSectionProps) {
+  const hasRepos = repos.length > 0;
 
   return (
     <div className="mb-6">
-      <div className="flex items-center gap-1.5 mb-2">
-        <div className="h-1 w-1 bg-lime-400"></div>
-        <h2 className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
-          Recently Viewed
-        </h2>
-      </div>
-      <div className="relative">
-        <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-thin scrollbar-thumb-stone-300 dark:scrollbar-thumb-stone-700 scrollbar-track-transparent">
-          {repos.map((repo) => (
-            <button
-              key={repo.id}
-              type="button"
-              onClick={() => onSelect(repo)}
-              className="flex-shrink-0 w-48 text-left p-3 rounded-md bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25 transition-colors"
-            >
-              <p className="text-xs font-bold text-stone-800 dark:text-stone-200 truncate">
-                {repo.owner}/{repo.name}
-              </p>
-              <p className="text-[11px] text-stone-500 dark:text-stone-400 mt-0.5 truncate">
-                {repo.description}
-              </p>
-            </button>
-          ))}
+      <div className="flex items-center justify-between gap-3 mb-2">
+        <div className="flex items-center gap-1.5">
+          <div className="h-1 w-1 bg-lime-400"></div>
+          <h2 className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+            Recently Viewed ({repos.length})
+          </h2>
         </div>
-        <div className="absolute right-0 top-0 bottom-2 w-8 bg-gradient-to-l from-stone-50 dark:from-stone-950 to-transparent pointer-events-none" />
+        {hasRepos ? (
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-[11px] font-medium text-stone-500 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-100 transition-colors"
+          >
+            Clear history
+          </button>
+        ) : null}
       </div>
+
+      {hasRepos ? (
+        <div className="relative">
+          <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-thin scrollbar-thumb-stone-300 dark:scrollbar-thumb-stone-700 scrollbar-track-transparent">
+            {repos.map((repo) => (
+              <button
+                key={repo.id}
+                type="button"
+                onClick={() => onSelect(repo)}
+                className="flex-shrink-0 w-48 text-left p-3 rounded-md bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25 transition-colors"
+              >
+                <p className="text-xs font-bold text-stone-800 dark:text-stone-200 truncate">
+                  {repo.owner}/{repo.name}
+                </p>
+                <p className="text-[11px] text-stone-500 dark:text-stone-400 mt-0.5 truncate">
+                  {repo.description}
+                </p>
+              </button>
+            ))}
+          </div>
+          <div className="absolute right-0 top-0 bottom-2 w-8 bg-gradient-to-l from-stone-50 dark:from-stone-950 to-transparent pointer-events-none" />
+        </div>
+      ) : (
+        <div className="rounded-md border border-dashed border-stone-200 dark:border-white/10 bg-white/60 dark:bg-stone-900/50 px-4 py-3">
+          <p className="text-sm font-medium text-stone-700 dark:text-stone-200">
+            No repos viewed yet.
+          </p>
+          <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            Repos you open will appear here
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/module/student/opensource/useRecentlyViewedRepos.ts
+++ b/client/src/module/student/opensource/useRecentlyViewedRepos.ts
@@ -2,9 +2,14 @@ import { useState, useCallback } from "react";
 import type { OpenSourceRepo } from "../../../lib/types";
 
 const STORAGE_KEY = "oss_recently_viewed";
-const MAX_RECENTLY_VIEWED = 5;
+const MAX_RECENTLY_VIEWED = 10;
 
-export function useRecentlyViewedRepos() {
+interface UseRecentlyViewedReposOptions {
+  onRepoRemoved?: (repo: OpenSourceRepo) => void;
+}
+
+export function useRecentlyViewedRepos(options: UseRecentlyViewedReposOptions = {}) {
+  const { onRepoRemoved } = options;
   const [recentlyViewed, setRecentlyViewed] = useState<OpenSourceRepo[]>(() => {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
@@ -16,15 +21,29 @@ export function useRecentlyViewedRepos() {
 
   const addRepo = useCallback((repo: OpenSourceRepo) => {
     setRecentlyViewed((prev) => {
-      const newRecentlyViewed = [repo, ...prev.filter((r) => r.id !== repo.id)].slice(0, MAX_RECENTLY_VIEWED);
+      const dedupedRepos = [repo, ...prev.filter((r) => r.id !== repo.id)];
+      const removedRepo = dedupedRepos[MAX_RECENTLY_VIEWED];
+      const newRecentlyViewed = dedupedRepos.slice(0, MAX_RECENTLY_VIEWED);
       try {
         localStorage.setItem(STORAGE_KEY, JSON.stringify(newRecentlyViewed));
       } catch (error) {
         console.error("Failed to save recently viewed repos to localStorage", error);
       }
+      if (removedRepo) {
+        onRepoRemoved?.(removedRepo);
+      }
       return newRecentlyViewed;
     });
+  }, [onRepoRemoved]);
+
+  const clearHistory = useCallback(() => {
+    setRecentlyViewed([]);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      console.error("Failed to clear recently viewed repos from localStorage", error);
+    }
   }, []);
 
-  return { recentlyViewed, addRepo };
+  return { recentlyViewed, addRepo, clearHistory };
 }


### PR DESCRIPTION
## What
Adds a visible Recently Viewed count placeholder, clear history action, larger history limit, and overflow feedback in repo discovery.

## Root cause
The recently viewed section was hidden before first use and silently discarded older repos once the small history limit was exceeded.

## Changes
- client/src/module/student/opensource/useRecentlyViewedRepos.ts — increased the max history size to 10, trims stored history, clears localStorage history, and reports overflow removals.
- client/src/module/student/opensource/_shared/RecentlyViewedSection.tsx — shows the Recently Viewed count, empty helper text, clear history link, and existing repo shortcuts.
- client/src/module/student/opensource/RepoDiscoveryPage.tsx — wires the clear action and overflow toast into repo discovery.

## Verification
- [x] Confirmed feature missing before starting
- [x] Feature verified locally
- [x] git diff upstream/main...HEAD --stat shows only intended files
- [x] No console.logs or debug logs remaining
- [ ] Tests pass if applicable
- [ ] Screenshots attached if UI changed

## CI failures (if any)
Client lint passes. Client typecheck currently fails on pre-existing unrelated TypeScript errors in ConfirmDialog, recruiter applications, interview questions, company detail, FirstPRRoadmapPage, and RoadmapCanvasPage.

## Before / After
Not attached.

Closes #1021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Clear history" button to manage recently viewed repositories
  * Display count of recently viewed repos in header
  * Show placeholder message when no repos have been viewed yet
  * Limit recently viewed history to 10 most recent items
<!-- end of auto-generated comment: release notes by coderabbit.ai -->