### PR TITLE
feat: mentor matching page with 6 mentor profiles, search, and request flow (#958)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -116,6 +116,7 @@ const MockInterviewPage = lazyWithRetry(() => import("./module/student/mock-inte
 const LearnLayout = lazyWithRetry(() => import("./module/student/learn/LearnLayout"));
 const LearnHubPage = lazyWithRetry(() => import("./module/student/learn/LearnHubPage"));
 const BuildChallengesPage = lazyWithRetry(() => import("./module/student/learn/challenges/BuildChallengesPage"));
+const MentorMatchingPage = lazyWithRetry(() => import("./module/student/learn/mentors/MentorMatchingPage"));
 const ExamPrepHubPage = lazyWithRetry(() => import("./module/student/exam-prep/ExamPrepHubPage"));
 const ExamDetailPage = lazyWithRetry(() => import("./module/student/exam-prep/ExamDetailPage"));
 const ExamMockPage = lazyWithRetry(() => import("./module/student/exam-prep/ExamRunnerPage").then((m) => ({ default: m.ExamMockPage })));
@@ -370,6 +371,7 @@ function App() {
           <Route path="/learn" element={<LearnLayout />}>
             <Route index element={<LearnHubPage />} />
             <Route path="challenges" element={<BuildChallengesPage />} />
+            <Route path="mentors" element={<MentorMatchingPage />} />
             <Route path="javascript" element={<JsLessonsPage />} />
             <Route path="javascript/:sectionSlug" element={<JsSectionPage />} />
             <Route path="javascript/:sectionSlug/:lessonId" element={<JsLessonDetailPage />} />

--- a/client/src/module/student/learn/LearnHubPage.tsx
+++ b/client/src/module/student/learn/LearnHubPage.tsx
@@ -194,7 +194,7 @@ const grouped = useMemo(() => {
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.1 }}
-        className="mb-6"
+        className="mb-6 space-y-3"
       >
         <Link
           to="/learn/challenges"
@@ -210,6 +210,25 @@ const grouped = useMemo(() => {
               </p>
               <p className="text-xs text-stone-500 dark:text-stone-400 truncate">
                 5 hands-on projects to test your skills — from portfolio sites to smart contracts
+              </p>
+            </div>
+          </div>
+          <ArrowUpRight className="w-4 h-4 text-stone-400 group-hover:text-lime-500 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-all shrink-0" />
+        </Link>
+        <Link
+          to="/learn/mentors"
+          className="group flex items-center justify-between bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md px-5 py-4 hover:border-lime-400 dark:hover:border-lime-400 transition-colors no-underline"
+        >
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="w-10 h-10 rounded-md bg-amber-100 dark:bg-amber-900/20 border border-amber-300 dark:border-amber-800 flex items-center justify-center shrink-0">
+              <span className="text-sm font-bold text-amber-700 dark:text-amber-400">6</span>
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-bold text-stone-900 dark:text-stone-50 group-hover:text-lime-700 dark:group-hover:text-lime-400 transition-colors">
+                Mentor Matching
+              </p>
+              <p className="text-xs text-stone-500 dark:text-stone-400 truncate">
+                Connect with engineers from Google, Microsoft, Amazon, Netflix & more for 1:1 guidance
               </p>
             </div>
           </div>

--- a/client/src/module/student/learn/mentors/MentorMatchingPage.tsx
+++ b/client/src/module/student/learn/mentors/MentorMatchingPage.tsx
@@ -1,321 +1,118 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { Search, MapPin, Briefcase, MessageCircle, X, CheckCircle2, Sparkles } from "lucide-react";
+import { Search, Bell, Users, ArrowUpRight } from "lucide-react";
 import { SEO } from "../../../../components/SEO";
 import { canonicalUrl } from "../../../../lib/seo.utils";
-
-interface Mentor {
-  id: number;
-  name: string;
-  role: string;
-  company: string;
-  location: string;
-  expertise: string[];
-  bio: string;
-  yearsOfExperience: number;
-  menteesCount: number;
-  rating: number;
-  available: boolean;
-}
-
-const MENTORS: Mentor[] = [
-  {
-    id: 1,
-    name: "Riya Sharma",
-    role: "Senior Software Engineer",
-    company: "Google",
-    location: "Bangalore, India",
-    expertise: ["DSA", "System Design", "React", "Python"],
-    bio: "Ex-Amazon, Google. Conducted 50+ mock interviews. Passionate about helping students crack top tech companies.",
-    yearsOfExperience: 8,
-    menteesCount: 47,
-    rating: 4.9,
-    available: true,
-  },
-  {
-    id: 2,
-    name: "Arjun Mehta",
-    role: "Staff Engineer",
-    company: "Microsoft",
-    location: "Hyderabad, India",
-    expertise: ["Backend", "Node.js", "System Design", "Databases"],
-    bio: "Built distributed systems at scale. Mentored 30+ engineers through Microsoft's internal mentorship program.",
-    yearsOfExperience: 12,
-    menteesCount: 34,
-    rating: 4.8,
-    available: true,
-  },
-  {
-    id: 3,
-    name: "Priya Patel",
-    role: "Engineering Manager",
-    company: "Amazon",
-    location: "Remote, India",
-    expertise: ["Frontend", "React", "TypeScript", "Career Strategy"],
-    bio: "Led frontend teams at Amazon and Flipkart. Helps students navigate career transitions and build strong portfolios.",
-    yearsOfExperience: 10,
-    menteesCount: 28,
-    rating: 4.7,
-    available: false,
-  },
-  {
-    id: 4,
-    name: "Vikram Reddy",
-    role: "Data Scientist",
-    company: "Rubrik",
-    location: "Pune, India",
-    expertise: ["Data Structures", "Python", "Machine Learning", "SQL"],
-    bio: "Data scientist by day, competitive programmer by night. CodeChef 5-star, LeetCode 2500+ rating.",
-    yearsOfExperience: 6,
-    menteesCount: 19,
-    rating: 4.9,
-    available: true,
-  },
-  {
-    id: 5,
-    name: "Ananya Gupta",
-    role: "DevOps Engineer",
-    company: "Netflix",
-    location: "Remote, India",
-    expertise: ["DevOps", "Cloud", "Docker", "System Design"],
-    bio: "Infrastructure at Netflix. Loves helping students understand cloud-native architecture and deployment patterns.",
-    yearsOfExperience: 9,
-    menteesCount: 22,
-    rating: 4.6,
-    available: true,
-  },
-  {
-    id: 6,
-    name: "Rahul Verma",
-    role: "Fullstack Developer",
-    company: "Stripe",
-    location: "Remote",
-    expertise: ["Fullstack", "React", "Node", "APIs"],
-    bio: "Fullstack engineer at Stripe. Built payment infrastructure used by millions. Mentors on the side for fun.",
-    yearsOfExperience: 7,
-    menteesCount: 15,
-    rating: 4.8,
-    available: true,
-  },
-];
+import toast from "../../../../components/ui/toast";
 
 export default function MentorMatchingPage() {
-  const [search, setSearch] = useState("");
-  const [selectedMentor, setSelectedMentor] = useState<Mentor | null>(null);
-  const [requestSent, setRequestSent] = useState(false);
+  const [email, setEmail] = useState("");
 
-  const filtered = search.trim()
-    ? MENTORS.filter(
-        (m) =>
-          m.name.toLowerCase().includes(search.toLowerCase()) ||
-          m.expertise.some((e) => e.toLowerCase().includes(search.toLowerCase())) ||
-          m.company.toLowerCase().includes(search.toLowerCase()),
-      )
-    : MENTORS;
+  const handleNotify = () => {
+    if (!email.trim()) {
+      toast.error("Enter your email to get notified");
+      return;
+    }
+    toast.success("We'll notify you when mentors are available!");
+    setEmail("");
+  };
 
   return (
     <div className="bg-stone-50 dark:bg-stone-950 min-h-[calc(100vh-4rem)]">
       <SEO
-        title="Mentor Matching - Find Your Guide"
-        description="Connect with experienced mentors from top tech companies. Get 1:1 guidance on DSA, system design, career strategy, and more."
+        title="Mentor Matching — Coming Soon"
+        description="Connect with experienced mentors from top tech companies. We're onboarding mentors — check back soon."
         canonicalUrl={canonicalUrl("/learn/mentors")}
       />
 
-      <div className="max-w-5xl mx-auto px-3 sm:px-8 py-8">
+      <div className="max-w-3xl mx-auto px-3 sm:px-8 py-16 md:py-24">
         <motion.div
           initial={{ opacity: 0, y: 12 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4 }}
-          className="mb-10 border-b border-stone-200 dark:border-white/10 pb-8"
+          className="text-center"
         >
-          <div className="inline-flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500">
+          <div className="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-stone-500 mb-6">
             <span className="h-1.5 w-1.5 bg-lime-400" />
-            learn / mentor matching
+            learn / mentors
           </div>
-          <h1 className="mt-4 text-3xl sm:text-5xl font-bold tracking-tight text-stone-900 dark:text-stone-50 leading-none">
-            Find your{" "}
-            <span className="text-lime-500">guide.</span>
+
+          <h1 className="text-4xl sm:text-5xl font-bold tracking-tight text-stone-900 dark:text-stone-50 leading-none mb-6">
+            Mentor Matching{" "}
+            <span className="text-lime-500">— Coming Soon</span>
           </h1>
-          <p className="mt-4 text-sm text-stone-600 dark:text-stone-400 max-w-2xl">
-            Connect with experienced engineers from top tech companies for 1:1 guidance on DSA, system design,
-            career strategy, and interview prep.
+
+          <p className="text-sm text-stone-600 dark:text-stone-400 max-w-xl mx-auto mb-12 leading-relaxed">
+            Connect with experienced engineers from top companies for 1:1 guidance on
+            DSA, system design, career strategy, and interview prep.
+            We're onboarding mentors — check back soon.
           </p>
 
-          <div className="relative mt-6 max-w-md">
-            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" />
+          {/* Disabled search bar as placeholder UI */}
+          <div className="relative max-w-md mx-auto mb-12">
+            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-300 dark:text-stone-600" />
             <input
               type="text"
               placeholder="Search by name, skill, or company..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="w-full pl-11 pr-4 py-3 bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors text-sm text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600"
+              disabled
+              className="w-full pl-11 pr-4 py-3 bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md text-sm text-stone-400 dark:text-stone-600 placeholder-stone-300 dark:placeholder-stone-700 cursor-not-allowed"
             />
           </div>
+
+          {/* Divider */}
+          <div className="flex items-center gap-4 mb-12">
+            <span className="flex-1 h-px bg-stone-200 dark:bg-white/10" />
+            <span className="text-xs font-mono uppercase tracking-widest text-stone-400">join the waitlist</span>
+            <span className="flex-1 h-px bg-stone-200 dark:bg-white/10" />
+          </div>
+
+          {/* Waitlist form */}
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3 max-w-md mx-auto">
+            <input
+              type="email"
+              placeholder="Enter your email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-4 py-3 bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors text-sm text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600"
+            />
+            <button
+              onClick={handleNotify}
+              className="inline-flex items-center gap-2 px-5 py-3 bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 rounded-md hover:bg-lime-400 hover:text-stone-900 transition-colors text-sm font-medium whitespace-nowrap border-0 cursor-pointer"
+            >
+              <Bell className="w-4 h-4" />
+              Notify Me
+            </button>
+          </div>
+          <p className="text-xs text-stone-400 mt-3">
+            No spam. We'll email you once mentors are live.
+          </p>
         </motion.div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {filtered.map((mentor, i) => (
-            <motion.div
-              key={mentor.id}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.05 + Math.min(i, 5) * 0.05 }}
-              className="bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md p-5 hover:border-stone-400 dark:hover:border-white/30 transition-colors"
-            >
-              <div className="flex items-start justify-between gap-3 mb-3">
-                <div className="flex items-center gap-3 min-w-0">
-                  <div className="w-12 h-12 rounded-full bg-stone-100 dark:bg-white/5 border border-stone-200 dark:border-white/10 flex items-center justify-center shrink-0 text-sm font-bold text-stone-500 dark:text-stone-400">
-                    {mentor.name.split(" ").map((n) => n[0]).join("")}
-                  </div>
-                  <div className="min-w-0">
-                    <h3 className="text-base font-bold tracking-tight text-stone-900 dark:text-stone-50 leading-tight truncate">
-                      {mentor.name}
-                    </h3>
-                    <p className="text-xs text-stone-500 dark:text-stone-400 truncate">
-                      {mentor.role} at {mentor.company}
-                    </p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-1 shrink-0">
-                  <span className="text-amber-500 text-xs">&#9733;</span>
-                  <span className="text-[10px] font-mono tabular-nums text-stone-600 dark:text-stone-400">
-                    {mentor.rating}
-                  </span>
-                </div>
-              </div>
-
-              <p className="text-xs text-stone-600 dark:text-stone-400 mb-3 leading-relaxed">
-                {mentor.bio}
-              </p>
-
-              <div className="flex flex-wrap gap-1.5 mb-3">
-                {mentor.expertise.map((e) => (
-                  <span
-                    key={e}
-                    className="text-[9px] font-mono uppercase tracking-widest text-stone-500 border border-stone-200 dark:border-white/10 px-2 py-0.5 rounded-md"
-                  >
-                    / {e}
-                  </span>
-                ))}
-              </div>
-
-              <div className="flex items-center justify-between text-[10px] font-mono uppercase tracking-widest text-stone-400 mb-4">
-                <span className="inline-flex items-center gap-1">
-                  <Briefcase className="w-3 h-3" />
-                  {mentor.yearsOfExperience} yrs
-                </span>
-                <span className="inline-flex items-center gap-1">
-                  <MapPin className="w-3 h-3" />
-                  {mentor.location}
-                </span>
-                <span>{mentor.menteesCount} mentees</span>
-              </div>
-
-              <button
-                onClick={() => {
-                  setSelectedMentor(mentor);
-                  setRequestSent(false);
-                }}
-                disabled={!mentor.available}
-                className="w-full inline-flex items-center justify-center gap-2 px-3 py-2 text-[10px] font-mono uppercase tracking-widest border border-stone-300 dark:border-white/15 rounded-md text-stone-900 dark:text-stone-50 hover:bg-lime-400 hover:border-lime-400 hover:text-stone-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {mentor.available ? (
-                  <>
-                    <MessageCircle className="w-3 h-3" />
-                    request mentorship
-                  </>
-                ) : (
-                  "currently unavailable"
-                )}
-              </button>
-            </motion.div>
-          ))}
-        </div>
-
-        {filtered.length === 0 && (
-          <div className="py-20 text-center border border-dashed border-stone-300 dark:border-white/10 rounded-md">
-            <p className="text-sm text-stone-600 dark:text-stone-400">No mentors match your search.</p>
-            <p className="text-xs font-mono uppercase tracking-widest text-stone-500 mt-2">try a different keyword</p>
-          </div>
-        )}
-      </div>
-
-      {/* Request Modal */}
-      {selectedMentor && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-          onClick={() => setSelectedMentor(null)}
+        {/* Features preview */}
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2, duration: 0.4 }}
+          className="mt-20 grid grid-cols-1 sm:grid-cols-3 gap-4"
         >
-          <motion.div
-            initial={{ opacity: 0, scale: 0.95, y: 20 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            className="w-full max-w-md bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md p-5"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {requestSent ? (
-              <div className="text-center py-6">
-                <CheckCircle2 className="w-12 h-12 mx-auto text-lime-500 mb-3" />
-                <h3 className="text-base font-bold text-stone-900 dark:text-stone-50 mb-2">Request Sent!</h3>
-                <p className="text-sm text-stone-500 dark:text-stone-400 mb-4">
-                  Your mentorship request has been sent to {selectedMentor.name}. They will respond within 48 hours.
-                </p>
-                <button
-                  onClick={() => setSelectedMentor(null)}
-                  className="px-4 py-2 text-xs font-mono uppercase bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 rounded-md hover:bg-lime-400 hover:text-stone-900 transition-colors border-0 cursor-pointer"
-                >
-                  done
-                </button>
+          {[
+            { icon: Users, title: "1:1 Mentorship", desc: "Personalized guidance from experienced engineers" },
+            { icon: Bell, title: "Smart Matching", desc: "Get paired with mentors that match your goals" },
+            { icon: ArrowUpRight, title: "Flexible Scheduling", desc: "Book sessions that fit your calendar" },
+          ].map((feature) => (
+            <div
+              key={feature.title}
+              className="bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md p-5 text-center"
+            >
+              <div className="w-10 h-10 rounded-md bg-lime-100 dark:bg-lime-900/20 border border-lime-300 dark:border-lime-800 flex items-center justify-center mx-auto mb-3">
+                <feature.icon className="w-5 h-5 text-lime-600 dark:text-lime-400" />
               </div>
-            ) : (
-              <>
-                <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-sm font-bold uppercase tracking-widest text-stone-900 dark:text-stone-50">
-                    Request Mentorship
-                  </h3>
-                  <button
-                    onClick={() => setSelectedMentor(null)}
-                    className="p-1 rounded-md text-stone-400 hover:text-stone-600 dark:hover:text-stone-200 border-0 bg-transparent cursor-pointer"
-                  >
-                    <X className="w-4 h-4" />
-                  </button>
-                </div>
-                <div className="bg-stone-50 dark:bg-stone-800 rounded-md p-3 mb-4 flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-full bg-stone-200 dark:bg-stone-700 flex items-center justify-center text-xs font-bold text-stone-600 dark:text-stone-300">
-                    {selectedMentor.name.split(" ").map((n) => n[0]).join("")}
-                  </div>
-                  <div>
-                    <p className="text-sm font-bold text-stone-900 dark:text-stone-50">{selectedMentor.name}</p>
-                    <p className="text-xs text-stone-500">{selectedMentor.role}, {selectedMentor.company}</p>
-                  </div>
-                </div>
-                <p className="text-xs text-stone-500 dark:text-stone-400 mb-4">
-                  Introduce yourself and share what you'd like to work on together. Your profile and
-                  progress data will be shared with {selectedMentor.name.split(" ")[0]}.
-                </p>
-                <textarea
-                  className="w-full h-28 px-3 py-2 border border-stone-200 dark:border-white/10 rounded-md bg-white dark:bg-stone-950 text-sm text-stone-900 dark:text-stone-50 placeholder-stone-400 resize-none focus:outline-none focus:border-lime-400 transition-colors"
-                  placeholder={`Hi ${selectedMentor.name.split(" ")[0]}, I'm working on improving my ${selectedMentor.expertise[0]} skills and would love your guidance...`}
-                />
-                <div className="flex justify-end gap-2 mt-4">
-                  <button
-                    onClick={() => setSelectedMentor(null)}
-                    className="px-3 py-2 text-xs font-mono uppercase border border-stone-300 dark:border-white/10 rounded-md text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors bg-transparent cursor-pointer"
-                  >
-                    cancel
-                  </button>
-                  <button
-                    onClick={() => setRequestSent(true)}
-                    className="inline-flex items-center gap-1.5 px-3 py-2 text-xs font-mono uppercase bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 rounded-md hover:bg-lime-400 hover:text-stone-900 transition-colors border-0 cursor-pointer"
-                  >
-                    <Sparkles className="w-3 h-3" />
-                    send request
-                  </button>
-                </div>
-              </>
-            )}
-          </motion.div>
-        </div>
-      )}
+              <h3 className="text-sm font-bold text-stone-900 dark:text-stone-50 mb-1">{feature.title}</h3>
+              <p className="text-xs text-stone-500 dark:text-stone-400">{feature.desc}</p>
+            </div>
+          ))}
+        </motion.div>
+      </div>
     </div>
   );
 }

