### PR TITLE
fix: add length bounds to YC search query filter parameters (#1534)

### DIFF
--- a/server/src/module/yc/yc.validation.ts
+++ b/server/src/module/yc/yc.validation.ts
@@ -3,10 +3,10 @@ import { z } from "zod";
 export const ycListQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(50).default(24),
-  search: z.string().optional(),
-  batch: z.string().optional(),
-  industry: z.string().optional(),
-  status: z.string().optional(),
+  search: z.string().max(200).optional(),
+  batch: z.string().max(100).optional(),
+  industry: z.string().max(100).optional(),
+  status: z.string().max(100).optional(),
   isHiring: z.enum(["true", "false"]).optional(),
   topCompany: z.enum(["true", "false"]).optional(),
 });


### PR DESCRIPTION
## What
Add length bounds to YC listing query parameters to prevent resource exhaustion.

## Root cause
`ycListQuerySchema` defined `search`, `batch`, `industry`, `status` as bare `z.string().optional()` with no `.max()` bounds.

## Changes
- Added `.max(200)` to `search`, `.max(100)` to `batch`, `industry`, `status` in `yc.validation.ts`

## Verification
Zod rejects strings exceeding these limits at the route level.

Closes #1534
