### PR TITLE
fix: skip slug regeneration when blog title has not changed (#1499)

### DIFF
--- a/server/src/module/blog/blog.service.ts
+++ b/server/src/module/blog/blog.service.ts
@@ -213,7 +213,9 @@ export class BlogService {
 
     if (data.title !== undefined) {
       updateData.title = data.title;
-      updateData.slug = await this.generateSlug(data.title);
+      if (data.title !== existing.title) {
+        updateData.slug = await this.generateSlug(data.title);
+      }
     }
 
     if (data.content !== undefined) {


### PR DESCRIPTION
## What\nPrevent unnecessary slug regeneration with timestamp when post title hasn't changed.\n\n## Root cause\n\update()\ called \generateSlug(data.title)\ every time \data.title\ was provided, even if the title was unchanged. \generateSlug\ appends \-\\ on collision detection, causing the slug to change on every update call.\n\n## Changes\n- Added check \if (data.title !== existing.title)\ before regenerating slug\n\nCloses #1499