### PR TITLE
fix: enforce minimum permissions requirement in role update (#1530)

### DIFF
--- a/server/src/module/rbac/rbac.validation.ts
+++ b/server/src/module/rbac/rbac.validation.ts
@@ -35,7 +35,7 @@ export const createRoleSchema = z.object({
 export const updateRoleSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   description: z.string().max(500).optional(),
-  permissions: z.array(z.string()).optional(),
+  permissions: z.array(z.string()).min(1, "At least one permission is required when updating permissions").optional(),
 });
 
 export const assignRoleSchema = z.object({


### PR DESCRIPTION
## What
Prevent setting an empty permissions array when updating a role.

## Root cause
`updateRoleSchema` had `permissions: z.array(z.string()).optional()` with no `.min(1)` check, allowing revoking all permissions.

## Changes
- Added `.min(1, "At least one permission is required when updating permissions")` to the permissions array

Closes #1530
