### PR TITLE
fix: add receipt attachment limit to reimbursement schemas (#1493)

### DIFF
--- a/server/src/module/reimbursement/reimbursement.validation.ts
+++ b/server/src/module/reimbursement/reimbursement.validation.ts
@@ -6,14 +6,14 @@ export const createReimbursementSchema = z.object({
   amount: z.number().positive(),
   currency: z.string().max(10).default("INR"),
   description: z.string().min(1).max(1000),
-  receiptUrls: z.array(z.string().url()).default([]),
+  receiptUrls: z.array(z.string().url()).max(10).default([]),
 });
 
 export const updateReimbursementSchema = z.object({
   category: z.string().min(1).max(100).optional(),
   amount: z.number().positive().optional(),
   description: z.string().min(1).max(1000).optional(),
-  receiptUrls: z.array(z.string().url()).optional(),
+  receiptUrls: z.array(z.string().url()).max(10).optional(),
 });
 
 export const approveReimbursementSchema = z.object({


### PR DESCRIPTION
## What
Add maximum receipt attachment limit to reimbursement schemas.

## Root cause
`createReimbursementSchema` and `updateReimbursementSchema` had `receiptUrls` arrays with no `.max()` limit, allowing unlimited attachments.

## Changes
- Added `.max(10)` to `receiptUrls` in both `createReimbursementSchema` and `updateReimbursementSchema`

Closes #1493
