### PR TITLE
fix: resolve issue #1503 - [Bug]: contact - Message length constraint lacks spam protection bounds

### DIFF
--- a/server/src/module/contact/contact.validation.ts
+++ b/server/src/module/contact/contact.validation.ts
@@ -4,7 +4,7 @@ export const contactSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
   email: z.string().email("Invalid email address"),
   subject: z.string().min(1, "Subject is required").max(200),
-  message: z.string().min(1, "Message is required").max(5000),
+  message: z.string().min(10, "Message must be at least 10 characters").max(5000),
 });
 
 export type ContactInput = z.infer<typeof contactSchema>;

--- a/server/src/module/contact/contact.validation.ts
+++ b/server/src/module/contact/contact.validation.ts
@@ -4,7 +4,7 @@ export const contactSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
   email: z.string().email("Invalid email address"),
   subject: z.string().min(1, "Subject is required").max(200),
-  message: z.string().min(10, "Message must be at least 10 characters").max(5000),
+  message: z.string().min(20, "Message must be at least 20 characters").max(5000),
 });
 
 export type ContactInput = z.infer<typeof contactSchema>;


### PR DESCRIPTION
Closes #1503

This PR implements the necessary bug fix or improvement for this issue. Tested and verified locally via backend build compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Contact form messages now require a minimum of 20 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->