### PR TITLE
fix: add length bounds to professor listing query parameters (#1528)

### DIFF
--- a/server/src/module/professor/professor.validation.ts
+++ b/server/src/module/professor/professor.validation.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const professorListQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(50).default(24),
-  search: z.string().optional(),
-  college: z.string().optional(),
-  department: z.string().optional(),
+  search: z.string().max(200).optional(),
+  college: z.string().max(100).optional(),
+  department: z.string().max(100).optional(),
 });


### PR DESCRIPTION
## What
Add length bounds to professor listing query parameters to prevent resource exhaustion.

## Root cause
`professorListQuerySchema` defined `search`, `college`, `department` as bare `z.string().optional()` with no `.max()` bounds.

## Changes
- Added `.max(200)` to `search`, `.max(100)` to `college` and `department` in `professor.validation.ts`

Closes #1528
