### PR TITLE
fix: align password reset strength requirements with registration (#1327)

### DIFF
--- a/server/src/module/auth/auth.validation.ts
+++ b/server/src/module/auth/auth.validation.ts
@@ -115,7 +115,14 @@ export const forgotPasswordSchema = z.object({
 export const resetPasswordSchema = z.object({
   email: z.string().email("Invalid email address"),
   otp: z.string().min(1, "OTP is required"),
-  newPassword: z.string().min(6, "Password must be at least 6 characters"),
+  newPassword: z
+    .string()
+    .min(8, "Password must be at least 8 characters")
+    .max(128, "Password must not exceed 128 characters")
+    .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
+    .regex(/[a-z]/, "Password must contain at least one lowercase letter")
+    .regex(/[0-9]/, "Password must contain at least one number")
+    .regex(/[\W_]/, "Password must contain at least one special character"),
 });
 
 export const verifyEmailSchema = z.object({


### PR DESCRIPTION
## What\nMatch password reset strength requirements to registration requirements.\n\n## Root cause\n\esetPasswordSchema\ required only 6 characters with no complexity rules, while \egisterSchema\ required 8+ characters with uppercase, lowercase, number, and special character rules.\n\n## Changes\n- Updated \esetPasswordSchema.newPassword\ to use same constraints as registration (min 8, uppercase, lowercase, number, special)\n\nCloses #1327