### PR TITLE
fix: replace Zod .parse() with .safeParse() in job controller (#1651)

### DIFF
--- a/server/src/module/job/job.controller.ts
+++ b/server/src/module/job/job.controller.ts
@@ -34,7 +34,9 @@ export class JobController {
 
   async getJobs(req: Request, res: Response) {
     try {
-      const query = jobQuerySchema.parse(req.query);
+      const result = jobQuerySchema.safeParse(req.query);
+      if (!result.success) return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
+      const query = result.data;
       const data = await this.jobService.getJobs(query);
       return res.status(200).json(data);
     } catch (error) {
@@ -103,7 +105,9 @@ export class JobController {
         return res.status(401).json({ message: "Authentication required" });
       }
 
-      const query = jobQuerySchema.parse(req.query);
+      const result = jobQuerySchema.safeParse(req.query);
+      if (!result.success) return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
+      const query = result.data;
       const data = await this.jobService.getRecruiterJobs(req.user.id, query);
       return res.status(200).json(data);
     } catch (error) {


### PR DESCRIPTION
## What\nReplace Zod .parse() with .safeParse() in getJobs() and getRecruiterJobs() to return 400 on invalid input instead of 500.\n\n## Why\nCloses #1651 — malformed query params caused 500 Internal Server Error instead of 400 Bad Request.\n\n## Changes\n- job.controller.ts:37,106 — replaced .parse() with .safeParse() + 400 return on failure\n\n## Verification\nGET /api/jobs?invalid=param now returns 400 with validation errors instead of 500.\n\nCloses #1651