### PR TITLE
feat: roadmap pace dashboard with per-card pace status and batch analytics (#1052)

### DIFF
--- a/client/src/module/student/roadmap/RoadmapDashboardPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapDashboardPage.tsx
@@ -11,12 +11,14 @@ import {
   Loader2,
   X,
   Zap,
+  AlertTriangle,
+  CheckCircle2,
 } from "lucide-react";
 import { SEO } from "../../../components/SEO";
 import { Button } from "../../../components/ui/button";
 import api from "../../../lib/axios";
 import toast from "../../../components/ui/toast";
-import type { RoadmapEnrollmentListItem } from "../../../lib/types";
+import type { RoadmapEnrollmentListItem, RoadmapEnrollmentAnalytics } from "../../../lib/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "../../../lib/query-keys";
 import {
@@ -60,6 +62,19 @@ export default function RoadmapDashboardPage() {
   });
 
   const enrollments = data?.enrollments || [];
+
+  const { data: batchAnalytics } = useQuery({
+    queryKey: [...queryKeys.roadmaps.enrollments(), "analytics-batch"],
+    queryFn: () =>
+      api
+        .get<{ analytics: RoadmapEnrollmentAnalytics[] }>("/roadmaps/me/enrollments/analytics/batch")
+        .then((r) => r.data),
+    staleTime: 5 * 60 * 1000,
+    enabled: enrollments.length > 0,
+  });
+  const analyticsMap = new Map(
+    (batchAnalytics?.analytics ?? []).map((a) => [a.enrollmentId, a]),
+  );
 
   const downloadPdf = async (id: number, slug: string) => {
     setDownloadingId(id);
@@ -240,6 +255,15 @@ export default function RoadmapDashboardPage() {
               e.roadmap.topicCount === 0
                 ? 0
                 : Math.round((completed / e.roadmap.topicCount) * 100);
+            const pace = analyticsMap.get(e.id);
+            const paceLabel =
+              pace?.onTrackStatus === "AHEAD"
+                ? { label: "Ahead", icon: CheckCircle2, cls: "text-emerald-600 dark:text-emerald-400" }
+                : pace?.onTrackStatus === "ON_TRACK"
+                  ? { label: "On Track", icon: CheckCircle2, cls: "text-lime-600 dark:text-lime-400" }
+                  : pace?.onTrackStatus === "BEHIND"
+                    ? { label: "Behind", icon: AlertTriangle, cls: "text-amber-600 dark:text-amber-400" }
+                    : null;
             return (
               <motion.article
                 key={e.id}
@@ -253,6 +277,12 @@ export default function RoadmapDashboardPage() {
                   <h2 className="text-lg font-bold text-gray-950 dark:text-white">
                     {e.roadmap.title}
                   </h2>
+                  {paceLabel && (
+                    <span className={`inline-flex items-center gap-1 text-xs font-mono font-bold shrink-0 ${paceLabel.cls}`}>
+                      <paceLabel.icon className="w-3.5 h-3.5" />
+                      {paceLabel.label}
+                    </span>
+                  )}
                 </div>
                 <p className="text-sm text-gray-500 dark:text-gray-400 line-clamp-2 mb-4">
                   {e.roadmap.shortDescription}
@@ -303,6 +333,19 @@ export default function RoadmapDashboardPage() {
                     <BookOpen className="w-3.5 h-3.5" aria-hidden="true" />{" "}
                     {e.roadmap.estimatedHours}h total
                   </span>
+                  {pace && (
+                    <>
+                      <span className="inline-flex items-center gap-1">
+                        <Zap className="w-3.5 h-3.5" aria-hidden="true" />{" "}
+                        {pace.topicsCompletedThisWeek}/{pace.weeklyTarget} this week
+                      </span>
+                      {pace.estimatedCompletionDate && (
+                        <span className="text-[10px] text-gray-400">
+                          Est. {new Date(pace.estimatedCompletionDate).toLocaleDateString("en-IN", { day: "numeric", month: "short" })}
+                        </span>
+                      )}
+                    </>
+                  )}
                 </div>
 
                 <div className="flex items-center gap-2">

--- a/server/src/module/roadmap/roadmap.controller.ts
+++ b/server/src/module/roadmap/roadmap.controller.ts
@@ -335,6 +335,23 @@ export async function getMyEnrollmentAnalytics(req: Request, res: Response, next
   }
 }
 
+export async function getMyEnrollmentsAnalyticsBatch(req: Request, res: Response, next: NextFunction) {
+  try {
+    const enrollments = await listEnrollmentsForUser(req.user!.id);
+    const analytics = await Promise.all(
+      enrollments.map((e) =>
+        getEnrollmentAnalyticsForUser({
+          userId: req.user!.id,
+          enrollmentId: e.id,
+        }),
+      ),
+    );
+    res.json({ analytics: analytics.filter(Boolean) });
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function deleteMyEnrollment(req: Request, res: Response, next: NextFunction) {
   try {
     const params = enrollmentIdParam.safeParse(req.params);

--- a/server/src/module/roadmap/roadmap.routes.ts
+++ b/server/src/module/roadmap/roadmap.routes.ts
@@ -11,6 +11,7 @@ import {
   getMyEnrollment,
   deleteMyEnrollment,
   getMyEnrollments,
+  getMyEnrollmentsAnalyticsBatch,
   getRoadmap,
   getRoadmaps,
   getTopic,
@@ -26,6 +27,7 @@ export const roadmapRouter = Router();
 
 roadmapRouter.post("/ai/generate", authMiddleware, aiRoadmapLimiter, postAiGenerate);
 roadmapRouter.get("/me/enrollments", authMiddleware, getMyEnrollments);
+roadmapRouter.get("/me/enrollments/analytics/batch", authMiddleware, getMyEnrollmentsAnalyticsBatch);
 roadmapRouter.get("/me/enrollments/:id/analytics", authMiddleware, getMyEnrollmentAnalytics);
 roadmapRouter.get("/me/enrollments/:id", authMiddleware, getMyEnrollment);
 roadmapRouter.delete("/me/enrollments/:id", authMiddleware, deleteMyEnrollment);


### PR DESCRIPTION
﻿## What
Adds pace tracking to the roadmap dashboard showing per-card status (Ahead/On Track/Behind), weekly progress, and estimated completion date.

## Why
Students set a pace on enrollment but the dashboard never showed if they're falling behind. This helps students stay accountable and recalibrate early.

## Changes
- server/src/module/roadmap/roadmap.service.ts — New batch analytics function (uses existing analytics logic for all enrollments)
- server/src/module/roadmap/roadmap.controller.ts — New controller endpoint for batch analytics
- server/src/module/roadmap/roadmap.routes.ts — New route GET /roadmaps/me/enrollments/analytics/batch
- client/src/module/student/roadmap/RoadmapDashboardPage.tsx — Fetches batch analytics, displays pace status badge (Ahead/On Track/Behind), weekly topic completion progress, and estimated completion date on each roadmap card

## Verification
- [ ] Feature implemented and tested locally
- [ ] No unrelated files changed
- [ ] Follows existing code patterns

## Screenshots
N/A

Closes #1052
