### PR TITLE
fix: enforce non-negative face violation duration in proctor log (#1491)

### DIFF
--- a/server/src/module/skill-test/skill-test.validation.ts
+++ b/server/src/module/skill-test/skill-test.validation.ts
@@ -20,7 +20,7 @@ export const submitTestSchema = z.object({
       faceViolations: z.array(z.object({
         type: z.enum(["NO_FACE", "MULTIPLE_FACES"]),
         timestamp: z.string(),
-        duration: z.number().optional(),
+        duration: z.number().min(0).optional(),
       })).default([]),
       warnings: z.array(z.any()).default([]),
       terminated: z.boolean().default(false),


### PR DESCRIPTION
## What
Enforce non-negative face violation duration in proctor log schema.

## Root cause
`submitTestSchema.proctorLog.faceViolations[].duration` was `z.number().optional()` with no `.min(0)` bound, allowing negative duration values.

## Changes
- Added `.min(0)` to the `duration` field in face violation object

Closes #1491
