### PR TITLE
fix: return x-request-id in response headers for client-side tracing …

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -186,8 +186,10 @@ app.use(cookieParser());
 app.use("/uploads", express.static(path.join(__dirname, "../uploads"), { dotfiles: "deny", index: false }));
 
 // ── Request ID tracing ──
-app.use((req, _res, next) => {
-  req.headers["x-request-id"] ??= crypto.randomUUID();
+app.use((req, res, next) => {
+  const requestId = req.headers["x-request-id"] ?? crypto.randomUUID();
+  req.headers["x-request-id"] = requestId;
+  res.setHeader("x-request-id", requestId);
   next();
 });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -158,6 +158,10 @@ app.use((req, res, next) => {
     res.setHeader("Access-Control-Allow-Credentials", "true");
     res.setHeader("Vary", "Origin");
   }
+  
+  // Expose headers to the browser client
+  res.setHeader("Access-Control-Expose-Headers", "x-request-id");
+
   if (req.method === "OPTIONS") {
     res.setHeader("Access-Control-Allow-Methods", "GET,HEAD,PUT,PATCH,POST,DELETE");
     res.setHeader("Access-Control-Allow-Headers", "Content-Type,Authorization,X-API-Key");


### PR DESCRIPTION
Closes #1441

## Changes
- Updated request-ID tracing middleware in `server/src/index.ts`
- The generated `x-request-id` is now returned in **response headers** via `res.setHeader("x-request-id", requestId)`
- Extracted the ID into a `const` for clarity instead of using `??=` inline mutation

## Why
The trace ID was only stored server-side on `req.headers`. Clients never received it in the response, making it impossible to reference a specific request when reporting errors to support.

Contributing under GSSoC'26 🎯


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request ID tracing now guarantees an x-request-id for every request (generating one when missing) and includes it in responses for reliable end-to-end tracing.
  * x-request-id is now exposed to browser clients so client-side tools can read and correlate request IDs for improved debugging and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->