### PR TITLE
fix: add length bounds to roadmap search query parameters (#1532)

### DIFF
--- a/server/src/module/roadmap/roadmap.validation.ts
+++ b/server/src/module/roadmap/roadmap.validation.ts
@@ -52,9 +52,9 @@ export const listQuerySchema = z.object({
   // limit: z.coerce.number().int().min(1).max(50).default(20),
   limit: z.coerce.number().int().min(1).max(100).default(20),
   level: z.enum(["BEGINNER", "INTERMEDIATE", "ADVANCED", "ALL_LEVELS"]).optional(),
-  search: z.string().optional(),
-  tag: z.string().optional(),
-  category: z.string().optional(),
+  search: z.string().max(200).optional(),
+  tag: z.string().max(100).optional(),
+  category: z.string().max(100).optional(),
 });
 
 export const aiGenerateSchema = z.object({


### PR DESCRIPTION
## What\nAdd length bounds to roadmap listing query parameters.\n\n## Root cause\n\listQuerySchema\ defined \search\, \	ag\, \category\ as bare \z.string().optional()\ with no \.max()\ bounds.\n\n## Changes\n- Added \.max(200)\ to \search\, \.max(100)\ to \	ag\, \category\ in \oadmap.validation.ts\\n\nCloses #1532