### PR TITLE
fix: add Zod validation for adminNote in rejectRepoRequest Closes #1627

### DIFF
--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -187,7 +187,15 @@ export class OpensourceController {
         return;
       }
 
-      await service.rejectRepoRequest(id, req.body.adminNote);
+      const body = approveRequestOverrideSchema.safeParse(req.body);
+      if (!body.success) {
+        res.status(400).json({
+          message: "Validation failed",
+          errors: body.error.flatten()
+        });
+        return;
+      }
+      await service.rejectRepoRequest(id, body.data.adminNote);
       res.json({ message: "Request rejected" });
     } catch (err: any) {
       if (err.message === "Request not found") {


### PR DESCRIPTION
## What
Adds Zod validation for adminNote in rejectRepoRequest endpoint

## Root cause
The `rejectRepoRequest` handler passed `req.body.adminNote` directly to the service without Zod validation, allowing arbitrary/unvalidated input.

## Changes
- `server/src/module/opensource/opensource.controller.ts` — added `safeParse` guard with `approveRequestOverrideSchema` before calling service

## Verification
- [ ] Bug reproduced before fix
- [ ] Fix verified locally
- [ ] git diff upstream/main...HEAD --stat shows only intended file
- [ ] No console.logs or debug logs remaining
- [ ] Build passes

## CI failures (if any)

## Before / After
Backend only — no UI changes

Closes #1627
