### PR TITLE
fix: add size limits to email inbound webhook inputs (#1505)

### DIFF
--- a/server/src/module/email-inbound/email-inbound.validation.ts
+++ b/server/src/module/email-inbound/email-inbound.validation.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 
 export const inboundWebhookSchema = z.object({
-  type: z.string(),
+  type: z.string().max(100),
   data: z.object({
-    from: z.string().optional(),
-    subject: z.string().optional(),
-    text: z.string().optional(),
-    html: z.string().optional(),
-    to: z.union([z.string(), z.array(z.string())]).optional(),
-    cc: z.union([z.string(), z.array(z.string())]).optional(),
+    from: z.string().max(500).optional(),
+    subject: z.string().max(1000).optional(),
+    text: z.string().max(100000).optional(),
+    html: z.string().max(500000).optional(),
+    to: z.union([z.string().max(500), z.array(z.string().max(500)).max(50)]).optional(),
+    cc: z.union([z.string().max(500), z.array(z.string().max(500)).max(50)]).optional(),
   }).passthrough(),
 });


### PR DESCRIPTION
## What
Add size limits to email inbound webhook inputs to prevent DOS attacks.

## Root cause
`inboundWebhookSchema` had fields like `type`, `from`, `subject`, `text`, `html`, `to`, `cc` with no `.max()` bounds, allowing arbitrarily large payloads.

## Changes
- Added `.max()` bounds to all string fields and array limits in `inboundWebhookSchema`

Closes #1505
