### PR TITLE
feat: add OSS resume section generator

### DIFF
--- a/client/src/module/student/ats/ResumeBuilderPage.tsx
+++ b/client/src/module/student/ats/ResumeBuilderPage.tsx
@@ -20,6 +20,7 @@ import {
   CheckCircle,
   UserPlus,
   GripVertical,
+  GitPullRequest,
 } from "lucide-react";
 import { DndContext, closestCenter, type DragEndEvent } from "@dnd-kit/core";
 import {
@@ -32,6 +33,7 @@ import { CSS } from "@dnd-kit/utilities";
 import toast from "@/components/ui/toast";
 import { SEO } from "../../../components/SEO";
 import { useAuthStore } from "../../../lib/auth.store";
+import api from "../../../lib/axios";
 import type {
   ResumeData,
   TemplateId,
@@ -87,6 +89,14 @@ const REORDERABLE_SECTIONS = [
   "certifications",
 ] as const;
 const ORDER_STORAGE_KEY = "internhack-resume-section-order";
+
+type OssSectionResponse = {
+  title: string;
+  bullets: string[];
+  rawActivity: {
+    approvedRepos: Array<{ techStack?: string[] }>;
+  };
+};
 
 // ── Drag & Drop Wrapper ───────────────────────────────────────
 function SortableFormSection({
@@ -442,6 +452,9 @@ export default function ResumeBuilderPage() {
   };
   const [mobileView, setMobileView] = useState<"form" | "preview">("form");
   const [skillInput, setSkillInput] = useState("");
+  const [ossLoading, setOssLoading] = useState(false);
+  const [ossDraft, setOssDraft] = useState("");
+  const [ossTechStack, setOssTechStack] = useState<string[]>([]);
   const debouncedData = useDebounce(data, 300);
   const debouncedSectionOrder = useDebounce(sectionOrder, 300);
   const printRef = useRef<HTMLDivElement>(null);
@@ -601,6 +614,54 @@ export default function ResumeBuilderPage() {
     })), []);
   const removeProject = useCallback((id: string) =>
     setData((d) => ({ ...d, projects: d.projects.filter((p) => p.id !== id) })), []);
+
+  const generateOssSection = useCallback(async () => {
+    setOssLoading(true);
+    try {
+      const { data: section } = await api.get<OssSectionResponse>("/resume/oss-section");
+      const draft = section.bullets.map((bullet) => `- ${bullet.replace(/^[-*]\s*/, "")}`).join("\n");
+      const stack = [
+        ...new Set(
+          section.rawActivity.approvedRepos.flatMap((repo) => repo.techStack ?? []).filter(Boolean)
+        ),
+      ];
+      setOssDraft(draft);
+      setOssTechStack(stack);
+      setOpenSections((current) => ({ ...current, projects: true }));
+      toast.success("OSS section draft generated. Review it before inserting.");
+    } catch {
+      toast.error("Could not generate your OSS section. Try again in a moment.");
+    } finally {
+      setOssLoading(false);
+    }
+  }, []);
+
+  const insertOssSection = useCallback(() => {
+    const cleanedDraft = ossDraft
+      .split("\n")
+      .map((line) => line.trim().replace(/^[-*]\s*/, ""))
+      .filter(Boolean)
+      .map((line) => `- ${line}`)
+      .join("\n");
+
+    if (!cleanedDraft) {
+      toast.error("Add at least one OSS bullet before inserting.");
+      return;
+    }
+
+    const project: Project = {
+      id: uid(),
+      name: "Open Source Contributions",
+      description: cleanedDraft,
+      techStack: (ossTechStack.length > 0 ? ossTechStack : ["Open Source", "Git", "GitHub"]).join(", "),
+      link: user?.githubUrl ?? "",
+    };
+
+    setData((current) => ({ ...current, projects: [project, ...current.projects] }));
+    setOssDraft("");
+    setOssTechStack([]);
+    toast.success("OSS section inserted into your projects.");
+  }, [ossDraft, ossTechStack, user?.githubUrl]);
 
   const addCertification = useCallback(() =>
     setData((d) => ({
@@ -966,6 +1027,54 @@ export default function ResumeBuilderPage() {
                             onToggle={() => toggle("projects")}
                             delay={delay}
                           >
+                            <div className="mb-4 rounded-md border border-lime-200 dark:border-lime-400/20 bg-lime-50/70 dark:bg-lime-400/5 p-3">
+                              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                                <div>
+                                  <p className="text-xs font-bold text-stone-900 dark:text-stone-50">
+                                    Open Source Contributions
+                                  </p>
+                                  <p className="text-xs text-stone-500 dark:text-stone-400 mt-0.5">
+                                    Generate bullets from approved repo requests, guide progress, and badges.
+                                  </p>
+                                </div>
+                                <button
+                                  type="button"
+                                  onClick={generateOssSection}
+                                  disabled={ossLoading}
+                                  className="inline-flex items-center justify-center gap-2 px-3 py-2 rounded-md text-xs font-bold text-stone-950 bg-lime-400 hover:bg-lime-300 disabled:opacity-60 disabled:cursor-not-allowed transition-colors border-0 cursor-pointer"
+                                >
+                                  <GitPullRequest className="w-3.5 h-3.5" />
+                                  {ossLoading ? "Generating..." : "Insert OSS Section"}
+                                </button>
+                              </div>
+                              {ossDraft && (
+                                <div className="mt-3 space-y-3">
+                                  <textarea
+                                    value={ossDraft}
+                                    onChange={(event) => setOssDraft(event.target.value)}
+                                    rows={5}
+                                    className={`${inputCls} font-mono leading-relaxed`}
+                                  />
+                                  <div className="flex flex-wrap gap-2">
+                                    <button
+                                      type="button"
+                                      onClick={insertOssSection}
+                                      className="inline-flex items-center justify-center gap-2 px-3 py-2 rounded-md text-xs font-bold text-white bg-stone-900 hover:bg-stone-800 dark:bg-stone-100 dark:text-stone-950 dark:hover:bg-white transition-colors border-0 cursor-pointer"
+                                    >
+                                      <Plus className="w-3.5 h-3.5" />
+                                      Insert section
+                                    </button>
+                                    <button
+                                      type="button"
+                                      onClick={() => setOssDraft("")}
+                                      className="inline-flex items-center justify-center gap-2 px-3 py-2 rounded-md text-xs font-bold text-stone-600 dark:text-stone-300 border border-stone-200 dark:border-white/10 hover:bg-white dark:hover:bg-stone-950 transition-colors bg-transparent cursor-pointer"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </div>
+                                </div>
+                              )}
+                            </div>
                             <AnimatePresence>
                               {data.projects.map((proj) => (
                                 <ProjectRow key={proj.id} proj={proj} onUpdate={updateProject} onRemove={removeProject} />

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -17,6 +17,7 @@ import { scraperRouter, scraperController } from "./module/scraper/scraper.route
 import { signalsRouter, signalsController } from "./module/signals/signals.routes.js";
 import { interviewExperienceRouter } from "./module/interview-experience/interview-experience.routes.js";
 import { atsRouter } from "./module/ats/ats.routes.js";
+import { resumeRouter } from "./module/resume/resume.routes.js";
 import { companyRouter } from "./module/company/company.routes.js";
 import { adminRouter } from "./module/admin/admin.routes.js";
 import { AdminService } from "./module/admin/admin.service.js";
@@ -240,6 +241,7 @@ app.use("/api/scraped-jobs", scraperRouter);
 app.use("/api/signals", signalsRouter);
 app.use("/api/interviews", interviewExperienceRouter);
 app.use("/api/ats", atsRouter);
+app.use("/api/resume", resumeRouter);
 app.use("/api/companies", companyRouter);
 app.use("/api/admin", adminRouter);
 app.use("/api/newsletter", newsletterRouter);

--- a/server/src/module/resume/resume.controller.ts
+++ b/server/src/module/resume/resume.controller.ts
@@ -1,0 +1,20 @@
+import type { NextFunction, Request, Response } from "express";
+import type { ResumeService } from "./resume.service.js";
+
+export class ResumeController {
+  constructor(private readonly resumeService: ResumeService) {}
+
+  async getOssSection(req: Request, res: Response, next: NextFunction) {
+    try {
+      if (!req.user) {
+        res.status(401).json({ message: "Authentication required" });
+        return;
+      }
+
+      const section = await this.resumeService.buildOssSection(req.user.id);
+      res.json(section);
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/server/src/module/resume/resume.routes.ts
+++ b/server/src/module/resume/resume.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { authMiddleware } from "../../middleware/auth.middleware.js";
+import { requireRole } from "../../middleware/role.middleware.js";
+import { ResumeController } from "./resume.controller.js";
+import { ResumeService } from "./resume.service.js";
+
+export const resumeRouter = Router();
+
+const resumeController = new ResumeController(new ResumeService());
+
+resumeRouter.use(authMiddleware, requireRole("STUDENT"));
+resumeRouter.get("/oss-section", (req, res, next) => resumeController.getOssSection(req, res, next));

--- a/server/src/module/resume/resume.service.ts
+++ b/server/src/module/resume/resume.service.ts
@@ -1,0 +1,204 @@
+import { prisma } from "../../database/db.js";
+import { getProviderForService } from "../../lib/ai-provider-registry.js";
+import { logAIRequest } from "../../lib/ai-request-logger.js";
+
+type RepoSummary = {
+  name: string;
+  owner: string;
+  language: string;
+  domain: string;
+  difficulty: string;
+  url: string;
+  reason: string;
+  techStack: string[];
+};
+
+type CertificateSummary = {
+  name: string;
+  category: string;
+  earnedAt: Date;
+};
+
+type RepoRequestRecord = Omit<RepoSummary, "domain" | "difficulty"> & {
+  domain: unknown;
+  difficulty: unknown;
+};
+
+type StudentBadgeRecord = {
+  earnedAt: Date;
+  badge: {
+    name: string;
+    category: unknown;
+  };
+};
+
+type OssSectionResult = {
+  title: string;
+  bullets: string[];
+  rawActivity: {
+    approvedRepos: RepoSummary[];
+    completedGuides: Array<{ name: string; completedSteps: number; totalSteps: number }>;
+    certificates: CertificateSummary[];
+  };
+};
+
+const FIRST_PR_TOTAL_STEPS = 7;
+const MAX_BULLETS = 5;
+
+export class ResumeService {
+  async buildOssSection(userId: number): Promise<OssSectionResult> {
+    const [user, approvedRequests, firstPrProgress, badges] = await Promise.all([
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: { name: true, skills: true, githubUrl: true },
+      }),
+      prisma.repoRequest.findMany({
+        where: { userId, status: "APPROVED" },
+        orderBy: { updatedAt: "desc" },
+        take: 6,
+        select: {
+          name: true,
+          owner: true,
+          language: true,
+          domain: true,
+          difficulty: true,
+          url: true,
+          reason: true,
+          techStack: true,
+        },
+      }),
+      prisma.studentFirstPrProgress.findUnique({
+        where: { userId },
+        select: { completedStepIds: true },
+      }),
+      prisma.studentBadge.findMany({
+        where: { studentId: userId },
+        orderBy: { earnedAt: "desc" },
+        take: 5,
+        select: {
+          earnedAt: true,
+          badge: {
+            select: {
+              name: true,
+              category: true,
+            },
+          },
+        },
+      }),
+    ]);
+
+    const repos: RepoSummary[] = (approvedRequests as RepoRequestRecord[]).map((repo) => ({
+      ...repo,
+      domain: String(repo.domain),
+      difficulty: String(repo.difficulty),
+    }));
+    const completedStepCount = firstPrProgress?.completedStepIds.length ?? 0;
+    const completedGuides =
+      completedStepCount > 0
+        ? [{ name: "First PR Guide", completedSteps: completedStepCount, totalSteps: FIRST_PR_TOTAL_STEPS }]
+        : [];
+    const certificates: CertificateSummary[] = (badges as StudentBadgeRecord[]).map((item) => ({
+      name: item.badge.name,
+      category: String(item.badge.category),
+      earnedAt: item.earnedAt,
+    }));
+
+    const fallbackBullets = this.buildFallbackBullets(repos, completedGuides, certificates, user?.skills ?? []);
+    const polishedBullets = await this.polishBullets({
+      userName: user?.name ?? "Student",
+      githubUrl: user?.githubUrl ?? null,
+      repos,
+      completedGuides,
+      certificates,
+      fallbackBullets,
+    });
+
+    return {
+      title: "Open Source Contributions",
+      bullets: polishedBullets.length > 0 ? polishedBullets : fallbackBullets,
+      rawActivity: {
+        approvedRepos: repos,
+        completedGuides,
+        certificates,
+      },
+    };
+  }
+
+  private buildFallbackBullets(
+    repos: RepoSummary[],
+    completedGuides: Array<{ name: string; completedSteps: number; totalSteps: number }>,
+    certificates: CertificateSummary[],
+    skills: string[]
+  ): string[] {
+    const bullets: string[] = [];
+    const primaryRepos = repos.slice(0, 3).map((repo) => `${repo.owner}/${repo.name}`);
+    const languages = [...new Set(repos.map((repo) => repo.language).filter(Boolean))].slice(0, 4);
+    const techStack = [...new Set(repos.flatMap((repo) => repo.techStack).concat(skills))].slice(0, 5);
+
+    if (primaryRepos.length > 0) {
+      bullets.push(
+        `Identified and proposed ${String(repos.length)} open-source repos including ${primaryRepos.join(", ")} for contribution readiness and issue discovery.`
+      );
+    } else {
+      bullets.push("Built open-source contribution readiness through InternHack guide work, GitHub workflows, and structured project discovery.");
+    }
+
+    if (languages.length > 0 || techStack.length > 0) {
+      bullets.push(
+        `Mapped contribution opportunities across ${languages.join(", ") || "multiple stacks"} using ${techStack.join(", ") || "Git, GitHub, and code review workflows"}.`
+      );
+    }
+
+    if (completedGuides.length > 0) {
+      const guide = completedGuides[0];
+      bullets.push(
+        `Completed ${String(guide.completedSteps)} of ${String(guide.totalSteps)} ${guide.name} steps, practicing repository setup, issue selection, commits, and pull request hygiene.`
+      );
+    }
+
+    if (certificates.length > 0) {
+      bullets.push(`Earned ${String(certificates.length)} InternHack badge${certificates.length === 1 ? "" : "s"} including ${certificates.map((badge) => badge.name).slice(0, 3).join(", ")}.`);
+    }
+
+    return bullets.slice(0, MAX_BULLETS);
+  }
+
+  private async polishBullets(input: {
+    userName: string;
+    githubUrl: string | null;
+    repos: RepoSummary[];
+    completedGuides: Array<{ name: string; completedSteps: number; totalSteps: number }>;
+    certificates: CertificateSummary[];
+    fallbackBullets: string[];
+  }): Promise<string[]> {
+    try {
+      const provider = getProviderForService("RESUME_GEN");
+      const prompt = `You are an expert technical resume writer.
+
+Create 3-5 concise resume bullets for an "Open Source Contributions" section.
+Use a STAR-style framing where possible, but do not invent pull requests, merged code, metrics, employers, or outcomes not present here.
+Keep each bullet under 28 words, start with an action verb, and return only bullet lines.
+
+Candidate: ${input.userName}
+GitHub: ${input.githubUrl ?? "Not provided"}
+Approved repository suggestions: ${JSON.stringify(input.repos)}
+Guide progress: ${JSON.stringify(input.completedGuides)}
+Badges/certificates: ${JSON.stringify(input.certificates)}
+Draft bullets to refine: ${JSON.stringify(input.fallbackBullets)}`;
+
+      const response = await provider.generateText(prompt);
+      logAIRequest("RESUME_GEN", response, true, undefined, undefined);
+      return this.parseBulletLines(response.text);
+    } catch {
+      return [];
+    }
+  }
+
+  private parseBulletLines(text: string): string[] {
+    return text
+      .split("\n")
+      .map((line) => line.trim().replace(/^[-*\d.)\s]+/, "").trim())
+      .filter(Boolean)
+      .slice(0, MAX_BULLETS);
+  }
+}


### PR DESCRIPTION
## What
Adds an OSS resume section generator that turns approved open-source activity into editable resume bullets.

## Root cause
The resume builder did not have a way to compile InternHack OSS activity into a polished resume-ready section.

## Changes
- client/src/module/student/ats/ResumeBuilderPage.tsx — added an editable OSS section draft panel and insertion flow in Projects.
- server/src/index.ts — mounted the new resume API router at `/api/resume`.
- server/src/module/resume/resume.controller.ts — added the student OSS section controller action.
- server/src/module/resume/resume.routes.ts — added the protected `GET /oss-section` route.
- server/src/module/resume/resume.service.ts — compiled approved repo requests, First PR guide progress, and badges into Gemini-polished STAR-style bullets with fallback bullets.

## Verification
- [x] Confirmed feature missing before starting
- [x] Feature verified locally
- [x] git diff upstream/main...HEAD --stat shows only intended files
- [x] No console.logs or debug logs remaining
- [x] Tests pass if applicable
- [ ] Screenshots attached if UI changed

## CI failures (if any)
Client typecheck has pre-existing unrelated failures in `ConfirmDialog.tsx`, recruiter application files, interview questions, company detail edit modal state, `FirstPRRoadmapPage.tsx`, and `RoadmapCanvasPage.tsx`. Server typecheck is blocked by missing generated Prisma exports plus existing repo-wide strict typing issues; filtered output shows no `module/resume` errors.

## Before / After
UI changed in the resume builder Projects section; no screenshot captured in this environment.

Closes #954