### PR TITLE
fix: accept assessment answer maps in round submissions

### DIFF
--- a/server/src/module/student/student.validation.test.ts
+++ b/server/src/module/student/student.validation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { submitRoundSchema } from "./student.validation.js";
+
+describe("student.validation", () => {
+  describe("submitRoundSchema", () => {
+    it("accepts assessment answer maps inside fieldAnswers", () => {
+      const result = submitRoundSchema.safeParse({
+        fieldAnswers: {
+          assessmentAnswers: {
+            "0": 1,
+            "1": 2,
+          },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.fieldAnswers.assessmentAnswers).toEqual({
+          "0": 1,
+          "1": 2,
+        });
+      }
+    });
+
+    it("continues to accept existing primitive field answer values", () => {
+      const result = submitRoundSchema.safeParse({
+        fieldAnswers: {
+          portfolio: "https://example.com",
+          yearsExperience: 2,
+          willingToRelocate: true,
+          skills: ["TypeScript", "Node.js"],
+        },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects nested answer maps with non-numeric assessment values", () => {
+      const result = submitRoundSchema.safeParse({
+        fieldAnswers: {
+          assessmentAnswers: {
+            "0": "first-option",
+          },
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0]?.path).toEqual(["fieldAnswers", "assessmentAnswers"]);
+    });
+  });
+});

--- a/server/src/module/student/student.validation.ts
+++ b/server/src/module/student/student.validation.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 
+const fieldAnswerValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.string()),
+  z.record(z.string(), z.number()),
+]);
+
 export const applyToJobSchema = z.object({
   customFieldAnswers: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.array(z.string())])).default({}),
   resumeUrl: z.string().optional(),
@@ -7,7 +15,7 @@ export const applyToJobSchema = z.object({
 });
 
 export const submitRoundSchema = z.object({
-  fieldAnswers: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.array(z.string())])).default({}),
+  fieldAnswers: z.record(z.string(), fieldAnswerValueSchema).default({}),
   attachments: z.array(z.string()).default([]),
 });
 


### PR DESCRIPTION
## What
Fixes the round-submission validation contract for assessment rounds.

The frontend sends assessment answers as a nested map under fieldAnswers.assessmentAnswers, and the service already reads that value as Record<string, number>. The Zod schema only allowed primitive/string-array values, so valid assessment submissions could fail before reaching the service.

## Root Cause
submitRoundSchema allowed fieldAnswers values to be string, number, boolean, or string[], but assessmentAnswers is an object mapping question IDs to numeric selected-answer indexes.

## Changes
- Adds a shared field answer value schema for submitRoundSchema.
- Allows constrained nested Record<string, number> values for assessment answer maps.
- Keeps existing primitive and string-array field answer support unchanged.
- Adds regression tests for accepted assessment answer maps, existing primitive values, and rejected non-numeric nested values.

## Validation
- npm test -- student.validation.test.ts
- npm run lint -- --quiet src/module/student/student.validation.ts src/module/student/student.validation.test.ts
- npm run typecheck
- git diff --check

Closes #1295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded student field answer validation to accept numeric assessment maps alongside existing value types (string, number, boolean, array).

* **Tests**
  * Added comprehensive test coverage for field answer validation, verifying support for numeric assessments and proper error handling for invalid formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->