### PR TITLE
fix: use req.user.id instead of req.body.creatorId in hr-task controller Closes #1629

### DIFF
--- a/server/src/module/hr-task/hr-task.controller.ts
+++ b/server/src/module/hr-task/hr-task.controller.ts
@@ -12,7 +12,7 @@ export class HRTaskController {
       const result = createTaskSchema.safeParse(req.body);
       if (!result.success) return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
 
-      const creatorId = Number(req.body.creatorId ?? req.user.id);
+      const creatorId = Number(req.user.id);
       const task = await this.taskService.create(creatorId, result.data);
       return res.status(201).json({ message: "Task created", task });
     } catch (error) {


### PR DESCRIPTION
## What
Uses authenticated user ID instead of raw req.body.creatorId in hr-task controller

## Root cause
The controller read `creatorId` from `req.body` before Zod validation, allowing a client to impersonate any user by sending an arbitrary `creatorId`.

## Changes
- `server/src/module/hr-task/hr-task.controller.ts` — replaced `req.body.creatorId ?? req.user.id` with `req.user.id`

## Verification
- [ ] Bug reproduced before fix
- [ ] Fix verified locally
- [ ] git diff upstream/main...HEAD --stat shows only intended file
- [ ] No console.logs or debug logs remaining
- [ ] Build passes

## CI failures (if any)

## Before / After
Backend only — no UI changes

Closes #1629


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved authorization issue where tasks could be created with an incorrect creator. Task creator now correctly defaults to the authenticated user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->