### PR TITLE
fix: prevent salaryMin exceeding salaryMax in job search (#1515)

### DIFF
--- a/server/src/module/job/job.validation.ts
+++ b/server/src/module/job/job.validation.ts
@@ -66,15 +66,20 @@ export const updateJobStatusSchema = z.object({
   status: z.enum(["DRAFT", "PUBLISHED", "CLOSED", "ARCHIVED"]),
 });
 
-export const jobQuerySchema = z.object({
-  page: z.coerce.number().int().positive().default(1),
-  limit: z.coerce.number().int().positive().max(100).default(10),
-  search: z.string().optional(),
-  location: z.string().optional(),
-  company: z.string().optional(),
-  status: z.enum(["DRAFT", "PUBLISHED", "CLOSED", "ARCHIVED"]).optional(),
-  tags: z.string().optional(),
-  includeExpired: coerceBoolean.default(false),
-  salaryMin: z.coerce.number().int().nonnegative().optional(),
-  salaryMax: z.coerce.number().int().nonnegative().optional(),
-});
+export const jobQuerySchema = z
+  .object({
+    page: z.coerce.number().int().positive().default(1),
+    limit: z.coerce.number().int().positive().max(100).default(10),
+    search: z.string().optional(),
+    location: z.string().optional(),
+    company: z.string().optional(),
+    status: z.enum(["DRAFT", "PUBLISHED", "CLOSED", "ARCHIVED"]).optional(),
+    tags: z.string().optional(),
+    includeExpired: coerceBoolean.default(false),
+    salaryMin: z.coerce.number().int().nonnegative().optional(),
+    salaryMax: z.coerce.number().int().nonnegative().optional(),
+  })
+  .refine(
+    (data) => data.salaryMin === undefined || data.salaryMax === undefined || data.salaryMin <= data.salaryMax,
+    { message: "salaryMin must not exceed salaryMax", path: ["salaryMin"] }
+  );


### PR DESCRIPTION
## What
Add cross-validation to ensure salaryMin does not exceed salaryMax in job search queries.

## Root cause
`jobQuerySchema` allowed `salaryMin` greater than `salaryMax` with no validation between the two fields.

## Changes
- Wrapped `jobQuerySchema` in `.refine()` checking `salaryMin <= salaryMax` when both are present

Closes #1515
