### PR TITLE
fix: add route wiring, Zod validation, and TypeScript types for professor cache invalidation

### DIFF
--- a/server/src/module/professor/professor.controller.ts
+++ b/server/src/module/professor/professor.controller.ts
@@ -2,6 +2,7 @@ import type { Request, Response, NextFunction } from "express";
 import { ProfessorService } from "./professor.service.js";
 import { isPremiumUser } from "../../utils/premium.utils.js";
 import { parsePagination } from "../../utils/pagination.utils.js";
+import { createProfessorSchema, updateProfessorSchema } from "./professor.validation.js";
 
 const service = new ProfessorService();
 
@@ -26,6 +27,53 @@ export class ProfessorController {
     try {
       const result = await service.stats();
       res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const parsed = createProfessorSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ message: "Invalid payload", errors: parsed.error.flatten() });
+        return;
+      }
+      const record = await service.create(parsed.data);
+      res.status(201).json(record);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const id = Number(String(req.params["id"]));
+      if (!Number.isFinite(id)) {
+        res.status(400).json({ message: "Invalid ID" });
+        return;
+      }
+      const parsed = updateProfessorSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ message: "Invalid payload", errors: parsed.error.flatten() });
+        return;
+      }
+      const record = await service.update(id, parsed.data);
+      res.json(record);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async delete(req: Request, res: Response, next: NextFunction) {
+    try {
+      const id = Number(String(req.params["id"]));
+      if (!Number.isFinite(id)) {
+        res.status(400).json({ message: "Invalid ID" });
+        return;
+      }
+      const record = await service.delete(id);
+      res.json({ message: "Professor deleted", record });
     } catch (err) {
       next(err);
     }

--- a/server/src/module/professor/professor.routes.ts
+++ b/server/src/module/professor/professor.routes.ts
@@ -1,9 +1,31 @@
 import { Router } from "express";
 import { ProfessorController } from "./professor.controller.js";
-import { optionalAuthMiddleware } from "../../middleware/auth.middleware.js";
+import { authMiddleware, optionalAuthMiddleware } from "../../middleware/auth.middleware.js";
+import { requireRole } from "../../middleware/role.middleware.js";
 
 const controller = new ProfessorController();
 export const professorRouter = Router();
 
 professorRouter.get("/stats", (_req, res, next) => controller.stats(_req, res, next));
 professorRouter.get("/", optionalAuthMiddleware, (req, res, next) => controller.list(req, res, next));
+
+professorRouter.post(
+  "/",
+  authMiddleware,
+  requireRole("ADMIN"),
+  (req, res, next) => controller.create(req, res, next),
+);
+
+professorRouter.patch(
+  "/:id",
+  authMiddleware,
+  requireRole("ADMIN"),
+  (req, res, next) => controller.update(req, res, next),
+);
+
+professorRouter.delete(
+  "/:id",
+  authMiddleware,
+  requireRole("ADMIN"),
+  (req, res, next) => controller.delete(req, res, next),
+);

--- a/server/src/module/professor/professor.service.ts
+++ b/server/src/module/professor/professor.service.ts
@@ -1,5 +1,6 @@
-﻿import { prisma } from "../../database/db.js";
-import { cacheGet, cacheSet } from "../../utils/cache.js";
+import { prisma } from "../../database/db.js";
+import { cacheGet, cacheSet, cacheDelPattern } from "../../utils/cache.js";
+import type { CreateProfessorInput, UpdateProfessorInput } from "./professor.validation.js";
 
 const PROF_TTL = 3600;
 
@@ -105,6 +106,24 @@ export class ProfessorService {
     };
     await cacheSet(cacheKey, result, PROF_TTL);
     return result;
+  }
+
+  async create(data: CreateProfessorInput) {
+    const record = await prisma.iitProfessor.create({ data });
+    await cacheDelPattern("professors:");
+    return record;
+  }
+
+  async update(id: number, data: UpdateProfessorInput) {
+    const record = await prisma.iitProfessor.update({ where: { id }, data });
+    await cacheDelPattern("professors:");
+    return record;
+  }
+
+  async delete(id: number) {
+    const record = await prisma.iitProfessor.delete({ where: { id } });
+    await cacheDelPattern("professors:");
+    return record;
   }
 }
 

--- a/server/src/module/professor/professor.validation.ts
+++ b/server/src/module/professor/professor.validation.ts
@@ -7,3 +7,17 @@ export const professorListQuerySchema = z.object({
   college: z.string().optional(),
   department: z.string().optional(),
 });
+
+export const createProfessorSchema = z.object({
+  collegeName: z.string().min(1, "College name is required"),
+  collegeType: z.string().min(1, "College type is required"),
+  department: z.string().min(1, "Department is required"),
+  name: z.string().min(1, "Professor name is required"),
+  areaOfInterest: z.string().optional().or(z.literal("")),
+  email: z.string().email("Invalid email format").optional().or(z.literal("")),
+});
+
+export const updateProfessorSchema = createProfessorSchema.partial();
+
+export type CreateProfessorInput = z.infer<typeof createProfessorSchema>;
+export type UpdateProfessorInput = z.infer<typeof updateProfessorSchema>;


### PR DESCRIPTION
Closes #1396

### Summary of Changes

Following the feedback on the previous PR #1397, this fresh pull request addresses:
- **TypeScript Types**: Replaced untyped `any` parameter types with proper Zod-inferred TypeScript types (`CreateProfessorInput`, `UpdateProfessorInput`) in the professor service.
- **Route Wiring**: Wired up the corresponding CRUD endpoints in the professor router:
  - `POST /api/professors/` (secured with `authMiddleware` and `requireRole("ADMIN")`)
  - `PATCH /api/professors/:id` (secured with `authMiddleware` and `requireRole("ADMIN")`)
  - `DELETE /api/professors/:id` (secured with `authMiddleware` and `requireRole("ADMIN")`)
- **Validation Schemas**: Added validation schemas (`createProfessorSchema` and `updateProfessorSchema`) for incoming requests.
- **Cache Invalidation**: Properly invalidates cached lists and stats upon data modifications using `cacheDelPattern("professors:")`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Administrators can now create, update, and delete professor records with input validation and error handling.
* Professor management endpoints now require admin authentication and authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->