### PR TITLE
fix: use existing createOrderSchema for payment checkout validation (#1638)

### DIFF
--- a/server/src/module/payment/payment.controller.ts
+++ b/server/src/module/payment/payment.controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import type { PaymentService } from "./payment.service.js";
+import { createOrderSchema } from "./payment.validation.js";
 
 export class PaymentController {
   constructor(private readonly paymentService: PaymentService) {}
@@ -11,17 +12,9 @@ export class PaymentController {
         return;
       }
 
-      const { plan, billing } = req.body;
-
-      if (!plan || !["pro"].includes(plan)) {
-        res.status(400).json({ message: "Invalid plan. Must be 'pro'" });
-        return;
-      }
-
-      if (!billing || !["monthly", "yearly"].includes(billing)) {
-        res.status(400).json({ message: "Invalid billing. Must be 'monthly' or 'yearly'" });
-        return;
-      }
+      const body = createOrderSchema.safeParse(req.body);
+      if (!body.success) return res.status(400).json({ message: "Validation failed", errors: body.error.flatten() });
+      const { plan, billing } = body.data;
 
       const result = await this.paymentService.createCheckoutSession(
         req.user.id,


### PR DESCRIPTION
## What\nReplace manual ad-hoc validation in createCheckout with existing createOrderSchema from payment.validation.ts.\n\n## Why\nCloses #1638 — the Zod schema existed but was never imported/used in the controller.\n\n## Changes\n- payment.controller.ts — import createOrderSchema, replace manual if-checks with safeParse\n\n## Verification\nValidation behavior is identical (same rules) but now follows project-standard Zod pattern.\n\nCloses #1638