### PR TITLE
fix: remove duplicate useEffect dependency array in ApplicationDetail.tsx Closes #1626

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationDetail.tsx
+++ b/client/src/module/recruiter/applications/ApplicationDetail.tsx
@@ -149,7 +149,6 @@ const fetchDetail = useCallback(async (signal) => {
       controller.abort();
     };
   }, [applicationId, fetchDetail]);
-  }, [applicationId]);
 
   useEffect(() => {
     if (application?.student?.id) {


### PR DESCRIPTION
## What
Removes duplicate useEffect dependency array in ApplicationDetail.tsx

## Root cause
A copy-paste error left a second `}, [applicationId]);` closing brace on line 152, which would cause a parse error at runtime.

## Changes
- `client/src/module/recruiter/applications/ApplicationDetail.tsx` — deleted the duplicate `}, [applicationId]);` line

## Verification
- [ ] Bug reproduced before fix
- [ ] Fix verified locally
- [ ] git diff upstream/main...HEAD --stat shows only intended file
- [ ] No console.logs or debug logs remaining
- [ ] Build passes

## CI failures (if any)
(pre-existing failures unrelated to this PR — remove if CI green)

## Before / After
Backend only — no UI changes

Closes #1626
