### PR TITLE
fix: resolve issue #1482 - [Bug]: payroll - Contractor payment end date allowed before start date

### DIFF
--- a/server/src/module/payroll/payroll.validation.ts
+++ b/server/src/module/payroll/payroll.validation.ts
@@ -28,4 +28,7 @@ export const contractorPaymentSchema = z.object({
   periodStart: z.string().datetime(),
   periodEnd: z.string().datetime(),
   invoiceUrl: z.string().url().optional(),
+}).refine((data) => new Date(data.periodStart) <= new Date(data.periodEnd), {
+  message: "Period end date must be after or equal to start date",
+  path: ["periodEnd"],
 });


### PR DESCRIPTION
Closes #1482

This PR implements the necessary bug fix or improvement for this issue. Tested and verified locally via backend build compilation.