### PR TITLE
fix: validate questionIdSchema with alphanumeric and dash regex (#1523)

### DIFF
--- a/server/src/module/learn/learn.validation.ts
+++ b/server/src/module/learn/learn.validation.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const questionIdSchema = z.string().trim().min(1).max(160);
+const questionIdSchema = z.string().trim().min(1).max(160).regex(/^[a-zA-Z0-9-]+$/, "Question ID must be alphanumeric with dashes only");
 const idArraySchema = z.array(questionIdSchema).max(1000);
 
 export const interviewProgressActionSchema = z.object({


### PR DESCRIPTION
## What
Add regex validation to questionIdSchema to enforce alphanumeric and dash format.

## Root cause
questionIdSchema accepted any string up to 160 chars with no format restriction.

## Changes
- Added `.regex(/^[a-zA-Z0-9-]+$/, "Question ID must be alphanumeric with dashes only")` to questionIdSchema in learn.validation.ts

Closes #1523
