### PR TITLE
docs: move Table of Contents above About section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 **Prepare. Practice. Placed.**
 
+## Table of Contents 📑
+
+- [About InternHack](#about-internhack)
+- [Tech Stack](#tech-stack)
+- [Features](#features)
+- [Getting Started](#getting-started)
+- [Environment Variables](#environment-variables)
+- [Project Structure](#project-structure)
+- [API Overview](#api-overview)
+- [Production Build](#production-build)
+- [Contributing](#contributing)
+- [Contributors](#contributors)
+- [Project Support](#project-support)
+- [License](#license)
+
 ## About InternHack
 - AI-powered career and hiring platform
 - Helps students prepare for placements and internships


### PR DESCRIPTION
# Pull Request

## Description
Reordered sections in README.md by moving the Table of Contents above 
the About section. This follows standard open-source documentation 
conventions, where the Table of Contents appears at the top for easier navigation.

## Related Issue
Fixes #

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ x ] Documentation  

## Testing
No testing required — documentation-only change.

## Screenshots / Video
_No UI changes in this PR_ (delete this line if you are making UI changes)

## Checklist
- [ x ] Code follows project guidelines
- [ x ] No new compile/type errors
- [ ] Tested manually (include steps above)
- [ ] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [ ] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Table of Contents section to the README with anchor links providing quick navigation to major sections including About, Tech Stack, Features, Getting Started, Environment Variables, Project Structure, API Overview, Production Build, Contributing, Contributors, Project Support, and License.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->