### PR TITLE
fix: add server-side file size validation in upload notification endpoint (#1617)

### DIFF
--- a/client/src/module/student/profile/components/ResumesSection.tsx
+++ b/client/src/module/student/profile/components/ResumesSection.tsx
@@ -68,7 +68,7 @@ export function ResumesSection({
         {uploadingResume ? <><Loader2 className="w-4 h-4 animate-spin" /> Uploading...</> : <><Upload className="w-4 h-4" /> Upload resume (PDF)</>}
       </button>
       <input ref={resumeInputRef} type="file" accept=".pdf" onChange={onUpload} className="hidden" />
-      <p className="text-[10px] font-mono text-stone-500">PDF only, max 10 MB each.</p>
+      <p className="text-[10px] font-mono text-stone-500">PDF only, max 5 MB each.</p>
     </div>
   );
 }

--- a/server/src/module/upload/upload.controller.ts
+++ b/server/src/module/upload/upload.controller.ts
@@ -9,6 +9,7 @@ import { createLogger } from "../../utils/logger.js";
 const logger = createLogger("UploadController");
 
 const MAX_RESUMES = 2;
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB — must match s3.utils.ts UPLOAD_POLICIES
 
 /**
  * Server-side allowlist of permitted MIME types for presigned URL generation.
@@ -177,6 +178,9 @@ export class UploadController {
       const { fileUrl, originalName, size, mimeType } = req.body;
       if (!isValidS3FileUrl(fileUrl)) {
         return res.status(400).json({ message: "Invalid fileUrl origin" });
+      }
+      if (typeof size === "number" && size > MAX_FILE_SIZE) {
+        return res.status(400).json({ message: `File size exceeds ${MAX_FILE_SIZE / (1024 * 1024)} MB limit` });
       }
 
       const userId = req.user.id;


### PR DESCRIPTION
﻿## What
Adds server-side file size validation to the upload notification endpoint and fixes the misleading UI text.

## Why
The 5 MB limit was only enforced client-side and via S3 presigned POST conditions. The server-side notification endpoint (POST /upload/profile-resume) accepted the size field from the client body without validation, meaning an attacker could bypass the client cap by calling the API directly.

## Changes
- server/src/module/upload/upload.controller.ts — Added MAX_FILE_SIZE constant (5 MB) and validation: rejects requests where size exceeds the limit
- client/src/module/student/profile/components/ResumesSection.tsx — Fixed UI text from \"max 10 MB\" to \"max 5 MB\" (was misleading)

## Verification
- [x] Server rejects upload metadata with size > 5 MB
- [x] Files under 5 MB continue to work
- [x] UI now accurately reflects the 5 MB limit
- [x] S3 presigned POST content-length-range provides defense-in-depth

## Screenshots
N/A

Closes #1617
