### PR TITLE
fix: limit interview year to current year to prevent future placement dates (#1513)

### DIFF
--- a/server/src/module/interview-experience/interview-experience.validation.ts
+++ b/server/src/module/interview-experience/interview-experience.validation.ts
@@ -27,7 +27,7 @@ const createExperienceBaseSchema = z.object({
   companyName: z.string().trim().min(1).max(200).optional(),
   role: z.string().trim().min(2).max(120),
   experienceYears: z.coerce.number().int().min(0).max(30).optional(),
-  interviewYear: z.coerce.number().int().min(2000).max(2100).optional(),
+  interviewYear: z.coerce.number().int().min(2000).max(2026).optional(),
   interviewMonth: z.coerce.number().int().min(1).max(12).optional(),
   source: z.enum(["ON_CAMPUS", "OFF_CAMPUS", "REFERRAL", "LINKEDIN", "PORTAL", "OTHER"]).default("ON_CAMPUS"),
   difficulty: z.enum(["EASY", "MEDIUM", "HARD"]).default("MEDIUM"),

--- a/server/src/module/interview-experience/interview-experience.validation.ts
+++ b/server/src/module/interview-experience/interview-experience.validation.ts
@@ -27,7 +27,7 @@ const createExperienceBaseSchema = z.object({
   companyName: z.string().trim().min(1).max(200).optional(),
   role: z.string().trim().min(2).max(120),
   experienceYears: z.coerce.number().int().min(0).max(30).optional(),
-  interviewYear: z.coerce.number().int().min(2000).max(2026).optional(),
+  interviewYear: z.coerce.number().int().min(2000).max(new Date().getFullYear()).optional(),
   interviewMonth: z.coerce.number().int().min(1).max(12).optional(),
   source: z.enum(["ON_CAMPUS", "OFF_CAMPUS", "REFERRAL", "LINKEDIN", "PORTAL", "OTHER"]).default("ON_CAMPUS"),
   difficulty: z.enum(["EASY", "MEDIUM", "HARD"]).default("MEDIUM"),


### PR DESCRIPTION
## What
Limit interview year to the current year to prevent experiences with future placement dates.

## Root cause
`createExperienceBaseSchema` set `interviewYear.max(2100)`, allowing years far in the future for experiences that cannot have happened yet.

## Changes
- Changed `.max(2100)` to `.max(2026)` on `interviewYear` field

Closes #1513


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated interview experience year validation to accept years up to the current year, ensuring more realistic validation for submitted experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->