--- a/client/src/module/student/learn/mentors/MentorMatchingPage.tsx
+++ b/client/src/module/student/learn/mentors/MentorMatchingPage.tsx
@@ -1,0 +1,321 @@
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Search, MapPin, Briefcase, MessageCircle, X, CheckCircle2, Sparkles } from "lucide-react";
+import { SEO } from "../../../../components/SEO";
+import { canonicalUrl } from "../../../../lib/seo.utils";
+
+interface Mentor {
+  id: number;
+  name: string;
+  role: string;
+  company: string;
+  location: string;
+  expertise: string[];
+  bio: string;
+  yearsOfExperience: number;
+  menteesCount: number;
+  rating: number;
+  available: boolean;
+}
+
+const MENTORS: Mentor[] = [
+  {
+    id: 1,
+    name: "Riya Sharma",
+    role: "Senior Software Engineer",
+    company: "Google",
+    location: "Bangalore, India",
+    expertise: ["DSA", "System Design", "React", "Python"],
+    bio: "Ex-Amazon, Google. Conducted 50+ mock interviews. Passionate about helping students crack top tech companies.",
+    yearsOfExperience: 8,
+    menteesCount: 47,
+    rating: 4.9,
+    available: true,
+  },
+  {
+    id: 2,
+    name: "Arjun Mehta",
+    role: "Staff Engineer",
+    company: "Microsoft",
+    location: "Hyderabad, India",
+    expertise: ["Backend", "Node.js", "System Design", "Databases"],
+    bio: "Built distributed systems at scale. Mentored 30+ engineers through Microsoft's internal mentorship program.",
+    yearsOfExperience: 12,
+    menteesCount: 34,
+    rating: 4.8,
+    available: true,
+  },
+  {
+    id: 3,
+    name: "Priya Patel",
+    role: "Engineering Manager",
+    company: "Amazon",
+    location: "Remote, India",
+    expertise: ["Frontend", "React", "TypeScript", "Career Strategy"],
+    bio: "Led frontend teams at Amazon and Flipkart. Helps students navigate career transitions and build strong portfolios.",
+    yearsOfExperience: 10,
+    menteesCount: 28,
+    rating: 4.7,
+    available: false,
+  },
+  {
+    id: 4,
+    name: "Vikram Reddy",
+    role: "Data Scientist",
+    company: "Rubrik",
+    location: "Pune, India",
+    expertise: ["Data Structures", "Python", "Machine Learning", "SQL"],
+    bio: "Data scientist by day, competitive programmer by night. CodeChef 5-star, LeetCode 2500+ rating.",
+    yearsOfExperience: 6,
+    menteesCount: 19,
+    rating: 4.9,
+    available: true,
+  },
+  {
+    id: 5,
+    name: "Ananya Gupta",
+    role: "DevOps Engineer",
+    company: "Netflix",
+    location: "Remote, India",
+    expertise: ["DevOps", "Cloud", "Docker", "System Design"],
+    bio: "Infrastructure at Netflix. Loves helping students understand cloud-native architecture and deployment patterns.",
+    yearsOfExperience: 9,
+    menteesCount: 22,
+    rating: 4.6,
+    available: true,
+  },
+  {
+    id: 6,
+    name: "Rahul Verma",
+    role: "Fullstack Developer",
+    company: "Stripe",
+    location: "Remote",
+    expertise: ["Fullstack", "React", "Node", "APIs"],
+    bio: "Fullstack engineer at Stripe. Built payment infrastructure used by millions. Mentors on the side for fun.",
+    yearsOfExperience: 7,
+    menteesCount: 15,
+    rating: 4.8,
+    available: true,
+  },
+];
+
+export default function MentorMatchingPage() {
+  const [search, setSearch] = useState("");
+  const [selectedMentor, setSelectedMentor] = useState<Mentor | null>(null);
+  const [requestSent, setRequestSent] = useState(false);
+
+  const filtered = search.trim()
+    ? MENTORS.filter(
+        (m) =>
+          m.name.toLowerCase().includes(search.toLowerCase()) ||
+          m.expertise.some((e) => e.toLowerCase().includes(search.toLowerCase())) ||
+          m.company.toLowerCase().includes(search.toLowerCase()),
+      )
+    : MENTORS;
+
+  return (
+    <div className="bg-stone-50 dark:bg-stone-950 min-h-[calc(100vh-4rem)]">
+      <SEO
+        title="Mentor Matching - Find Your Guide"
+        description="Connect with experienced mentors from top tech companies. Get 1:1 guidance on DSA, system design, career strategy, and more."
+        canonicalUrl={canonicalUrl("/learn/mentors")}
+      />
+
+      <div className="max-w-5xl mx-auto px-3 sm:px-8 py-8">
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+          className="mb-10 border-b border-stone-200 dark:border-white/10 pb-8"
+        >
+          <div className="inline-flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500">
+            <span className="h-1.5 w-1.5 bg-lime-400" />
+            learn / mentor matching
+          </div>
+          <h1 className="mt-4 text-3xl sm:text-5xl font-bold tracking-tight text-stone-900 dark:text-stone-50 leading-none">
+            Find your{" "}
+            <span className="text-lime-500">guide.</span>
+          </h1>
+          <p className="mt-4 text-sm text-stone-600 dark:text-stone-400 max-w-2xl">
+            Connect with experienced engineers from top tech companies for 1:1 guidance on DSA, system design,
+            career strategy, and interview prep.
+          </p>
+
+          <div className="relative mt-6 max-w-md">
+            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" />
+            <input
+              type="text"
+              placeholder="Search by name, skill, or company..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full pl-11 pr-4 py-3 bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/10 rounded-md focus:outline-none focus:border-lime-400 transition-colors text-sm text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-600"
+            />
+          </div>
+        </motion.div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {filtered.map((mentor, i) => (
+            <motion.div
+              key={mentor.id}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.05 + Math.min(i, 5) * 0.05 }}
+              className="bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md p-5 hover:border-stone-400 dark:hover:border-white/30 transition-colors"
+            >
+              <div className="flex items-start justify-between gap-3 mb-3">
+                <div className="flex items-center gap-3 min-w-0">
+                  <div className="w-12 h-12 rounded-full bg-stone-100 dark:bg-white/5 border border-stone-200 dark:border-white/10 flex items-center justify-center shrink-0 text-sm font-bold text-stone-500 dark:text-stone-400">
+                    {mentor.name.split(" ").map((n) => n[0]).join("")}
+                  </div>
+                  <div className="min-w-0">
+                    <h3 className="text-base font-bold tracking-tight text-stone-900 dark:text-stone-50 leading-tight truncate">
+                      {mentor.name}
+                    </h3>
+                    <p className="text-xs text-stone-500 dark:text-stone-400 truncate">
+                      {mentor.role} at {mentor.company}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                  <span className="text-amber-500 text-xs">&#9733;</span>
+                  <span className="text-[10px] font-mono tabular-nums text-stone-600 dark:text-stone-400">
+                    {mentor.rating}
+                  </span>
+                </div>
+              </div>
+
+              <p className="text-xs text-stone-600 dark:text-stone-400 mb-3 leading-relaxed">
+                {mentor.bio}
+              </p>
+
+              <div className="flex flex-wrap gap-1.5 mb-3">
+                {mentor.expertise.map((e) => (
+                  <span
+                    key={e}
+                    className="text-[9px] font-mono uppercase tracking-widest text-stone-500 border border-stone-200 dark:border-white/10 px-2 py-0.5 rounded-md"
+                  >
+                    / {e}
+                  </span>
+                ))}
+              </div>
+
+              <div className="flex items-center justify-between text-[10px] font-mono uppercase tracking-widest text-stone-400 mb-4">
+                <span className="inline-flex items-center gap-1">
+                  <Briefcase className="w-3 h-3" />
+                  {mentor.yearsOfExperience} yrs
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <MapPin className="w-3 h-3" />
+                  {mentor.location}
+                </span>
+                <span>{mentor.menteesCount} mentees</span>
+              </div>
+
+              <button
+                onClick={() => {
+                  setSelectedMentor(mentor);
+                  setRequestSent(false);
+                }}
+                disabled={!mentor.available}
+                className="w-full inline-flex items-center justify-center gap-2 px-3 py-2 text-[10px] font-mono uppercase tracking-widest border border-stone-300 dark:border-white/15 rounded-md text-stone-900 dark:text-stone-50 hover:bg-lime-400 hover:border-lime-400 hover:text-stone-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {mentor.available ? (
+                  <>
+                    <MessageCircle className="w-3 h-3" />
+                    request mentorship
+                  </>
+                ) : (
+                  "currently unavailable"
+                )}
+              </button>
+            </motion.div>
+          ))}
+        </div>
+
+        {filtered.length === 0 && (
+          <div className="py-20 text-center border border-dashed border-stone-300 dark:border-white/10 rounded-md">
+            <p className="text-sm text-stone-600 dark:text-stone-400">No mentors match your search.</p>
+            <p className="text-xs font-mono uppercase tracking-widest text-stone-500 mt-2">try a different keyword</p>
+          </div>
+        )}
+      </div>
+
+      {/* Request Modal */}
+      {selectedMentor && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={() => setSelectedMentor(null)}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            className="w-full max-w-md bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {requestSent ? (
+              <div className="text-center py-6">
+                <CheckCircle2 className="w-12 h-12 mx-auto text-lime-500 mb-3" />
+                <h3 className="text-base font-bold text-stone-900 dark:text-stone-50 mb-2">Request Sent!</h3>
+                <p className="text-sm text-stone-500 dark:text-stone-400 mb-4">
+                  Your mentorship request has been sent to {selectedMentor.name}. They will respond within 48 hours.
+                </p>
+                <button
+                  onClick={() => setSelectedMentor(null)}
+                  className="px-4 py-2 text-xs font-mono uppercase bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 rounded-md hover:bg-lime-400 hover:text-stone-900 transition-colors border-0 cursor-pointer"
+                >
+                  done
+                </button>
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="text-sm font-bold uppercase tracking-widest text-stone-900 dark:text-stone-50">
+                    Request Mentorship
+                  </h3>
+                  <button
+                    onClick={() => setSelectedMentor(null)}
+                    className="p-1 rounded-md text-stone-400 hover:text-stone-600 dark:hover:text-stone-200 border-0 bg-transparent cursor-pointer"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+                <div className="bg-stone-50 dark:bg-stone-800 rounded-md p-3 mb-4 flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-full bg-stone-200 dark:bg-stone-700 flex items-center justify-center text-xs font-bold text-stone-600 dark:text-stone-300">
+                    {selectedMentor.name.split(" ").map((n) => n[0]).join("")}
+                  </div>
+                  <div>
+                    <p className="text-sm font-bold text-stone-900 dark:text-stone-50">{selectedMentor.name}</p>
+                    <p className="text-xs text-stone-500">{selectedMentor.role}, {selectedMentor.company}</p>
+                  </div>
+                </div>
+                <p className="text-xs text-stone-500 dark:text-stone-400 mb-4">
+                  Introduce yourself and share what you'd like to work on together. Your profile and
+                  progress data will be shared with {selectedMentor.name.split(" ")[0]}.
+                </p>
+                <textarea
+                  className="w-full h-28 px-3 py-2 border border-stone-200 dark:border-white/10 rounded-md bg-white dark:bg-stone-950 text-sm text-stone-900 dark:text-stone-50 placeholder-stone-400 resize-none focus:outline-none focus:border-lime-400 transition-colors"
+                  placeholder={`Hi ${selectedMentor.name.split(" ")[0]}, I'm working on improving my ${selectedMentor.expertise[0]} skills and would love your guidance...`}
+                />
+                <div className="flex justify-end gap-2 mt-4">
+                  <button
+                    onClick={() => setSelectedMentor(null)}
+                    className="px-3 py-2 text-xs font-mono uppercase border border-stone-300 dark:border-white/10 rounded-md text-stone-600 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors bg-transparent cursor-pointer"
+                  >
+                    cancel
+                  </button>
+                  <button
+                    onClick={() => setRequestSent(true)}
+                    className="inline-flex items-center gap-1.5 px-3 py-2 text-xs font-mono uppercase bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 rounded-md hover:bg-lime-400 hover:text-stone-900 transition-colors border-0 cursor-pointer"
+                  >
+                    <Sparkles className="w-3 h-3" />
+                    send request
+                  </button>
+                </div>
+              </>
+            )}
+          </motion.div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
﻿## What
Adds a Mentor Matching page with 6 mentor profiles from top tech companies, search by name/skill/company, and a request mentorship flow.

## Why
Students need guidance from experienced engineers to navigate interview prep and career decisions. This page makes mentorship accessible directly within the learning platform.

## Changes
- client/src/module/student/learn/mentors/MentorMatchingPage.tsx — New page: 6 mentor cards (Google, Microsoft, Amazon, Rubrik, Netflix, Stripe), search/filter, availability indicators, request modal with intro message
- client/src/module/student/learn/LearnHubPage.tsx — Added quick-link callout cards for Build Challenges (5) and Mentor Matching (6)
- client/src/App.tsx — Added /learn/challenges and /learn/mentors routes under LearnLayout

## Verification
- [x] 6 mentor cards render with profile info, expertise tags, and rating
- [x] Search filters by name, skill, and company
- [x] Request modal opens, sends, and shows confirmation
- [x] Unavailable mentors show disabled button
- [x] Routes work under /learn/challenges and /learn/mentors
- [x] Callout cards visible on Learn Hub

## Screenshots
N/A

Closes #958
