### PR TITLE
fix: normalize skills to lowercase on profile update to fix case-insensitive search

### DIFF
--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -459,7 +459,7 @@ export class AuthService {
       updateData.graduationYear = data.graduationYear ? Number(data.graduationYear) : null;
     }
     if ("skills" in data) {
-      updateData.skills = Array.isArray(data.skills) ? data.skills : [];
+      updateData.skills = Array.isArray(data.skills) ? data.skills.map((s: string) => s.trim().toLowerCase()) : [];
     }
     if ("jobStatus" in data) {
       updateData.jobStatus = data.jobStatus || null;


### PR DESCRIPTION
## What
Fix case-insensitive talent search failing for mixed-case skills (e.g., "javascript" doesn't match "JavaScript").

## Root cause
`recruiter.service.ts` lowercases the search query (`toLowerCase()`) but Prisma's `hasSome` does exact byte-by-byte comparison against the stored array. Skills were stored in their original case, so `"javascript" !== "JavaScript"`.

## Changes
- `auth.service.ts`: Normalize skills to lowercase when storing via `updateProfile`, so stored values always match the lowercased query

## Verification
- [x] Skills are now stored as `["javascript", "react"]` regardless of input casing
- [x] Recruiter `hasSome` filter now matches correctly since both sides are lowercase
- [x] Existing `.toLowerCase()` in recruiter search is kept as safety

## CI failures
N/A

## Before
`["JavaScript", "React"]` stored; query `"javascript"` returned zero results.

## After
Skills lowercased on storage; `"javascript"` correctly matches `["javascript", "react"]`.

Closes #1303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced user profile skill updates with automatic text normalization, including whitespace trimming and lowercase conversion for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->