### PR TITLE
fix: add Zod validation for compliance acknowledge endpoint Closes #1628

### DIFF
--- a/server/src/module/compliance/compliance.controller.ts
+++ b/server/src/module/compliance/compliance.controller.ts
@@ -1,6 +1,11 @@
 import type { Request, Response } from "express";
 import type { ComplianceService } from "./compliance.service.js";
 import { createComplianceDocSchema, updateComplianceDocSchema, complianceQuerySchema } from "./compliance.validation.js";
+import { z } from "zod";
+
+const acknowledgeSchema = z.object({
+  employeeId: z.coerce.number()
+});
 
 export class ComplianceController {
   constructor(private readonly complianceService: ComplianceService) {}
@@ -82,8 +87,12 @@ export class ComplianceController {
       const id = Number(req.params["id"]);
       if (isNaN(id)) return res.status(400).json({ message: "Invalid document ID" });
 
-      const employeeId = Number(req.body.employeeId);
-      if (isNaN(employeeId)) return res.status(400).json({ message: "employeeId required" });
+      const body = acknowledgeSchema.safeParse(req.body);
+      if (!body.success) return res.status(400).json({
+        message: "Validation failed",
+        errors: body.error.flatten()
+      });
+      const employeeId = body.data.employeeId;
 
       const document = await this.complianceService.acknowledge(id, employeeId);
       return res.json({ message: "Document acknowledged", document });


### PR DESCRIPTION
## What
Adds Zod validation for the acknowledge endpoint in compliance controller

## Root cause
The handler manually parsed `employeeId` from `req.body` without Zod validation, using bare `Number()` and `isNaN()`.

## Changes
- `server/src/module/compliance/compliance.controller.ts` — added `acknowledgeSchema` (Zod), replaced manual parse with `safeParse` guard

## Verification
- [ ] Bug reproduced before fix
- [ ] Fix verified locally
- [ ] git diff upstream/main...HEAD --stat shows only intended file
- [ ] No console.logs or debug logs remaining
- [ ] Build passes

## CI failures (if any)

## Before / After
Backend only — no UI changes

Closes #1628
