### PR TITLE
fix: validate review goals weight sum does not exceed 100% (#1486)

### DIFF
--- a/server/src/module/performance/performance.validation.ts
+++ b/server/src/module/performance/performance.validation.ts
@@ -11,7 +11,10 @@ export const createReviewSchema = z.object({
     achieved: z.string().optional(),
     weight: z.number().min(0).max(100).optional(),
   })).default([]),
-});
+}).refine((data) => {
+  const sum = data.goals.reduce((acc, g) => acc + (g.weight ?? 0), 0);
+  return sum <= 100;
+}, { message: "Sum of goal weights must not exceed 100%" });
 
 export const updateReviewSchema = z.object({
   selfRating: z.number().min(1).max(5).optional(),
@@ -28,7 +31,11 @@ export const updateReviewSchema = z.object({
   strengths: z.string().max(1000).optional(),
   improvements: z.string().max(1000).optional(),
   promotionRecommended: z.boolean().optional(),
-});
+}).refine((data) => {
+  if (!data.goals) return true;
+  const sum = data.goals.reduce((acc, g) => acc + (g.weight ?? 0), 0);
+  return sum <= 100;
+}, { message: "Sum of goal weights must not exceed 100%" });
 
 export const submitReviewSchema = z.object({
   status: z.enum(["SELF_REVIEW", "MANAGER_REVIEW", "CALIBRATION", "COMPLETED"]),


### PR DESCRIPTION
## What
Validate that review goals weight sum does not exceed 100%.

## Root cause
`createReviewSchema` and `updateReviewSchema` accepted individual goal weights up to 100% each with no check on the total sum.

## Changes
- Added `.refine()` to both schemas enforcing `sum(weights) <= 100`

Closes #1486
