### PR TITLE
fix: replace useState+useEffect with lazy initialization to eliminate unnecessary re-renders (#1471)

### DIFF
--- a/client/src/module/blog/hooks/useBookmarks.ts
+++ b/client/src/module/blog/hooks/useBookmarks.ts
@@ -1,31 +1,20 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 const STORAGE_KEY = "bookmarkedBlogs";
 
 export function useBookmarks() {
-  const [bookmarks, setBookmarks] = useState<number[]>([]);
-
-  useEffect(() => {
+  const [bookmarks, setBookmarks] = useState<number[]>(() => {
     try {
-      const stored =
-        localStorage.getItem(STORAGE_KEY);
-
-      if (!stored) return;
-
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) return [];
       const raw: unknown = JSON.parse(stored);
-      const parsed = Array.isArray(raw)
+      return Array.isArray(raw)
         ? raw.filter((x): x is number => typeof x === "number")
         : [];
-
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setBookmarks(parsed);
-    } catch (error) {
-      console.error(
-        "Failed to load bookmarks:",
-        error
-      );
+    } catch {
+      return [];
     }
-  }, []);
+  });
 
   const saveBookmarks = (
     updated: number[]

--- a/client/src/module/student/opensource/useRecentlyViewedRepos.ts
+++ b/client/src/module/student/opensource/useRecentlyViewedRepos.ts
@@ -1,23 +1,18 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import type { OpenSourceRepo } from "../../../lib/types";
 
 const STORAGE_KEY = "oss_recently_viewed";
 const MAX_RECENTLY_VIEWED = 5;
 
 export function useRecentlyViewedRepos() {
-  const [recentlyViewed, setRecentlyViewed] = useState<OpenSourceRepo[]>([]);
-
-  useEffect(() => {
+  const [recentlyViewed, setRecentlyViewed] = useState<OpenSourceRepo[]>(() => {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setRecentlyViewed(JSON.parse(stored));
-      }
-    } catch (error) {
-      console.error("Failed to read recently viewed repos from localStorage", error);
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
     }
-  }, []);
+  });
 
   const addRepo = useCallback((repo: OpenSourceRepo) => {
     setRecentlyViewed((prev) => {

--- a/client/src/module/student/roadmap/RoadmapCanvasPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapCanvasPage.tsx
@@ -437,10 +437,6 @@ export default function RoadmapCanvasPage() {
     return () => window.removeEventListener("resize", onResize);
   }, []);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setIsTouchDevice("ontouchstart" in window || navigator.maxTouchPoints > 0);
-  }, []);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const graphOffsetsRef = useRef(new Map<number, { x: number; y: number }>());


### PR DESCRIPTION
## What
Replace `useState([])` + `useEffect(() => { setState(data) }, [])` with lazy state initialization to eliminate unnecessary re-renders and removed suppressed ESLint warnings.

## Root cause
Three files used the pattern of initializing state to a default value, then immediately setting it in a `useEffect` with `[]` deps — guaranteeing at least one extra render on every mount.

## Changes
- `useRecentlyViewedRepos.ts`: Moved `localStorage.getItem` into `useState(() => ...)` lazy initializer; removed `useEffect` import and eslint-disable comment
- `useBookmarks.ts`: Same pattern — lazy initializer for localStorage bookmarks; removed `useEffect` import and eslint-disable
- `RoadmapCanvasPage.tsx`: Removed redundant `useEffect` that set `isTouchDevice` — the state already had a lazy initializer computing the same value

## Verification
Components now initialize with the correct value on the first render instead of flashing default → corrected.

## CI failures
N/A

## Before / After
Before: `useState([])` → render → `useEffect` → `setState(realData)` → re-render (2 renders)
After: `useState(() => readFromStorage())` → render with real data (1 render)

Closes #1471
