### PR TITLE
fix: prevent duplicate round names within a job (#1169)

### DIFF
--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -183,6 +183,7 @@ model round {
   roundSubmissions    roundSubmission[]
 
   @@unique([jobId, orderIndex])
+  @@unique([jobId, name])
   @@index([jobId])
 }
 

--- a/server/src/module/recruiter/recruiter.controller.ts
+++ b/server/src/module/recruiter/recruiter.controller.ts
@@ -33,6 +33,7 @@ export class RecruiterController {
       return res.status(201).json({ message: "Round created successfully", round });
     } catch (error) {
       if (error instanceof Error) {
+        if ((error as any).statusCode === 409) return res.status(409).json({ message: error.message });
         if (error.message === "Job not found") return res.status(404).json({ message: error.message });
         if (error.message === "Not authorized") return res.status(403).json({ message: error.message });
       }
@@ -75,6 +76,7 @@ export class RecruiterController {
       return res.status(200).json({ message: "Round updated successfully", round });
     } catch (error) {
       if (error instanceof Error) {
+        if ((error as any).statusCode === 409) return res.status(409).json({ message: error.message });
         if (error.message === "Job not found" || error.message === "Round not found") return res.status(404).json({ message: error.message });
         if (error.message === "Not authorized") return res.status(403).json({ message: error.message });
       }

--- a/server/src/module/recruiter/recruiter.service.test.ts
+++ b/server/src/module/recruiter/recruiter.service.test.ts
@@ -12,6 +12,9 @@ const mocks = vi.hoisted(() => ({
     },
     round: {
       findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
     },
     roundSubmission: {
       update: vi.fn(),
@@ -208,5 +211,90 @@ describe("RecruiterService - evaluateSubmission", () => {
         }),
       })
     );
+  });
+});
+
+describe("RecruiterService - createRound", () => {
+  const service = new RecruiterService();
+  const jobId = 1;
+  const recruiterId = 10;
+  const roundData = { name: "Technical Interview", orderIndex: 0, description: "Test round" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should throw 409 if round name already exists for the job", async () => {
+    mocks.prisma.job.findUnique.mockResolvedValue({ id: jobId, recruiterId });
+    mocks.prisma.round.findFirst.mockResolvedValue({ id: 99, jobId, name: roundData.name });
+
+    await expect(
+      service.createRound(jobId, recruiterId, roundData)
+    ).rejects.toMatchObject({ message: `A round named "${roundData.name}" already exists for this job`, statusCode: 409 });
+
+    expect(mocks.prisma.round.create).not.toHaveBeenCalled();
+  });
+
+  it("should create the round if name is unique", async () => {
+    mocks.prisma.job.findUnique.mockResolvedValue({ id: jobId, recruiterId });
+    mocks.prisma.round.findFirst.mockResolvedValue(null);
+    mocks.prisma.round.create.mockResolvedValue({ id: 1, jobId, ...roundData });
+
+    const result = await service.createRound(jobId, recruiterId, roundData);
+
+    expect(result).toEqual({ id: 1, jobId, ...roundData });
+    expect(mocks.prisma.round.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ name: roundData.name }),
+      })
+    );
+  });
+});
+
+describe("RecruiterService - updateRound", () => {
+  const service = new RecruiterService();
+  const jobId = 1;
+  const roundId = 5;
+  const recruiterId = 10;
+  const existingRound = { id: roundId, jobId, name: "Original Name", orderIndex: 0 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should throw 409 if renamed to an existing name within the job", async () => {
+    mocks.prisma.job.findUnique.mockResolvedValue({ id: jobId, recruiterId });
+    mocks.prisma.round.findUnique.mockResolvedValue(existingRound);
+    mocks.prisma.round.findFirst.mockResolvedValue({ id: 99, jobId, name: "Duplicate Name" });
+
+    await expect(
+      service.updateRound(jobId, roundId, recruiterId, { name: "Duplicate Name" })
+    ).rejects.toMatchObject({ message: 'A round named "Duplicate Name" already exists for this job', statusCode: 409 });
+
+    expect(mocks.prisma.round.update).not.toHaveBeenCalled();
+  });
+
+  it("should skip duplicate check if name is unchanged", async () => {
+    mocks.prisma.job.findUnique.mockResolvedValue({ id: jobId, recruiterId });
+    mocks.prisma.round.findUnique.mockResolvedValue(existingRound);
+    mocks.prisma.round.update.mockResolvedValue(existingRound);
+
+    await service.updateRound(jobId, roundId, recruiterId, { name: "Original Name" });
+
+    expect(mocks.prisma.round.findFirst).not.toHaveBeenCalled();
+    expect(mocks.prisma.round.update).toHaveBeenCalled();
+  });
+
+  it("should allow update when new name is unique", async () => {
+    const updated = { ...existingRound, name: "Unique Name" };
+    mocks.prisma.job.findUnique.mockResolvedValue({ id: jobId, recruiterId });
+    mocks.prisma.round.findUnique.mockResolvedValue(existingRound);
+    mocks.prisma.round.findFirst.mockResolvedValue(null);
+    mocks.prisma.round.update.mockResolvedValue(updated);
+
+    const result = await service.updateRound(jobId, roundId, recruiterId, { name: "Unique Name" });
+
+    expect(result.name).toBe("Unique Name");
+    expect(mocks.prisma.round.update).toHaveBeenCalled();
   });
 });

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -114,6 +114,13 @@ export class RecruiterService {
     if (!job) throw new Error("Job not found");
     if (job.recruiterId !== recruiterId) throw new Error("Not authorized");
 
+    const existing = await prisma.round.findFirst({
+      where: { jobId, name: data.name },
+    });
+    if (existing) {
+      throw Object.assign(new Error(`A round named "${data.name}" already exists for this job`), { statusCode: 409 });
+    }
+
     return prisma.round.create({
       data: {
         jobId,
@@ -152,6 +159,15 @@ export class RecruiterService {
 
     const round = await prisma.round.findUnique({ where: { id: roundId } });
     if (!round || round.jobId !== jobId) throw new Error("Round not found");
+
+    if (data.name !== undefined && data.name !== round.name) {
+      const existing = await prisma.round.findFirst({
+        where: { jobId, name: data.name, id: { not: roundId } },
+      });
+      if (existing) {
+        throw Object.assign(new Error(`A round named "${data.name}" already exists for this job`), { statusCode: 409 });
+      }
+    }
 
     return prisma.round.update({
       where: { id: roundId },


### PR DESCRIPTION
## What
Prevent recruiters from creating multiple rounds with the same name within a job.

## Root cause
The `round` model had `@@unique([jobId, orderIndex])` but no `@@unique([jobId, name])`, allowing duplicate round names.

## Changes
- `base.prisma`: Added `@@unique([jobId, name])` constraint to the round model
- `recruiter.service.ts`: Added `findFirst` check in `createRound()` before insert, and in `updateRound()` before rename
- `recruiter.controller.ts`: Added 409 Conflict handling for duplicate name errors in both `createRound` and `updateRound`
- `recruiter.service.test.ts`: Added 5 test cases covering create (duplicate reject, success) and update (duplicate reject, skip on unchanged, success)

## Verification
New tests pass: duplicate round name → 409 error; unique name → success; unchanged name on update → skip check.

## CI failures
N/A

## Before / After
Before: Round "Technical Interview" could be created 3 times under the same job.
After: Second attempt returns 409 "A round named 'Technical Interview' already exists for this job"

Closes #1169


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Round names are now uniquely enforced per job, preventing duplicate names from being created or applied during updates
  * System returns a conflict error when attempting to create a new round with a name that already exists within the same job or when renaming a round to duplicate an existing name

* **Tests**
  * Added comprehensive test coverage for round creation and update operations, verifying proper conflict error handling for duplicate round names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->