### PR TITLE
feat: add dark mode OG images for guide and repo pages (#1030)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -57,7 +57,7 @@
       name="twitter:description"
       content="Browse curated internships, score your resume with AI-powered ATS analysis, follow guided career roadmaps, and connect with recruiters."
     />
-    <meta name="twitter:image" content="https://www.internhack.xyz/og-image.png" />
+    <meta name="twitter:image" content="https://www.internhack.xyz/og-image-dark.png" />
     <meta name="twitter:image:alt" content="InternHack, AI-powered career platform for students" />
 
     <!-- NOTE: Per-route canonical is injected at runtime by the <SEO> component

--- a/client/scripts/generate-og-image-dark.mjs
+++ b/client/scripts/generate-og-image-dark.mjs
@@ -1,0 +1,157 @@
+/**
+ * Generate dark OG image (1200x630) for social media sharing (Discord fallback).
+ *
+ * Dark variant: stone-950 background, white text, lime accent.
+ * Uses Puppeteer to render an HTML template and screenshot it.
+ * Run: node scripts/generate-og-image-dark.mjs
+ *
+ * Requires: npm i -D puppeteer (already added for prerendering)
+ */
+
+import puppeteer from "puppeteer";
+import { writeFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT = join(__dirname, "..", "public", "og-image-dark.png");
+
+const HTML = /* html */ `
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      width: 1200px;
+      height: 630px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #0c0a09;
+      font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+      overflow: hidden;
+      position: relative;
+    }
+    .orb {
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(80px);
+      opacity: 0.25;
+    }
+    .orb-1 { width: 400px; height: 400px; top: -100px; right: -80px; background: #84cc16; }
+    .orb-2 { width: 350px; height: 350px; bottom: -80px; left: -60px; background: #65a30d; }
+    .content {
+      position: relative;
+      z-index: 1;
+      text-align: center;
+      padding: 0 80px;
+    }
+    .logo-row {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 16px;
+      margin-bottom: 32px;
+    }
+    .logo-box {
+      width: 64px;
+      height: 64px;
+      background: #1c1917;
+      border: 2px solid #292524;
+      border-radius: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .logo-text {
+      font-size: 28px;
+      font-weight: 800;
+      color: white;
+      letter-spacing: -0.02em;
+    }
+    .logo-text span { color: #84cc16; }
+    .brand {
+      font-size: 32px;
+      font-weight: 700;
+      color: white;
+      letter-spacing: -0.02em;
+    }
+    h1 {
+      font-size: 56px;
+      font-weight: 800;
+      color: white;
+      line-height: 1.1;
+      letter-spacing: -0.03em;
+      margin-bottom: 20px;
+    }
+    h1 em {
+      font-style: normal;
+      background: linear-gradient(135deg, #84cc16, #a3e635);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .sub {
+      font-size: 22px;
+      color: #a8a29e;
+      line-height: 1.5;
+      max-width: 700px;
+      margin: 0 auto;
+    }
+    .tags {
+      margin-top: 28px;
+      display: flex;
+      gap: 12px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+    .tag {
+      padding: 8px 18px;
+      background: rgba(132,204,22,0.15);
+      border: 1px solid rgba(132,204,22,0.3);
+      border-radius: 8px;
+      color: #a3e635;
+      font-size: 14px;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <div class="orb orb-1"></div>
+  <div class="orb orb-2"></div>
+  <div class="content">
+    <div class="logo-row">
+      <div class="logo-box">
+        <span class="logo-text">I<span>H</span></span>
+      </div>
+      <span class="brand">InternHack</span>
+    </div>
+    <h1>AI-Powered Internship &<br/><em>Career Platform for Students</em></h1>
+    <p class="sub">Score your resume with AI, browse curated internships,<br/>learn to code, and connect with top recruiters.</p>
+    <div class="tags">
+      <span class="tag">AI ATS Scorer</span>
+      <span class="tag">Resume Builder</span>
+      <span class="tag">Coding Tutorials</span>
+      <span class="tag">DSA Practice</span>
+      <span class="tag">Job Board</span>
+    </div>
+  </div>
+</body>
+</html>
+`;
+
+async function main() {
+  const browser = await puppeteer.launch({ headless: true, args: ["--no-sandbox"] });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 630 });
+  await page.setContent(HTML, { waitUntil: "networkidle0" });
+  const buffer = await page.screenshot({ type: "png" });
+  writeFileSync(OUTPUT, buffer);
+  await browser.close();
+  console.log(`Dark OG image saved to ${OUTPUT}`);
+}
+
+main().catch((err) => {
+  console.error("Failed to generate dark OG image:", err);
+  process.exit(1);
+});

