### PR TITLE
fix: prevent JSON parse crash on workflow definition steps and history (#1476)

### DIFF
--- a/server/src/module/workflow/workflow.service.ts
+++ b/server/src/module/workflow/workflow.service.ts
@@ -129,8 +129,14 @@ export class WorkflowService {
       validatedPerformedBy = performedBy;
     }
 
-    const steps = JSON.parse(instance.definition.steps as string) as unknown[];
-    const history = JSON.parse(instance.stepHistory as string) as StepHistoryEntry[];
+    let steps: unknown[];
+    let history: StepHistoryEntry[];
+    try {
+      steps = JSON.parse(instance.definition.steps as string) as unknown[];
+      history = JSON.parse(instance.stepHistory as string) as StepHistoryEntry[];
+    } catch {
+      throw new Error("Invalid workflow data: failed to parse definition steps or history");
+    }
 
     history.push({
       step: instance.currentStep,


### PR DESCRIPTION
## What\nPrevent unhandled crash when parsing workflow JSON data.\n\n## Root cause\n\dvanceStep\ called \JSON.parse()\ on \definition.steps\ and \stepHistory\ without try/catch, causing unhandled crashes if stored data is corrupted.\n\n## Changes\n- Wrapped both \JSON.parse\ calls in try/catch with descriptive error message\n\nCloses #1476