### PR TITLE
feat: add backend streak tracking for roadmap progress

### DIFF
--- a/server/src/database/prisma/schema/roadmap.prisma
+++ b/server/src/database/prisma/schema/roadmap.prisma
@@ -84,25 +84,29 @@ model roadmapResource {
 
   @@index([topicId])
 }
-
 model roadmapEnrollment {
-  id              Int                    @id @default(autoincrement())
-  userId          Int
-  user            user                   @relation("UserRoadmapEnrollments", fields: [userId], references: [id], onDelete: Cascade)
-  roadmapId       Int
-  roadmap         roadmap                @relation(fields: [roadmapId], references: [id], onDelete: Cascade)
-  hoursPerWeek    Int                    @default(8)
-  preferredDays   String[]               @default([])
-  startDate       DateTime               @default(now())
-  targetEndDate   DateTime
-  experienceLevel ExperienceLevel        @default(NEW)
-  goal            EnrollmentGoal         @default(JOB_READY)
-  status          EnrollmentStatus       @default(ACTIVE)
-  weeklyPlan      Json                   @default("[]")
-  pdfUrl          String?
-  topicProgress   roadmapTopicProgress[]
-  createdAt       DateTime               @default(now())
-  updatedAt       DateTime               @updatedAt
+  id                 Int                    @id @default(autoincrement())
+  userId             Int
+  user               user                   @relation("UserRoadmapEnrollments", fields: [userId], references: [id], onDelete: Cascade)
+  roadmapId          Int
+  roadmap            roadmap                @relation(fields: [roadmapId], references: [id], onDelete: Cascade)
+  hoursPerWeek       Int                    @default(8)
+  preferredDays      String[]               @default([])
+  startDate          DateTime               @default(now())
+  targetEndDate      DateTime
+  experienceLevel    ExperienceLevel        @default(NEW)
+  goal               EnrollmentGoal         @default(JOB_READY)
+  status             EnrollmentStatus       @default(ACTIVE)
+  currentStreak      Int                    @default(0)
+  bestStreak         Int                    @default(0)
+  lastStreakDate     DateTime?
+  weeklyStreak       Int                    @default(0)
+  lastWeeklyStreakAt DateTime?
+  weeklyPlan         Json                   @default("[]")
+  pdfUrl             String?
+  topicProgress      roadmapTopicProgress[]
+  createdAt          DateTime               @default(now())
+  updatedAt          DateTime               @updatedAt
 
   @@unique([userId, roadmapId])
   @@index([userId])

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -397,6 +397,38 @@ export async function listEnrollmentsForUser(userId: number) {
 
 type TopicStatusValue = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED" | "SKIPPED";
 
+async function updateEnrollmentStreak(enrollmentId: number) {
+  const completedTopics = await prisma.roadmapTopicProgress.findMany({
+    where: {
+      enrollmentId,
+      status: "COMPLETED",
+      completedAt: { not: null },
+    },
+    select: { completedAt: true },
+    orderBy: { completedAt: "asc" },
+  });
+
+  const completedDayKeys = getCompletedUtcDays(
+    completedTopics.map((topic) => ({
+      completedAt: topic.completedAt!,
+    })),
+  );
+
+  const { currentStreak, longestStreak } = calculateStreaks(completedDayKeys);
+  const lastCompletedAt = completedTopics.at(-1)?.completedAt ?? null;
+
+  await prisma.roadmapEnrollment.update({
+    where: { id: enrollmentId },
+    data: {
+      currentStreak,
+      bestStreak: longestStreak,
+      lastStreakDate: lastCompletedAt,
+      weeklyStreak: currentStreak >= 7 ? Math.floor(currentStreak / 7) : 0,
+      lastWeeklyStreakAt: currentStreak >= 7 ? lastCompletedAt : null,
+    },
+  });
+}
+
 export async function updateTopicProgress(args: {
   userId: number;
   enrollmentId: number;
@@ -453,6 +485,10 @@ export async function updateTopicProgress(args: {
     update: data,
     create,
   });
+
+  if (args.status === "COMPLETED") {
+  await updateEnrollmentStreak(enrollment.id);
+}
 
   // Check if all topics are now complete
   let roadmapCompleted = false;


### PR DESCRIPTION
# Pull Request

## Description

Added backend support for roadmap learning streak tracking.

This PR introduces streak metadata on roadmap enrollments and updates streak values automatically when a user marks a roadmap topic as completed.

Changes include:

* Added current streak tracking
* Added best streak tracking
* Added last streak activity date
* Added weekly streak metadata
* Recomputed streak values when topic progress is marked as `COMPLETED`

This creates the backend foundation for future dashboard/profile badges and leaderboard streak display.

## Related Issue

Fixes #98

## Type of Change

* [ ] Bug Fix
* [x] Feature
* [x] Enhancement
* [ ] Documentation

## Testing

* Verified the changed Prisma schema fields are present.
* Verified streak update helper is added in roadmap progress service.
* Ran backend typecheck, but the current codebase has existing unrelated TypeScript errors across multiple modules, so the full typecheck does not pass independently of this PR.

## Screenshots / Video

*No UI changes in this PR*

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors from the changed files identified during review
* [x] Tested manually as described above
* [x] No `.env`, credentials, or `node_modules` committed
* [x] Docs updated (if needed)
* [x] Screenshot or video attached for every UI change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive streak tracking to measure learning consistency with current streak, best streak, and weekly streak metrics
  * Streaks automatically calculate and update when you complete topics in your learning roadmap, helping you stay motivated and track your progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->