### PR TITLE
Refactor components to avoid setting state inside useEffect

### DIFF
--- a/client/src/components/dsa-theory/algo/InputEditor.tsx
+++ b/client/src/components/dsa-theory/algo/InputEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Shuffle } from "lucide-react";
 
 interface Preset {
@@ -28,12 +28,13 @@ export function InputEditor({
   monospace = true,
 }: InputEditorProps) {
   const [draft, setDraft] = useState(value);
+  const [prevValue, setPrevValue] = useState(value);
 
   // Sync local draft when parent updates value externally (random/preset).
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+  if (value !== prevValue) {
+    setPrevValue(value);
     setDraft(value);
-  }, [value]);
+  }
 
   return (
     <div className="flex flex-col gap-2">

--- a/client/src/components/ui/LocationDropdown.tsx
+++ b/client/src/components/ui/LocationDropdown.tsx
@@ -70,11 +70,17 @@ export function LocationDropdown({
     loc.toLowerCase().includes(query.trim().toLowerCase())
   ).slice(0, 10);
 
+  const [prevValue, setPrevValue] = useState(value);
+  const [prevOpen, setPrevOpen] = useState(open);
+
   // ── Sync external value → query when closed ────────────────────────────────
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (!open) setQuery(value);
-  }, [value, open]);
+  if (value !== prevValue || open !== prevOpen) {
+    setPrevValue(value);
+    setPrevOpen(open);
+    if (!open) {
+      setQuery(value);
+    }
+  }
 
   const commitSelection = useCallback(() => {
     const trimmed = query.trim();

--- a/client/src/hooks/useInterviewCountdown.ts
+++ b/client/src/hooks/useInterviewCountdown.ts
@@ -23,10 +23,14 @@ export function useInterviewCountdown(targetDate: string) {
   }, [targetDate]);
 
   const [timeLeft, setTimeLeft] = useState(() => calculate());
+  const [prevTargetDate, setPrevTargetDate] = useState(targetDate);
+
+  if (targetDate !== prevTargetDate) {
+    setPrevTargetDate(targetDate);
+    setTimeLeft(calculate());
+  }
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setTimeLeft(calculate());
 
     const interval = setInterval(() => {
       const updated = calculate();

--- a/client/src/module/student/sql/SqlExercisePage.tsx
+++ b/client/src/module/student/sql/SqlExercisePage.tsx
@@ -118,6 +118,21 @@ export default function SqlExercisePage() {
   const [dbReady, setDbReady] = useState(false);
   const [solved, setSolved] = useState(false);
 
+  const [prevExerciseId, setPrevExerciseId] = useState(exercise?.id);
+
+  if (exercise?.id !== prevExerciseId) {
+    setPrevExerciseId(exercise?.id);
+    setDbReady(false);
+    setResult(null);
+    setValidation(null);
+    setShowHints(0);
+    setShowExpected(false);
+
+    const savedEntry = exercise ? progress[exercise.id] : undefined;
+    setCode(savedEntry?.code || exercise?.starterCode || "");
+    setSolved(!!savedEntry?.solved);
+  }
+
   // Load database and exercise
   useEffect(() => {
     if (!exercise || !section) return;
@@ -131,27 +146,8 @@ export default function SqlExercisePage() {
       setDbReady(true);
     };
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setDbReady(false);
-     
-    setResult(null);
-     
-    setValidation(null);
-     
-    setShowHints(0);
-     
-    setShowExpected(false);
-
-    // Restore saved code or use starter
-    const savedEntry = progress[exercise.id];
-     
-    setCode(savedEntry?.code || exercise.starterCode);
-     
-    setSolved(!!savedEntry?.solved);
-
     load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [exercise?.id, section?.id, progress]);
+  }, [exercise, section]);
 
   const handleRun = useCallback(async () => {
     if (!exercise || !dbReady) return;


### PR DESCRIPTION
# Pull Request

## Description
Refactored components to remove state updates inside `useEffect`, addressing React Hook anti-patterns. State is now either derived during render or updated via proper event handlers. Removed all instances of `eslint-disable-next-line react-hooks/set-state-in-effect` to enforce better data flow and reduce unnecessary re-renders.

## Related Issue
Fixes #1471 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
- Verified that components render correctly without errors or double renders.  
- Checked that ESLint no longer warns about setting state inside `useEffect`.  
- Tested interactive components (`LocationDropdown`, `InputEditor`, etc.) to ensure event handlers correctly update state.  
- Ran unit tests and confirmed all existing tests pass.  

## Screenshots / Video

_No UI changes in this PR_ 

## Checklist
- [x] Code follows project guidelines  
- [x] No new compile/type errors  
- [x] Tested manually (see testing section above)  
- [x] No `.env`, credentials, or `node_modules` committed  
- [x] Docs updated (if needed)  
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized state management in editor, dropdown, countdown timer, and SQL exercise components for improved render performance and code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->