### PR TITLE
fix: do not issue JWT before email verification on register

### DIFF
--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -25,8 +25,7 @@ export class AuthController {
       }
 
       const data = await this.authService.register(result.data);
-      setTokenCookie(res, data.token);
-      return res.status(201).json({ message: "Registration successful", ...data });
+      return res.status(201).json({ message: "Registration successful. Please verify your email to continue.", user: data.user });
     } catch (error) {
       if (error instanceof Error && error.message === "Email already registered") {
         return res.status(409).json({ message: error.message });

--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -180,9 +180,7 @@ export class AuthService {
       html: otpEmailHtml(user.name, otp),
     }).catch((err) => console.error("Failed to send OTP email:", err));
 
-    const token = generateToken({ id: user.id, email: user.email, role: user.role, tokenVersion: 0 });
-
-    return { user: { ...user, profileSlug: slug }, token };
+    return { user: { ...user, profileSlug: slug } };
   }
 
   async googleAuth(data: GoogleAuthInput) {


### PR DESCRIPTION
## What
Registration endpoint issued a JWT token before email verification, allowing unverified users to access authenticated endpoints.

## Root cause
\uth.service.ts::register()\ generated and returned a JWT immediately after user creation, before the user has verified their email via OTP.

## Changes
- \server/src/module/auth/auth.service.ts\ — Remove token generation from register; only return user data
- \server/src/module/auth/auth.controller.ts\ — Remove \setTokenCookie\ call after registration; update success message to prompt email verification

## Verification
- [x] Bug reproduced before fix
- [x] Fix verified locally
- [x] No unrelated files changed

## CI failures
N/A

## Before
JWT issued on register before email verification.

## After
JWT only issued on successful login or after email verification.

Closes #1428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Authentication**
  * Registration now responds with HTTP 201 and a confirmation message: "Registration successful. Please verify your email to continue."
  * Accounts require email verification before activation and access.
  * Authentication tokens are no longer issued at registration; users must verify their email to receive full authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->