### PR TITLE
fix: reject empty changes object in company edit suggestions (#1501)

### DIFF
--- a/server/src/module/company/company.validation.ts
+++ b/server/src/module/company/company.validation.ts
@@ -41,6 +41,8 @@ export const contributeCompanySchema = z.object({
 export const suggestEditSchema = z.object({
   changes: z.record(z.string(), z.unknown()),
   reason: z.string().min(1).max(1000),
+}).refine((data) => Object.keys(data.changes).length > 0, {
+  message: "At least one change must be provided",
 });
 
 export const addContactSchema = z.object({


### PR DESCRIPTION
## What
Reject empty changes object in company edit suggestions.

## Root cause
`suggestEditSchema` accepted `changes: z.record(z.string(), z.unknown())` with no check that at least one change is provided.

## Changes
- Added `.refine()` to `suggestEditSchema` verifying the changes object is non-empty

Closes #1501
