### PR TITLE
fix: add items and string length validation limits to job-feed preferences (#1519)

### DIFF
--- a/server/src/module/job-feed/job-feed.validation.ts
+++ b/server/src/module/job-feed/job-feed.validation.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 
 export const updatePreferencesSchema = z.object({
-  desiredRoles: z.array(z.string()).optional(),
-  desiredSkills: z.array(z.string()).optional(),
-  desiredLocations: z.array(z.string()).optional(),
+  desiredRoles: z.array(z.string().min(1).max(100)).max(20).optional(),
+  desiredSkills: z.array(z.string().min(1).max(100)).max(20).optional(),
+  desiredLocations: z.array(z.string().min(1).max(100)).max(20).optional(),
   minSalary: z.number().int().positive().nullable().optional(),
-  workMode: z.array(z.enum(["REMOTE", "HYBRID", "ONSITE"])).optional(),
-  experienceLevel: z.array(z.enum(["INTERN", "ENTRY", "MID", "SENIOR"])).optional(),
-  domains: z.array(z.string()).optional(),
+  workMode: z.array(z.enum(["REMOTE", "HYBRID", "ONSITE"])).max(5).optional(),
+  experienceLevel: z.array(z.enum(["INTERN", "ENTRY", "MID", "SENIOR"])).max(4).optional(),
+  domains: z.array(z.string().min(1).max(100)).max(20).optional(),
 });
 
 export const feedQuerySchema = z.object({


### PR DESCRIPTION
## What
Add items and string length validation limits to job-feed preference update fields.

## Root cause
`updatePreferencesSchema` had array fields (`desiredRoles`, `desiredSkills`, `desiredLocations`, `domains`) as bare `z.array(z.string()).optional()` with no item length bounds or array size limits.

## Changes
- Added `.min(1).max(100)` to string items in all text arrays
- Added `.max(20)` to text array sizes
- Added `.max(5)` to `workMode` and `.max(4)` to `experienceLevel`

Closes #1519
