### PR TITLE
fix(recruiter): add composite index to savedCandidate model

### DIFF
--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -982,7 +982,7 @@ model savedCandidate {
   student     user     @relation("StudentSavedByRecruiters", fields: [studentId], references: [id], onDelete: Cascade)
 
   @@unique([recruiterId, studentId])
-  @@index([recruiterId])
+  @@index([recruiterId, studentId])
   @@index([studentId])
 }
 


### PR DESCRIPTION
# Pull Request

## Description
This PR addresses an issue where checking whether a candidate is saved by a recruiter resulted in a full-table scan due to the lack of an explicit composite index. 

Added `@@index([recruiterId, studentId])` to the `savedCandidate` model in `base.prisma` to ensure index-backed fast lookups when querying a specific saved candidate for a given recruiter.

## Related Issue
Fixes #1197

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing
- Verified `npx prisma generate` completes without issues.
- Synchronized database using `npx prisma db push` to ensure the composite index is correctly applied to the Postgres database.

## Screenshots / Video



## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database indexes to improve query performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->