### PR TITLE
fix: add beforeunload handler to flush LaTeX editor changes on browser refresh (#1615)

### DIFF
--- a/client/src/module/student/ats/useLatexAutoSave.ts
+++ b/client/src/module/student/ats/useLatexAutoSave.ts
@@ -73,11 +73,19 @@ export function useLatexAutoSave(
     [flush],
   );
 
+  // Flush on unmount (React navigation)
   useEffect(() => {
     return () => {
       clearTimeout(timeoutRef.current);
       flush();
     };
+  }, [flush]);
+
+  // Flush on browser refresh/tab close — beforeunload fires synchronously
+  useEffect(() => {
+    const handleBeforeUnload = () => flush();
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [flush]);
 
   return { code, setCode, supportingFiles, setSupportingFiles };


### PR DESCRIPTION
﻿## What
Adds a eforeunload event listener that flushes unsaved LaTeX editor content to localStorage before the browser tab closes or refreshes.

## Why
The autosave hook relied on React's useEffect cleanup to flush data on unmount, but this does not reliably fire during a browser page refresh. The 800ms debounce meant changes made within 800ms of a refresh were lost.

## Changes
- client/src/module/student/ats/useLatexAutoSave.ts — Added useEffect with window.addEventListener(\"beforeunload\", flush) to synchronously save the buffer before page teardown

## Verification
- [x] eforeunload handler calls lush() which writes code + files to localStorage
- [x] Listener is removed on component unmount (no leaks)
- [x] Debounce-based flush still works as before for normal saves
- [x] Changes made milliseconds before refresh are now preserved

## Screenshots
N/A

Closes #1615
