### PR TITLE
fix: implement stale-while-revalidate pattern to prevent cache stampe…

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -305,13 +305,23 @@ app.use(express.static(path.join(__dirname, "../public"), { dotfiles: "deny", in
 
 // ── Public platform stats with in-memory cache (30 min TTL) ──
 let statsCache: { data: unknown; expiresAt: number } | null = null;
+let isRefreshingStats = false;
 const STATS_TTL = 30 * 60 * 1000;
 
 app.get("/api/stats", async (_req, res) => {
   try {
+    // Return cache if it's still fresh
     if (statsCache && statsCache.expiresAt > Date.now()) {
       return res.json(statsCache.data);
     }
+
+    // Stale-while-revalidate pattern: if someone is already fetching, 
+    // serve the stale cache to prevent a database stampede.
+    if (isRefreshingStats && statsCache) {
+      return res.json(statsCache.data);
+    }
+
+    isRefreshingStats = true;
 
     const [users, jobs, companies] = await Promise.all([
       prisma.user.count({ where: { role: "STUDENT" } }),
@@ -321,9 +331,11 @@ app.get("/api/stats", async (_req, res) => {
 
     const data = { users, jobs, companies };
     statsCache = { data, expiresAt: Date.now() + STATS_TTL };
+    isRefreshingStats = false;
     return res.json(data);
   } catch {
-    return res.json({ users: 0, jobs: 0, companies: 0 });
+    isRefreshingStats = false;
+    return res.json(statsCache ? statsCache.data : { users: 0, jobs: 0, companies: 0 });
   }
 });
 


### PR DESCRIPTION
Closes #1445

## Changes
- Implemented a "stale-while-revalidate" caching mechanism for the `/api/stats` endpoint.
- Added an `isRefreshingStats` lock variable.
- If the cache expires but `isRefreshingStats` is already true, the server now immediately serves the stale cache to incoming concurrent requests.
- Also added fallback logic in the `catch` block to serve the stale cache rather than `0`s if the Prisma query fails while revalidating.

## Why
Under high concurrent load, when the 30-minute `statsCache` TTL expired, every single incoming request bypassed the cache and hit the database simultaneously. This created a "cache stampede" that triggered massive CPU spikes since `prisma.count()` is expensive. This fix ensures exactly 1 request queries the database while the rest are instantly served the stale data.

Contributing under GSSoC'26 🎯


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `/api/stats` endpoint to handle concurrent requests more efficiently
  * Enhanced error handling to provide fallback data when issues occur

<!-- end of auto-generated comment: release notes by coderabbit.ai -->