### PR TITLE
fix: increase contact message minimum length for spam protection (#1503)

### DIFF
--- a/server/src/module/contact/contact.validation.ts
+++ b/server/src/module/contact/contact.validation.ts
@@ -4,7 +4,7 @@ export const contactSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
   email: z.string().email("Invalid email address"),
   subject: z.string().min(1, "Subject is required").max(200),
-  message: z.string().min(1, "Message is required").max(5000),
+  message: z.string().min(20, "Message must be at least 20 characters").max(5000),
 });
 
 export type ContactInput = z.infer<typeof contactSchema>;


### PR DESCRIPTION
## What
Increase minimum message length to prevent spam submissions.

## Root cause
`contactSchema` allowed messages as short as 1 character (`min(1)`), offering no spam protection.

## Changes
- Changed `min(1)` to `min(20)` on the message field

Closes #1503
