### PR TITLE
feat(ci): add server build validation to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
   test-server:
     name: Test Server
     runs-on: ubuntu-latest
+    needs: [typecheck-server]
     steps:
       - uses: actions/checkout@v6
 
@@ -118,4 +119,30 @@ jobs:
 
       - name: Run unit tests
         run: npm test
+        working-directory: server
+
+  build-server:
+    name: Build Server
+    runs-on: ubuntu-latest
+    needs: [typecheck-server, test-server]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: server
+
+      - name: Generate Prisma client
+        run: npx prisma generate --schema=src/database/prisma/schema
+        working-directory: server
+
+      - name: Build server
+        run: npm run build
         working-directory: server


### PR DESCRIPTION
## What
Add server build validation step to the CI workflow to ensure the backend can complete its production build during pull requests.

## Root cause
The CI validated server code via type checking and tests, but never verified that the production build (`prisma generate && tsc`) actually succeeds. Build-time issues could slip through.

## Changes
- Added `build-server` job to `.github/workflows/ci.yml`
- Depends on `typecheck-server` and `test-server` (sequential pipeline)
- Runs `npm run build` which executes `prisma generate && tsc`
- Also added `needs: [typecheck-server]` to `test-server` for consistency

## Verification
- [x] Follows the same pattern as the existing `build-client` job
- [x] No CI infrastructure changes needed

## CI failures
N/A

## Before
Server typechecking and tests passed, but production build could fail.

## After
PR cannot merge if the server production build fails.

Closes #1395