### PR TITLE
fix: resolve issue #1521 - [Bug]: latex - Supporting file validation allows duplicate filenames

### DIFF
--- a/server/src/module/latex/latex.validation.ts
+++ b/server/src/module/latex/latex.validation.ts
@@ -15,6 +15,12 @@ export const compileLatexSchema = z.object({
     .min(10, "LaTeX source too short")
     .max(200000, "LaTeX source too large (200KB max)"),
   supportingFiles: z.array(supportingFileSchema).max(5).optional().default([]),
-});
+}).refine(
+  (data) => {
+    const names = data.supportingFiles.map((f) => f.filename);
+    return new Set(names).size === names.length;
+  },
+  { message: "Supporting file names must be unique", path: ["supportingFiles"] }
+);
 
 export type CompileLatexInput = z.infer<typeof compileLatexSchema>;


### PR DESCRIPTION
Closes #1521

This PR implements the necessary bug fix or improvement for this issue. Tested and verified locally via backend build compilation.