--- a/client/src/components/SEO.tsx
+++ b/client/src/components/SEO.tsx
@@ -9,6 +9,8 @@ interface SEOProps {
   keywords?: string;
   canonicalUrl?: string;
   ogImage?: string;
+  /** Dark-mode OG image used for twitter:image (Discord fallback). Defaults to /og-image-dark.png. */
+  ogImageDark?: string;
   ogType?: string;
   noIndex?: boolean;
   structuredData?: Record<string, unknown> | Record<string, unknown>[];
@@ -18,12 +20,14 @@ const SITE_NAME = "InternHack";
 const DEFAULT_DESCRIPTION =
   "InternHack is an AI-powered career platform for students. Browse curated internships, score your resume with ATS AI, follow career roadmaps, and connect directly with recruiters.";
 const DEFAULT_OG_IMAGE = `${SITE_URL}/og-image.png`;
+const DEFAULT_OG_IMAGE_DARK = `${SITE_URL}/og-image-dark.png`;
 
 export function SEO({
   title,
   description = DEFAULT_DESCRIPTION,
   canonicalUrl,
   ogImage = DEFAULT_OG_IMAGE,
+  ogImageDark = DEFAULT_OG_IMAGE_DARK,
   ogType = "website",
   noIndex = false,
   structuredData,
@@ -32,6 +36,7 @@ export function SEO({
   const fullTitle = title ? `${title} | ${SITE_NAME}` : `${SITE_NAME} - AI-Powered Career Platform for Students`;
   const effectiveCanonical = canonicalUrl || `${SITE_URL}${pathname}`;
   const absoluteOgImage = ogImage.startsWith("http") ? ogImage : `${SITE_URL}${ogImage}`;
+  const absoluteOgImageDark = ogImageDark.startsWith("http") ? ogImageDark : `${SITE_URL}${ogImageDark}`;
 
   return (
     <Helmet>
@@ -54,7 +59,7 @@ export function SEO({
       <meta name="twitter:url" content={effectiveCanonical} />
       <meta name="twitter:title" content={fullTitle} />
       <meta name="twitter:description" content={description} />
-      <meta name="twitter:image" content={absoluteOgImage} />
+      <meta name="twitter:image" content={absoluteOgImageDark} />
 
       {/* Canonical URL */}
       <link rel="canonical" href={effectiveCanonical} />

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -15,7 +15,7 @@
       "source": "/sitemap.xml",
       "destination": "https://api.internhack.xyz/sitemap.xml"
     },
-    { "source": "/((?!sitemap\\.xml|robots\\.txt|llms\\.txt|manifest\\.webmanifest|favicon\\.png|og-image\\.png|.*\\.(?:js|css|woff2?|ttf|otf|png|jpg|jpeg|webp|avif|svg|ico|map|json|txt|xml)).*)", "destination": "/index.html" }
+    { "source": "/((?!sitemap\\.xml|robots\\.txt|llms\\.txt|manifest\\.webmanifest|favicon\\.png|og-image\\.png|og-image-dark\\.png|.*\\.(?:js|css|woff2?|ttf|otf|png|jpg|jpeg|webp|avif|svg|ico|map|json|txt|xml)).*)", "destination": "/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
## What

Adds light + dark OG image variants for social sharing, wiring the dark variant to twitter:image as Discord fallback.

## Root cause

All pages used a single light OG image — Discord link previews had no dark variant for users on dark mode.

## Changes

- client/scripts/generate-og-image-dark.mjs — new Puppeteer-based dark OG image with stone-950 background, white text, lime accent
- client/src/components/SEO.tsx — added ogImageDark prop, defaults to /og-image-dark.png, wired to twitter:image meta tag
- client/index.html — twitter:image points to og-image-dark.png
- client/vercel.json — excluded og-image-dark.png from SPA catch-all rewrite

## Verification

- [ ] Confirmed feature missing before starting — all pages used single og-image.png
- [ ] Feature verified locally — og-image-dark.png generates correctly via puppeteer
- [ ] git diff upstream/main...HEAD --stat shows only intended files
- [ ] No console.logs or debug logs remaining

## CI failures (if any)

[remove if CI green]

## Before / After

Backend only — no UI changes

Closes #1030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark-mode Open Graph image variant for improved social media sharing previews with dark-themed backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->