### PR TITLE
fix: prevent negative work hours in attendance check-out (#1337)

### DIFF
--- a/server/src/module/attendance/attendance.service.ts
+++ b/server/src/module/attendance/attendance.service.ts
@@ -59,6 +59,9 @@ export class AttendanceService {
 
     const now = new Date();
     const workHours = (now.getTime() - record.checkIn.getTime()) / 3600000;
+    if (workHours < 0) {
+      throw new Error("Check-out time cannot be before check-in time");
+    }
     const standardHours = 8;
     const overtime = Math.max(0, workHours - standardHours);
     const status: AttendanceStatus = workHours < 4 ? "HALF_DAY" : "PRESENT";


### PR DESCRIPTION
## What\nPrevent negative work hours when check-out is before check-in.\n\n## Root cause\n\checkOut\ calculated \workHours = now - checkIn\ without validating that check-out is after check-in, producing negative work hours on clock skew.\n\n## Changes\n- Added validation in \checkOut\ that throws if work hours are negative\n\nCloses #1337