### PR TITLE
fix: resolve issue #1515 - [Bug]: job - Salary search minimum range allowed to exceed maximum range

### DIFF
--- a/server/src/module/job/job.validation.ts
+++ b/server/src/module/job/job.validation.ts
@@ -77,4 +77,12 @@ export const jobQuerySchema = z.object({
   includeExpired: coerceBoolean.default(false),
   salaryMin: z.coerce.number().int().nonnegative().optional(),
   salaryMax: z.coerce.number().int().nonnegative().optional(),
+}).refine((data) => {
+  if (data.salaryMin !== undefined && data.salaryMax !== undefined) {
+    return data.salaryMin <= data.salaryMax;
+  }
+  return true;
+}, {
+  message: "Minimum salary cannot be greater than maximum salary",
+  path: ["salaryMin"],
 });


### PR DESCRIPTION
Closes #1515

This PR implements the necessary bug fix or improvement for this issue. Tested and verified locally via backend build compilation.