### PR TITLE
fix: add isNaN validation for problemId param in 3 DSA endpoints (#1641)

### DIFF
--- a/server/src/module/dsa/dsa.controller.ts
+++ b/server/src/module/dsa/dsa.controller.ts
@@ -49,6 +49,7 @@ export class DsaController {
       const userId = req.user?.id;
       if (!userId) { res.status(401).json({ message: "Authentication required" }); return; }
       const problemId = parseInt(req.params.problemId as string);
+      if (isNaN(problemId)) return res.status(400).json({ message: "Invalid problem ID" });
       const result = await this.dsaService.toggleProblem(userId, problemId);
       res.json(result);
     } catch (err) {
@@ -61,6 +62,7 @@ export class DsaController {
       const userId = req.user?.id;
       if (!userId) { res.status(401).json({ message: "Authentication required" }); return; }
       const problemId = parseInt(req.params.problemId as string);
+      if (isNaN(problemId)) return res.status(400).json({ message: "Invalid problem ID" });
       const { notes } = req.body;
       const result = await this.dsaService.updateNotes(userId, problemId, notes ?? "");
       res.json(result);
@@ -74,6 +76,7 @@ export class DsaController {
       const userId = req.user?.id;
       if (!userId) { res.status(401).json({ message: "Authentication required" }); return; }
       const problemId = parseInt(req.params.problemId as string);
+      if (isNaN(problemId)) return res.status(400).json({ message: "Invalid problem ID" });
       const result = await this.dsaService.toggleBookmark(userId, problemId);
       res.json(result);
     } catch (err) {


### PR DESCRIPTION
## What\nAdd isNaN validation after parseInt for problemId param in toggleProblem, updateNotes, and toggleBookmark.\n\n## Why\nCloses #1641 — non-numeric problemId passed NaN to service layer, causing unhandled Prisma errors.\n\n## Changes\n- dsa.controller.ts:51,63,76 — added isNaN checks returning 400 on invalid ID\n\n## Verification\nGET /api/dsa/problems/abc/toggle now returns 400 instead of crashing.\n\nCloses #1641