### PR TITLE
fix: reject duplicate filenames in LaTeX supporting files (#1521)

### DIFF
--- a/server/src/module/latex/latex.validation.ts
+++ b/server/src/module/latex/latex.validation.ts
@@ -15,6 +15,12 @@ export const compileLatexSchema = z.object({
     .min(10, "LaTeX source too short")
     .max(200000, "LaTeX source too large (200KB max)"),
   supportingFiles: z.array(supportingFileSchema).max(5).optional().default([]),
-});
+}).refine(
+  (data) => {
+    const filenames = (data.supportingFiles ?? []).map(f => f.filename);
+    return new Set(filenames).size === filenames.length;
+  },
+  { message: "Duplicate filenames in supporting files are not allowed", path: ["supportingFiles"] }
+);
 
 export type CompileLatexInput = z.infer<typeof compileLatexSchema>;


### PR DESCRIPTION
## What
Reject duplicate filenames in LaTeX supporting files array.

## Root cause
`compileLatexSchema` accepted an array of `supportingFiles` without checking for filename duplicates.

## Changes
- Added `.refine()` to `compileLatexSchema` verifying all filenames in `supportingFiles` are unique

Closes #1521


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent duplicate filenames in supporting files during LaTeX compilation. Invalid submissions with duplicate filenames will now be rejected with a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->