### PR TITLE
fix: add XSS sanitization to DSA problem description and hint rendering (#1650)

### DIFF
--- a/client/src/lib/sanitize.ts
+++ b/client/src/lib/sanitize.ts
@@ -18,3 +18,4 @@ export function sanitizeHtml(html: string): string {
     .replace(/<\/?font[^>]*>/gi, "")
     .replace(/<img\b[^>]*\/?>/gi, "");
 }
+}

--- a/client/src/module/student/dsa/DsaCompaniesPage.tsx
+++ b/client/src/module/student/dsa/DsaCompaniesPage.tsx
@@ -16,6 +16,7 @@ import { useAuthStore } from "../../../lib/auth.store";
 import { SEO } from "../../../components/SEO";
 import { canonicalUrl } from "../../../lib/seo.utils";
 import { LoadingScreen } from "../../../components/LoadingScreen";
+import { sanitizeHtml } from "../../../lib/sanitize";
 import { Button } from "../../../components/ui/button";
 import { DIFF_COLOR } from "../../../lib/difficulty-colors";
 
@@ -770,7 +771,7 @@ export default function DsaCompaniesPage() {
                                     {problem.hints.map((hint, i) => (
                                       <div key={i} className="text-sm text-stone-700 dark:text-stone-300 leading-relaxed flex gap-1">
                                         {problem.hints.length > 1 && <span className="font-mono font-medium text-stone-500 dark:text-stone-400 shrink-0">{i + 1}.</span>}
-                                        <span dangerouslySetInnerHTML={{ __html: cleanHint(hint) }} />
+                                        <span dangerouslySetInnerHTML={{ __html: sanitizeHtml(cleanHint(hint)) }} />
                                       </div>
                                     ))}
                                   </div>

--- a/client/src/module/student/dsa/DsaProblemDetailPage.tsx
+++ b/client/src/module/student/dsa/DsaProblemDetailPage.tsx
@@ -19,6 +19,7 @@ import { canonicalUrl, SITE_URL } from "../../../lib/seo.utils";
 import { breadcrumbSchema } from "../../../lib/structured-data";
 import { LoadingScreen } from "../../../components/LoadingScreen";
 import { AiHintPanel } from "./components/AiHintPanel";
+import { sanitizeHtml } from "../../../lib/sanitize";
 import { DsaCodeEditor } from "./components/DsaCodeEditor";
 import { DsaTestResults } from "./components/DsaTestResults";
 import { DsaSubmissionHistory } from "./components/DsaSubmissionHistory";
@@ -464,7 +465,7 @@ export default function DsaProblemDetailPage() {
                   <div className="mt-2 bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md p-4">
                     <div
                       className="prose dark:prose-invert max-w-none text-sm text-stone-700 dark:text-stone-300 leading-relaxed whitespace-pre-wrap"
-                      dangerouslySetInnerHTML={{ __html: formatDescription(problem.description) }}
+                      dangerouslySetInnerHTML={{ __html: sanitizeHtml(formatDescription(problem.description)) }}
                     />
                   </div>
                 </div>
@@ -484,7 +485,7 @@ export default function DsaProblemDetailPage() {
                   <div className="mt-2 bg-stone-50 dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md p-4">
                     <div
                       className="text-sm text-stone-700 dark:text-stone-300 whitespace-pre-wrap leading-relaxed"
-                      dangerouslySetInnerHTML={{ __html: formatDescription(problem.constraints) }}
+                      dangerouslySetInnerHTML={{ __html: sanitizeHtml(formatDescription(problem.constraints)) }}
                     />
                   </div>
                 </div>
@@ -528,7 +529,7 @@ export default function DsaProblemDetailPage() {
                             >
                               <div
                                 className="px-4 pb-4 pl-11 text-sm text-stone-700 dark:text-stone-300 leading-relaxed"
-                                dangerouslySetInnerHTML={{ __html: cleanHint(hint) }}
+                                dangerouslySetInnerHTML={{ __html: sanitizeHtml(cleanHint(hint)) }}
                               />
                             </motion.div>
                           )}

--- a/client/src/module/student/dsa/DsaTopicDetailPage.tsx
+++ b/client/src/module/student/dsa/DsaTopicDetailPage.tsx
@@ -17,6 +17,7 @@ import { SEO } from "../../../components/SEO";
 import { canonicalUrl, SITE_URL } from "../../../lib/seo.utils";
 import { breadcrumbSchema } from "../../../lib/structured-data";
 import { LoadingScreen } from "../../../components/LoadingScreen";
+import { sanitizeHtml } from "../../../lib/sanitize";
 import { Button } from "../../../components/ui/button";
 import { DIFF_COLOR } from "../../../lib/difficulty-colors";
 
@@ -552,7 +553,7 @@ export const DsaProblemCard = React.memo(function DsaProblemCard({
                             {i + 1}.
                           </span>
                         )}
-                        <span dangerouslySetInnerHTML={{ __html: cleanHint(hint) }} />
+                        <span dangerouslySetInnerHTML={{ __html: sanitizeHtml(cleanHint(hint)) }} />
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
## What\nAdd robust XSS sanitization to formatDescription and cleanHint outputs used in dangerouslySetInnerHTML across three DSA pages.\n\n## Why\nCloses #1650 — stored XSS vulnerability (Tier A). Custom regex functions passed raw HTML through unchanged, allowing script injection, event handlers, and javascript: URLs.\n\n## Changes\n- Created client/src/lib/sanitize.ts with shared sanitizeHtml function\n- DsaProblemDetailPage.tsx — sanitized description (451), constraints (471), hints (515)\n- DsaTopicDetailPage.tsx — sanitized hints (555)\n- DsaCompaniesPage.tsx — sanitized hints (773)\n\nSanitizer blocks: script tags, on* event handlers, javascript: URLs, iframe/embed/object, svg onload, img onerror, style/class attributes.\n\nCloses #1650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code structure in sanitization utility
  * Added HTML sanitization to DSA hints, problem descriptions, and constraints to protect against unsafe content injection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->