### PR TITLE
fix: swap inverted mobile theme toggle icons in Navbar (#1637)

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -260,9 +260,9 @@ export function Navbar({ sidebarOffset = 0 }: { sidebarOffset?: number }) {
               className="p-2 text-stone-500 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-50 rounded-md transition-colors"
             >
               {theme === "dark" ? (
-                <Moon className="w-4 h-4" />
-              ) : (
                 <Sun className="w-4 h-4" />
+              ) : (
+                <Moon className="w-4 h-4" />
               )}
             </button>
             {isAuthenticated && (


### PR DESCRIPTION
## What\nSwap the inverted Moon/Sun icons on the mobile theme toggle in Navbar.\n\n## Why\nCloses #1637 — mobile toggle showed Moon when dark (should show Sun, meaning 'click for light') and Sun when light (should show Moon, meaning 'click for dark'). Desktop version was correct.\n\n## Changes\n- Navbar.tsx:262-266 — swapped ternary operands to match desktop pattern\n\n## Verification\nMobile toggle now shows Sun icon in dark mode, Moon icon in light mode — consistent with desktop.\n\nCloses #1637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the mobile theme toggle button to correctly display the sun icon in dark mode and the moon icon in light mode, ensuring the icon accurately represents the theme that will be activated when clicked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->