### PR TITLE
fix: stale closure in ProctoringCamera useEffect causing memory leak (#1325)

### DIFF
--- a/client/src/components/ProctoringCamera.tsx
+++ b/client/src/components/ProctoringCamera.tsx
@@ -28,12 +28,11 @@ export default function ProctoringCamera({ onViolation, onSnapshot, onError, onR
     onError,
   });
 
-  // Auto-start camera on mount
+  // Auto-start camera on mount and re-create intervals when config changes
   useEffect(() => {
     start();
     return () => stop();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [start, stop]);
 
   const statusColor =
     currentFaceCount === 1


### PR DESCRIPTION
## Description

Fixes #1325

The \ProctoringCamera\ component had a stale closure in its \useEffect\ that captured the initial \start\ and \stop\ functions from \useFaceDetection\. The effect had an empty dependency array with a suppressed ESLint warning, meaning:

- The effect only ran on mount with the initial \start\ function
- If the \start\ function changed (e.g., because config values like \detectionIntervalMs\, \snapshotIntervalMs\ changed), the old function was still used
- The cleanup function always called the initial \stop\, which could lead to orphaned intervals and memory leaks

## Changes

- Added \start\ and \stop\ to the effect's dependency array
- Removed the \eslint-disable-next-line\ comment that was hiding the warning
- The effect now properly re-runs when \start\ changes, cleaning up previous intervals before setting up new ones

## Impact

- Prevents memory leaks from orphaned intervals when config values change
- Ensures the camera feed and detection/snapshot timers always use the latest configuration
- Makes the component more robust during re-renders with updated props

## Testing

- Verified the component still auto-starts the camera on mount
- Verified cleanup stops all intervals and streams on unmount
- The effect correctly re-runs when config values change via the \start\ dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced lifecycle management in the proctoring camera component to ensure face detection functionality is properly initialized and cleaned up when relevant dependencies change. The component now correctly manages interval recreation and cleanup operations throughout its lifetime, replacing the previous approach that only occurred at initial component mount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->