### PR TITLE
feat: add upcoming-deadline reminder banner to ApplicationProgressPage (#1264)

### DIFF
--- a/client/src/module/student/applications/ApplicationProgressPage.tsx
+++ b/client/src/module/student/applications/ApplicationProgressPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from "react";
 import { getStatusColor } from "../../../lib/application-colors";
 import { useParams, useNavigate, Link } from "react-router";
-import { ArrowLeft, CheckCircle, Clock, Circle, Send, ExternalLink, Calendar as CalendarIcon, Download } from "lucide-react";
+import { ArrowLeft, CheckCircle, Clock, Circle, Send, ExternalLink, Calendar as CalendarIcon, Download, AlertTriangle } from "lucide-react";
 import { motion } from "framer-motion";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { DynamicFieldRenderer } from "../../../components/DynamicFieldRenderer";
@@ -13,6 +13,17 @@ import type { Application, CustomFieldDefinition, AssessmentQuestion } from "../
 import { LoadingScreen } from "../../../components/LoadingScreen";
 import { Button } from "../../../components/ui/button";
 import { googleCalendarUrl, downloadICS } from "../../../lib/calendar";
+
+function getDeadlineBanner(deadline: string): { level: "warning" | "critical" | null; daysLeft: number } {
+  const now = new Date();
+  const deadlineDate = new Date(deadline);
+  const diffMs = deadlineDate.getTime() - now.getTime();
+  const daysLeft = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  if (daysLeft < 0) return { level: null, daysLeft };
+  if (daysLeft <= 2) return { level: "critical", daysLeft };
+  if (daysLeft <= 7) return { level: "warning", daysLeft };
+  return { level: null, daysLeft };
+}
 
 export default function ApplicationProgressPage() {
   const { applicationId } = useParams();
@@ -102,6 +113,41 @@ export default function ApplicationProgressPage() {
           )}
         </div>
       </div>
+
+      {/* Deadline urgency banner */}
+      {application.job?.deadline && (() => {
+        const banner = getDeadlineBanner(application.job!.deadline!);
+        if (!banner.level) return null;
+        const isCritical = banner.level === "critical";
+        return (
+          <div className={`mb-6 p-4 rounded-lg border ${isCritical ? "border-red-300 bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-400" : "border-amber-300 bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-400"}`}>
+            <div className="flex items-start gap-3">
+              {isCritical ? <Clock className="w-5 h-5 mt-0.5 text-red-500" /> : <AlertTriangle className="w-5 h-5 mt-0.5 text-amber-500" />}
+              <div className="flex-1">
+                <p className="font-medium">
+                  {isCritical
+                    ? `Deadline ${banner.daysLeft === 0 ? "is today" : `is in ${banner.daysLeft} day${banner.daysLeft !== 1 ? "s" : ""}`}`
+                    : `Deadline is in ${banner.daysLeft} day${banner.daysLeft !== 1 ? "s" : ""}`}
+                </p>
+                <p className="text-sm mt-1 opacity-80">Submit your rounds before the deadline to avoid missing this opportunity.</p>
+              </div>
+              <Button
+                variant={isCritical ? "mono" : "outline"}
+                size="sm"
+                className="shrink-0 h-8 text-xs flex items-center gap-1"
+                onClick={() => window.open(googleCalendarUrl({
+                  title: `${application.job?.title} @ ${application.job?.company} — Application Deadline`,
+                  details: `Applied via InternHack: https://internhack.xyz/student/applications/${application.id}\\nCompany: ${application.job?.company}\\nRole: ${application.job?.title}\\nLocation: ${application.job?.location || "Remote"}`,
+                  start: new Date(application.job?.deadline ?? ""),
+                  end: new Date(new Date(application.job?.deadline ?? "").getTime() + 30 * 60000),
+                }), '_blank')}
+              >
+                <CalendarIcon className="w-3.5 h-3.5" /> Add to Calendar
+              </Button>
+            </div>
+          </div>
+        );
+      })()}
 
       {/* Round Progress Timeline */}
       <div className="space-y-4">


### PR DESCRIPTION
## What
Add visual urgency to the ApplicationProgressPage by showing a colored deadline reminder banner when the deadline is approaching.

## Root cause
Job deadline was displayed only as small text next to the status badge — easy to miss.

## Changes
- Added `getDeadlineBanner(deadline)` helper that computes `daysLeft` and returns `{ level, daysLeft }`
  - `daysLeft < 0` → returns `null` (hide banner)
  - `daysLeft <= 2` → `{ level: "critical" }` (red banner)
  - `daysLeft <= 7` → `{ level: "warning" }` (amber banner)
- Renders the banner with:
  - **Amber/red styling** matching the urgency level (`border-amber-300 bg-amber-50` / `border-red-300 bg-red-50`)
  - **AlertTriangle icon** for warning, **Clock icon** for critical
  - **"Add to Calendar" button** that opens Google Calendar with the deadline event
  - Descriptive message: "Deadline is today", "Deadline is in N days", etc.

## Verification
Tested manually by checking banner visibility at different date ranges. Banner hides after deadline passes.

## CI failures
N/A

## Before / After
Before: Tiny "Deadline: Apr 15, 2026" text next to status badge.
After: Amber banner when ≤7 days away, red banner when ≤2 days or today, hidden after deadline.

Closes #1264


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual deadline urgency indicators on the application progress page that display critical, warning, or normal statuses based on the number of days remaining until the application deadline closes
  * Enabled calendar integration functionality allowing users to add application deadlines directly to their personal calendar for improved deadline awareness and scheduling convenience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->