### PR TITLE
fix: add character length limits to skills array items in auth profile validation (#1497)

### DIFF
--- a/server/src/module/auth/auth.validation.ts
+++ b/server/src/module/auth/auth.validation.ts
@@ -80,7 +80,7 @@ export const updateProfileSchema = z.object({
   bio: z.string().max(500).optional(),
   college: z.string().optional(),
   graduationYear: z.coerce.number().int().min(1990).max(2040).optional().nullable(),
-  skills: z.array(z.string()).max(20).optional(),
+  skills: z.array(z.string().min(1).max(100)).max(20).optional(),
   location: z.string().optional(),
   linkedinUrl: z.string().url().or(z.literal("")).optional(),
   githubUrl: z.string().url().or(z.literal("")).optional(),


### PR DESCRIPTION
## What
Add character length bounds to the skills array items in the auth profile update validation schema.

## Root cause
`updateProfileSchema` defined `skills: z.array(z.string()).max(20).optional()` — the array had a max item count but individual skill strings had no length limits. A user could submit a skill name with thousands of characters.

## Changes
- `auth.validation.ts`: Changed `z.string()` to `z.string().min(1).max(100)` in the skills array definition

## Verification
Zod schema will now reject empty strings and strings longer than 100 characters per skill.

## CI failures
N/A

## Before / After
Before: `skills: z.array(z.string()).max(20).optional()`
After: `skills: z.array(z.string().min(1).max(100)).max(20).optional()`

Closes #1497


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated skill validation constraints in profile updates: individual skills are now limited to 1-100 characters with a maximum of 20 skills per profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->