### PR TITLE
feat: DSA streak tracker with flame widget, 7-day mini calendar, and milestone badges (#1047)

### DIFF
--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -232,6 +232,7 @@ export const queryKeys = {
     sheets: () => ["dsa", "sheets"] as const,
     submissions: (problemId: number) => ["dsa", "submissions", problemId] as const,
     importStatus: () => ["dsa", "import-status"] as const,
+    streak: () => ["dsa", "streak"] as const,
     activity: (year: number) => ["dsa", "activity", year] as const,
     similar: (id: number) => ["dsa", "similar", id] as const,
   },

--- a/client/src/lib/types/learning.types.ts
+++ b/client/src/lib/types/learning.types.ts
@@ -192,6 +192,14 @@ export interface DsaCodeReview {
   suggestions: string[];
 }
 
+export interface DsaStreak {
+  currentStreak: number;
+  longestStreak: number;
+  solvedToday: boolean;
+  lastSolvedDate: string | null;
+  activeDays: string[];
+}
+
 export interface DsaSubmissionSummary {
   id: number;
   language: DsaLanguage;

--- a/client/src/module/student/dsa/DsaTopicsPage.tsx
+++ b/client/src/module/student/dsa/DsaTopicsPage.tsx
@@ -19,6 +19,7 @@ import { LoginGate } from "../../../components/LoginGate";
 import { LeetCodeSync } from "./components/LeetCodeSync";
 import { LeetcodeImportModal } from "./components/LeetcodeImportModal";
 import { DsaHeatmap } from "./components/DsaHeatmap";
+import { DsaStreakWidget } from "./components/DsaStreakWidget";
 import { ResultCount } from "../../../components/ui/ResultCount";
 
 const TOPICS_PER_PAGE = 20;
@@ -422,7 +423,17 @@ const clearFilters = () => {
           </motion.div>
         )}
 
-        {/* Heatmap (logged-in) */}
+        {/* Streak widget + Heatmap (logged-in) */}
+        {user && (
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.08 }}
+            className="mb-4"
+          >
+            <DsaStreakWidget />
+          </motion.div>
+        )}
         {user && (
           <motion.div
             initial={{ opacity: 0, y: 10 }}

--- a/client/src/module/student/dsa/components/DsaStreakWidget.tsx
+++ b/client/src/module/student/dsa/components/DsaStreakWidget.tsx
@@ -27,7 +27,7 @@ function StreakCalendar({ activeDays, currentStreak }: { activeDays: string[]; c
             title={`${dayNum} ${dayStr}${isActive ? " — solved" : ""}`}
           >
             <div
-              className={`w-5 h-5 rounded-sm text-[8px] font-mono flex items-center justify-center ${
+              className={`w-5 h-5 rounded-sm text-xs font-mono flex items-center justify-center ${
                 isActive
                   ? "bg-orange-500 text-white"
                   : "bg-stone-100 dark:bg-stone-800 text-stone-300 dark:text-stone-600"
@@ -35,7 +35,7 @@ function StreakCalendar({ activeDays, currentStreak }: { activeDays: string[]; c
             >
               {isActive ? <CheckCircle2 className="w-3 h-3" /> : null}
             </div>
-            <span className="text-[8px] font-mono text-stone-400">{dayNum.charAt(0)}</span>
+            <span className="text-xs font-mono text-stone-400">{dayNum.charAt(0)}</span>
           </div>
         );
       })}
@@ -70,7 +70,7 @@ export function DsaStreakWidget() {
           </span>
           <span className="text-xs text-stone-500 dark:text-stone-400">day streak</span>
           {milestone && (
-            <span className="text-[10px] font-mono text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-1.5 py-0.5 rounded-sm">
+            <span className="text-xs font-mono text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-1.5 py-0.5 rounded-sm">
               {milestone}
             </span>
           )}

--- a/client/src/module/student/dsa/components/DsaStreakWidget.tsx
+++ b/client/src/module/student/dsa/components/DsaStreakWidget.tsx
@@ -1,0 +1,93 @@
+import { Flame, CheckCircle2, Target } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import api from "../../../../lib/axios";
+import { queryKeys } from "../../../../lib/query-keys";
+import type { DsaStreak } from "../../../../lib/types";
+
+function StreakCalendar({ activeDays, currentStreak }: { activeDays: string[]; currentStreak: number }) {
+  const today = new Date();
+  const dayStrings: string[] = [];
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    dayStrings.push(d.toISOString().slice(0, 10));
+  }
+
+  const activeSet = new Set(activeDays);
+
+  return (
+    <div className="flex items-center gap-1">
+      {dayStrings.map((dayStr) => {
+        const isActive = activeSet.has(dayStr);
+        const dayNum = new Date(dayStr + "T00:00:00Z").toLocaleDateString("en", { weekday: "short" });
+        return (
+          <div
+            key={dayStr}
+            className="flex flex-col items-center gap-0.5"
+            title={`${dayNum} ${dayStr}${isActive ? " — solved" : ""}`}
+          >
+            <div
+              className={`w-5 h-5 rounded-sm text-[8px] font-mono flex items-center justify-center ${
+                isActive
+                  ? "bg-orange-500 text-white"
+                  : "bg-stone-100 dark:bg-stone-800 text-stone-300 dark:text-stone-600"
+              }`}
+            >
+              {isActive ? <CheckCircle2 className="w-3 h-3" /> : null}
+            </div>
+            <span className="text-[8px] font-mono text-stone-400">{dayNum.charAt(0)}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function DsaStreakWidget() {
+  const { data: streak, isLoading } = useQuery<DsaStreak>({
+    queryKey: queryKeys.dsa.streak(),
+    queryFn: () => api.get("/dsa/streak").then((r) => r.data),
+    staleTime: 60 * 1000,
+  });
+
+  if (isLoading || !streak) return null;
+
+  const milestone =
+    streak.currentStreak >= 100 ? "100-day streak!" :
+    streak.currentStreak >= 30 ? "30-day streak!" :
+    streak.currentStreak >= 7 ? "7-day streak!" :
+    null;
+
+  const todayStr = new Date().toISOString().slice(0, 10);
+
+  return (
+    <div className="bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md p-4">
+      <div className="flex items-center justify-between gap-4 mb-3">
+        <div className="flex items-center gap-2">
+          <Flame className={`w-5 h-5 ${streak.currentStreak > 0 ? "text-orange-500" : "text-stone-300"}`} />
+          <span className="text-lg font-bold tabular-nums text-stone-900 dark:text-white">
+            {streak.currentStreak}
+          </span>
+          <span className="text-xs text-stone-500 dark:text-stone-400">day streak</span>
+          {milestone && (
+            <span className="text-[10px] font-mono text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-1.5 py-0.5 rounded-sm">
+              {milestone}
+            </span>
+          )}
+        </div>
+        <div className="text-xs text-stone-500 dark:text-stone-400 font-mono">
+          Best: {streak.longestStreak}d
+        </div>
+      </div>
+
+      <StreakCalendar activeDays={streak.activeDays} currentStreak={streak.currentStreak} />
+
+      <div className="flex items-center gap-2 mt-3 text-xs text-stone-500 dark:text-stone-400">
+        <Target className="w-3.5 h-3.5" />
+        <span>
+          {streak.solvedToday ? "Solved today" : "Solve a problem to start your streak"}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/server/src/module/dsa/dsa.service.ts
+++ b/server/src/module/dsa/dsa.service.ts
@@ -892,13 +892,64 @@ Return ONLY a JSON array, no markdown fences:
 
   async getUserDsaStreak(userId: number) {
     const today = new Date().toISOString().slice(0, 10);
-    const daily = await this.getDailyProblem(userId);
+
+    const submissions = await prisma.dsaSubmission.findMany({
+      where: { studentId: userId },
+      select: { createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const uniqueDays = new Set<string>();
+    for (const s of submissions) {
+      uniqueDays.add(s.createdAt.toISOString().slice(0, 10));
+    }
+
+    const sortedDays = Array.from(uniqueDays).sort().reverse();
+
+    let currentStreak = 0;
+    let longestStreak = 0;
+    let tempStreak = 0;
+
+    const todayDate = new Date(today);
+
+    for (const dayStr of sortedDays) {
+      const dayDate = new Date(dayStr + "T00:00:00Z");
+      const diffDays = Math.round(
+        (todayDate.getTime() - dayDate.getTime()) / (1000 * 60 * 60 * 24),
+      );
+
+      if (diffDays === currentStreak) {
+        currentStreak++;
+      } else {
+        break;
+      }
+    }
+
+    const allDays = [...uniqueDays].sort();
+    for (let i = 0; i < allDays.length; i++) {
+      if (i === 0) {
+        tempStreak = 1;
+      } else {
+        const prev = new Date(allDays[i - 1] + "T00:00:00Z");
+        const curr = new Date(allDays[i] + "T00:00:00Z");
+        const diff = Math.round(
+          (curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24),
+        );
+        if (diff === 1) {
+          tempStreak++;
+        } else {
+          tempStreak = 1;
+        }
+      }
+      longestStreak = Math.max(longestStreak, tempStreak);
+    }
 
     return {
-      currentStreak: daily.solvedToday ? 1 : 0,
-      longestStreak: daily.solvedToday ? 1 : 0,
-      solvedToday: daily.solvedToday,
-      lastSolvedDate: daily.solvedToday ? today : null,
+      currentStreak,
+      longestStreak,
+      solvedToday: uniqueDays.has(today),
+      lastSolvedDate: sortedDays[0] || null,
+      activeDays: sortedDays.slice(0, 30),
     };
   }
 


### PR DESCRIPTION
﻿## What
Adds a DSA streak tracker widget with flame icon, day count, 7-day mini calendar, and milestone badges.

## Why
Streak tracking is the #1 daily retention mechanic (proven by LeetCode, Duolingo). The backend endpoint existed as a stub — this PR implements proper streak computation and a prominent widget.

## Changes
- server/src/module/dsa/dsa.service.ts — Fixed getUserDsaStreak to compute actual consecutive-day streaks from submission history; returns activeDays array for calendar rendering
- client/src/module/student/dsa/components/DsaStreakWidget.tsx — New widget: flame icon + streak count, 7-day mini calendar showing solved/unsolved days, milestone badges (7d/30d/100d), solved today indicator
- client/src/module/student/dsa/DsaTopicsPage.tsx — Added streak widget above the heatmap
- client/src/lib/query-keys.ts — Added streak query key
- client/src/lib/types/learning.types.ts — Added DsaStreak interface

## Verification
- [ ] Feature implemented and tested locally
- [ ] No unrelated files changed
- [ ] Follows existing code patterns

## Screenshots
N/A

Closes #1047
