### PR TITLE
fix: align package license metadata with repository MIT license

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,7 @@
   },
   "keywords": [],
   "author": "Sachin Chaurasiya",
-  "license": "ISC",
+  "license": "MIT",
   "type": "module",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.98.0",


### PR DESCRIPTION
﻿## What

Changes server/package.json license field from ISC to MIT to match the repository's actual MIT license.

## Root cause

The package.json was initialized with ISC (npm default) while the repository uses MIT.

## Changes

- server/package.json — license field changed from ISC to MIT

## Verification

- [ ] Confirmed license mismatch before starting
- [ ] Fix verified locally
- [ ] git diff upstream/main...HEAD --stat shows only intended file

Closes #1600


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project license to MIT.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->