### PR TITLE
fix: add isNaN validation for cover letter ID params (#1642)

### DIFF
--- a/server/src/module/ats/cover-letter.controller.ts
+++ b/server/src/module/ats/cover-letter.controller.ts
@@ -102,8 +102,10 @@ export class CoverLetterController {
         res.status(401).json({ message: "Authentication required" });
         return;
       }
+      const id = Number(req.params["id"]);
+      if (isNaN(id)) return res.status(400).json({ message: "Invalid cover letter ID" });
       const letter = await this.coverLetterService.getOne(
-        Number(req.params["id"]),
+        id,
         req.user.id
       );
       if (!letter) {
@@ -122,8 +124,10 @@ export class CoverLetterController {
         res.status(401).json({ message: "Authentication required" });
         return;
       }
+      const id = Number(req.params["id"]);
+      if (isNaN(id)) return res.status(400).json({ message: "Invalid cover letter ID" });
       await this.coverLetterService.deleteOne(
-        Number(req.params["id"]),
+        id,
         req.user.id
       );
       res.json({ success: true });


### PR DESCRIPTION
## What\nAdd isNaN checks after Number() conversion for id param in getOne and deleteOne endpoints.\n\n## Why\nCloses #1642 — non-numeric IDs passed NaN to service layer, causing unhandled Prisma errors.\n\n## Changes\n- cover-letter.controller.ts:106,126 — added isNaN checks returning 400 on invalid ID\n\n## Verification\nGET /api/cover-letters/abc now returns 400 instead of crashing.\n\nCloses #1642