### PR TITLE
fix: prevent future dates in attendance regularization (#1495)

### DIFF
--- a/server/src/module/attendance/attendance.validation.ts
+++ b/server/src/module/attendance/attendance.validation.ts
@@ -16,6 +16,8 @@ export const regularizeSchema = z.object({
   checkIn: z.string().datetime(),
   checkOut: z.string().datetime(),
   notes: z.string().min(1, "Reason for regularization is required").max(500),
+}).refine((data) => new Date(data.date) <= new Date(), {
+  message: "Date must not be in the future",
 });
 
 export const attendanceQuerySchema = z.object({


### PR DESCRIPTION
## What
Prevent future dates in attendance regularization.

## Root cause
`regularizeSchema` accepted any datetime for `date` with no check against the current time.

## Changes
- Added `.refine()` to `regularizeSchema` enforcing `date <= now()`

Closes #1495
