### PR TITLE
fix: add length bounds to GSOC search query filter parameters (#1507)

### DIFF
--- a/server/src/module/gsoc/gsoc.validation.ts
+++ b/server/src/module/gsoc/gsoc.validation.ts
@@ -3,11 +3,11 @@ import { z } from "zod";
 export const gsocListQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(50).default(20),
-  search: z.string().optional(),
-  category: z.string().optional(),
-  technology: z.string().optional(),
+  search: z.string().min(1).max(200).optional(),
+  category: z.string().min(1).max(100).optional(),
+  technology: z.string().min(1).max(100).optional(),
   year: z.coerce.number().int().min(2005).max(2030).optional(),
-  topic: z.string().optional(),
+  topic: z.string().min(1).max(100).optional(),
   sortBy: z.enum(["totalProjects", "name", "createdAt"]).default("totalProjects"),
   sortOrder: z.enum(["asc", "desc"]).default("desc"),
 });

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -70,9 +70,9 @@ export const bulkRepoRequestSchema = z.object({
 export const gsocOrgsQuerySchema = z.object({
   page: z.coerce.number().int().positive().optional().default(1),
   limit: z.coerce.number().int().positive().max(100).optional().default(20),
-  search: z.string().optional(),
-  category: z.string().optional(),
-  technology: z.string().optional(),
+  search: z.string().min(1).max(200).optional(),
+  category: z.string().min(1).max(100).optional(),
+  technology: z.string().min(1).max(100).optional(),
   year: z.coerce.number().int().optional(),
 });
 


### PR DESCRIPTION
## What
Add length bounds to GSOC and opensource search query parameters to prevent resource exhaustion / DoS from arbitrarily long search strings.

## Root cause
Both `gsocListQuerySchema` and `gsocOrgsQuerySchema` defined `search: z.string().optional()` without `.min()` or `.max()` bounds. These search values are used in Prisma `contains` + `mode: "insensitive"` queries, which are expensive on unbounded input.

## Changes
- `gsoc.validation.ts`: Added `.min(1).max(200)` to `search`, added `.min(1).max(100)` to `category`, `technology`, `topic`
- `opensource.validation.ts`: Same constraints on `search`, `category`, `technology`

## Verification
Zod schema now rejects empty and overly long search strings at the route level before they reach Prisma.

## CI failures
N/A

## Before / After
Before: `search: z.string().optional()`
After: `search: z.string().min(1).max(200).optional()`

Closes #1507


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for search and filtering parameters across the application.
  * Search queries are now limited to 200 characters maximum.
  * Category, technology, and topic filters are now limited to 100 characters maximum.
  * Empty values are no longer accepted for these optional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->