### PR TITLE
fix: add max length validation to stipend description field (#1509)

### DIFF
--- a/server/src/module/internship/internship.validation.ts
+++ b/server/src/module/internship/internship.validation.ts
@@ -13,7 +13,7 @@ export const createGovInternshipSchema = z.object({
   timeline: z.string().min(1, "Timeline is required"),
   organizer: z.string().min(1, "Organizer is required"),
   domain: z.string().min(1, "Domain is required"),
-  stipend: z.string().min(1, "Stipend is required"),
+  stipend: z.string().min(1, "Stipend is required").max(500),
   eligibility: z.string().min(1, "Eligibility is required"),
   reality: z.string().min(1, "Reality is required"),
   applyUrl: z.string().url("Must be a valid URL").regex(/^https?:\/\//i, "Must be a valid http(s) URL").optional().nullable(),


### PR DESCRIPTION
## What
Add maximum length validation to the stipend description field.

## Root cause
`createGovInternshipSchema` had `stipend: z.string().min(1, ...)` with no `.max()` bound, allowing arbitrarily long stipend descriptions.

## Changes
- Added `.max(500)` to the stipend field in `internship.validation.ts`

Closes #1509


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stipend input fields now have a maximum character limit of 500 characters to prevent oversized entries and ensure data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->