### PR TITLE
fix: handle badge slug collision with retry instead of crash (#1488)

### DIFF
--- a/server/src/module/badge/badge.service.ts
+++ b/server/src/module/badge/badge.service.ts
@@ -52,24 +52,40 @@ export class BadgeService {
 
   async createBadge(input: CreateBadgeInput) {
     let slug = input.slug || slugify(input.name);
-    const existing = await prisma.badge.findUnique({ where: { slug } });
-    if (existing) {
-      slug = `${slug}-${Date.now()}`;
-    }
 
-    const created = await prisma.badge.create({
-      data: {
-        name: input.name,
-        slug,
-        description: input.description,
-        iconUrl: input.iconUrl || null,
-        category: input.category,
-        criteria: JSON.parse(JSON.stringify(input.criteria)) as Prisma.InputJsonValue,
-        isActive: input.isActive ?? true,
-      },
-    });
-    await cacheDel(BADGES_CACHE_KEY);
-    return created;
+    try {
+      const created = await prisma.badge.create({
+        data: {
+          name: input.name,
+          slug,
+          description: input.description,
+          iconUrl: input.iconUrl || null,
+          category: input.category,
+          criteria: JSON.parse(JSON.stringify(input.criteria)) as Prisma.InputJsonValue,
+          isActive: input.isActive ?? true,
+        },
+      });
+      await cacheDel(BADGES_CACHE_KEY);
+      return created;
+    } catch (error: any) {
+      if (error.code === "P2002") {
+        slug = `${slug}-${Date.now()}`;
+        const created = await prisma.badge.create({
+          data: {
+            name: input.name,
+            slug,
+            description: input.description,
+            iconUrl: input.iconUrl || null,
+            category: input.category,
+            criteria: JSON.parse(JSON.stringify(input.criteria)) as Prisma.InputJsonValue,
+            isActive: input.isActive ?? true,
+          },
+        });
+        await cacheDel(BADGES_CACHE_KEY);
+        return created;
+      }
+      throw error;
+    }
   }
 
   async updateBadge(id: number, input: UpdateBadgeInput) {
@@ -92,9 +108,19 @@ export class BadgeService {
     }
     if (input.isActive !== undefined) data.isActive = input.isActive;
 
-    const updated = await prisma.badge.update({ where: { id }, data });
-    await cacheDel(BADGES_CACHE_KEY);
-    return updated;
+    try {
+      const updated = await prisma.badge.update({ where: { id }, data });
+      await cacheDel(BADGES_CACHE_KEY);
+      return updated;
+    } catch (error: any) {
+      if (error.code === "P2002" && data.slug) {
+        data.slug = `${data.slug}-${Date.now()}`;
+        const updated = await prisma.badge.update({ where: { id }, data });
+        await cacheDel(BADGES_CACHE_KEY);
+        return updated;
+      }
+      throw error;
+    }
   }
 
   async deleteBadge(id: number) {


### PR DESCRIPTION
## What\nHandle unique slug collisions in badge create/update with retry instead of crashing.\n\n## Root cause\n\createBadge\ and \updateBadge\ had a race condition between slug existence check and DB write, causing unhandled Prisma P2002 unique constraint errors under concurrent requests.\n\n## Changes\n- Wrapped \prisma.badge.create\ in try/catch with \-\\ retry on P2002\n- Wrapped \prisma.badge.update\ in try/catch with same retry logic\n\nCloses #1488