### PR TITLE
fix: make sanitizeBody recursive to redact deeply nested sensitive fi…

### DIFF
--- a/server/src/middleware/error.middleware.test.ts
+++ b/server/src/middleware/error.middleware.test.ts
@@ -235,5 +235,42 @@ describe("errorMiddleware", () => {
         name: "Test User",
       });
     });
+
+    it("should redact deeply nested sensitive fields in request body before logging", async () => {
+      const { prisma } = await import("../database/db.js");
+      const err = new Error("User not found");
+      const req = mockReq({
+        body: {
+          email: "user@test.com",
+          data: {
+            profile: {
+              password: "secret123",
+              cvv: "123",
+            }
+          },
+          items: [{ token: "jwt-token" }],
+        },
+      });
+      const res = mockRes();
+
+      errorMiddleware(err, req, res, noop);
+
+      // Give the async create a tick to resolve
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(prisma.errorLog.create).toHaveBeenCalled();
+      const callArg = (prisma.errorLog.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      const body = callArg?.data?.requestBody;
+      expect(body).toEqual({
+        email: "user@test.com",
+        data: {
+          profile: {
+            password: "[REDACTED]",
+            cvv: "[REDACTED]",
+          }
+        },
+        items: [{ token: "[REDACTED]" }],
+      });
+    });
   });
 });

--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -8,10 +8,18 @@ const SENSITIVE_KEYS = new Set([
 ]);
 
 function sanitizeBody(body: unknown): Prisma.InputJsonValue | null {
-  if (!body || typeof body !== "object") return null;
+  if (!body || typeof body !== "object") return body as Prisma.InputJsonValue | null;
+  if (Array.isArray(body)) return body.map(sanitizeBody) as Prisma.InputJsonValue;
+  
   const sanitized: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
-    sanitized[key] = SENSITIVE_KEYS.has(key) ? "[REDACTED]" : value;
+    if (SENSITIVE_KEYS.has(key)) {
+      sanitized[key] = "[REDACTED]";
+    } else if (typeof value === "object" && value !== null) {
+      sanitized[key] = sanitizeBody(value);
+    } else {
+      sanitized[key] = value;
+    }
   }
   return sanitized as Prisma.InputJsonValue;
 }

--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -8,7 +8,8 @@ const SENSITIVE_KEYS = new Set([
 ]);
 
 function sanitizeBody(body: unknown): Prisma.InputJsonValue | null {
-  if (!body || typeof body !== "object") return body as Prisma.InputJsonValue | null;
+  if (body === undefined) return null;
+  if (body === null || typeof body !== "object") return body as Prisma.InputJsonValue | null;
   if (Array.isArray(body)) return body.map(sanitizeBody) as Prisma.InputJsonValue;
   
   const sanitized: Record<string, unknown> = {};


### PR DESCRIPTION
Closes #1662 

## Changes
- Rewrote `sanitizeBody` in `server/src/middleware/error.middleware.ts` to be a recursive function.
- It now handles arrays (`body.map`) and deeply traverses objects.
- Primitive values of keys found inside the `SENSITIVE_KEYS` set are correctly replaced with `"[REDACTED]"`, regardless of how deeply nested they are within the JSON payload.
- Fallback logic safely returns the body if it is primitive or `null` to avoid breaking downstream Prisma inputs.

## Why
Previously, the middleware only sanitized keys at depth 1 (the root level of the JSON body). If a client sent a payload like `{ "data": { "password": "supersecret" } }`, the `password` field completely bypassed the filter and was logged in plain text to the database, resulting in a severe security leak.

Contributing under GSSoC'26 🎯


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging sanitization: request bodies now preserve primitive values, recursively handle nested objects and arrays, and redact sensitive fields so logs store more complete, safe request data.
* **Tests**
  * Added a test to verify deep nested sensitive fields are redacted before request data is recorded in error logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->