### PR TITLE
fix: add error handling to empty .catch() blocks (#1644)

### DIFF
--- a/client/src/module/admin/AdminSubscribersPage.tsx
+++ b/client/src/module/admin/AdminSubscribersPage.tsx
@@ -5,6 +5,7 @@ import { SEO } from "../../components/SEO";
 import { PaginationControls } from "../../components/ui/PaginationControls";
 import { Button } from "../../components/ui/button";
 import api from "../../lib/axios";
+import toast from "../../components/ui/toast";
 
 interface Subscriber {
   id: number;
@@ -27,7 +28,10 @@ export default function AdminSubscribersPage() {
         setSubscribers(res.data.subscribers);
         setTotal(res.data.total);
       })
-      .catch(() => {})
+      .catch((err) => {
+        console.error("Failed to fetch subscribers:", err);
+        toast.error("Failed to fetch subscribers");
+      })
       .finally(() => setLoading(false));
   }, [page]);
 

--- a/client/src/module/student/roadmap/RoadmapCanvasPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapCanvasPage.tsx
@@ -481,7 +481,9 @@ export default function RoadmapCanvasPage() {
         );
         setWeakTopicTitles(slugs);
       })
-      .catch(() => { });
+      .catch((err) => {
+        console.error("Failed to fetch recommendations:", err);
+      });
   }, []);
 
   const toggleSection = useCallback((id: number) => {


### PR DESCRIPTION
## What\nReplace empty .catch(() => {}) blocks with proper error handling including toast notifications for admins and console logging for developers.\n\n## Why\nCloses #1644 — API errors were silently swallowed, leaving admin subscribers page in infinite loading and roadmap weak areas feature silently broken.\n\n## Changes\n- AdminSubscribersPage.tsx — added toast.error on fetch failure\n- RoadmapCanvasPage.tsx — added console.error for recommendations fetch failure\n\n## Verification\nNetwork errors now show toast notifications on admin page and log to console on roadmap page.\n\nCloses #1644