### PR TITLE
fix: add size bounds to Razorpay transaction verification fields (#1525)

### DIFF
--- a/server/src/module/payment/payment.validation.ts
+++ b/server/src/module/payment/payment.validation.ts
@@ -6,7 +6,7 @@ export const createOrderSchema = z.object({
 });
 
 export const verifyPaymentSchema = z.object({
-  razorpay_order_id: z.string().min(1, "razorpay_order_id is required"),
-  razorpay_payment_id: z.string().min(1, "razorpay_payment_id is required"),
-  razorpay_signature: z.string().min(1, "razorpay_signature is required"),
+  razorpay_order_id: z.string().min(1, "razorpay_order_id is required").max(255),
+  razorpay_payment_id: z.string().min(1, "razorpay_payment_id is required").max(255),
+  razorpay_signature: z.string().min(1, "razorpay_signature is required").max(512),
 });


### PR DESCRIPTION
## What
Add size bounds to Razorpay transaction verification fields to prevent resource exhaustion.

## Root cause
`verifyPaymentSchema` defined `razorpay_order_id`, `razorpay_payment_id`, and `razorpay_signature` with only `.min(1)` and no `.max()` bounds.

## Changes
- Added `.max(255)` to `razorpay_order_id` and `razorpay_payment_id`, `.max(512)` to `razorpay_signature` in `payment.validation.ts`

Closes #1525
