### PR TITLE
fix: replace Zod .parse() with .safeParse() in 4 controllers to return 400 on invalid input (#1653)

### DIFF
--- a/server/src/module/attendance/attendance.controller.ts
+++ b/server/src/module/attendance/attendance.controller.ts
@@ -46,8 +46,9 @@ export class AttendanceController {
       const employeeId = Number(req.query["employeeId"]);
       if (isNaN(employeeId)) return res.status(400).json({ message: "employeeId required" });
 
-      const query = attendanceQuerySchema.parse(req.query);
-      const data = await this.attendanceService.getMyAttendance(employeeId, query);
+      const parsed = attendanceQuerySchema.safeParse(req.query);
+      if (!parsed.success) return res.status(400).json({ message: "Validation failed", errors: parsed.error.flatten() });
+      const data = await this.attendanceService.getMyAttendance(employeeId, parsed.data);
       return res.json(data);
     } catch (error) {
       console.error(error);
@@ -97,8 +98,9 @@ export class AttendanceController {
 
   async getReport(req: Request, res: Response) {
     try {
-      const query = attendanceQuerySchema.parse(req.query);
-      const data = await this.attendanceService.getReport(query);
+      const parsed = attendanceQuerySchema.safeParse(req.query);
+      if (!parsed.success) return res.status(400).json({ message: "Validation failed", errors: parsed.error.flatten() });
+      const data = await this.attendanceService.getReport(parsed.data);
       return res.json(data);
     } catch (error) {
       console.error(error);

--- a/server/src/module/interview/interview.controller.ts
+++ b/server/src/module/interview/interview.controller.ts
@@ -28,8 +28,9 @@ export class InterviewController {
   async getAll(req: Request, res: Response) {
     try {
       if (!req.user) return res.status(401).json({ message: "Authentication required" });
-      const query = interviewQuerySchema.parse(req.query);
-      const data = await this.interviewService.getAll(req.user.id, query);
+      const parsed = interviewQuerySchema.safeParse(req.query);
+      if (!parsed.success) return res.status(400).json({ message: "Validation failed", errors: parsed.error.flatten() });
+      const data = await this.interviewService.getAll(req.user.id, parsed.data);
       return res.json(data);
     } catch (error) {
       console.error(error);

--- a/server/src/module/job-feed/job-feed.controller.ts
+++ b/server/src/module/job-feed/job-feed.controller.ts
@@ -11,8 +11,9 @@ export class JobFeedController {
         res.status(403).json({ message: "InternHack AI is a premium feature. Upgrade to access personalized job recommendations.", upgradeUrl: "/student/checkout" });
         return;
       }
-      const query = feedQuerySchema.parse(req.query);
-      const result = await jobFeedService.getFeed(req.user.id, query.page, query.limit);
+      const parsed = feedQuerySchema.safeParse(req.query);
+      if (!parsed.success) { res.status(400).json({ message: "Validation failed", errors: parsed.error.flatten() }); return; }
+      const result = await jobFeedService.getFeed(req.user.id, parsed.data.page, parsed.data.limit);
       res.json(result);
     } catch (err) { next(err); }
   };

--- a/server/src/module/recruiter/recruiter.controller.ts
+++ b/server/src/module/recruiter/recruiter.controller.ts
@@ -137,7 +137,9 @@ export class RecruiterController {
       const jobId = parseInt(String(req.params["jobId"]), 10);
       if (isNaN(jobId)) return res.status(400).json({ message: "Invalid job ID" });
 
-      const filter = applicationFilterSchema.parse(req.query);
+      const parsed = applicationFilterSchema.safeParse(req.query);
+      if (!parsed.success) return res.status(400).json({ message: "Validation failed", errors: parsed.error.flatten() });
+      const filter = parsed.data;
       const data = await this.recruiterService.getApplications(jobId, req.user.id, filter);
       return res.status(200).json(data);
     } catch (error) {


### PR DESCRIPTION
## What\nReplace Zod .parse() with .safeParse() in 5 endpoints across 4 controllers.\n\n## Why\nCloses #1653 — malformed query params caused 500 Internal Server Error instead of 400 Bad Request.\n\n## Changes\n- ecruiter.controller.ts:140 — getApplications safeParse\n- ttendance.controller.ts:49,100 — getMyAttendance + getReport safeParse\n- interview.controller.ts:31 — getAll safeParse\n- job-feed.controller.ts:14 — getFeed safeParse\n\n## Verification\nAll 5 endpoints now return 400 with validation errors on malformed input instead of 500.\n\nCloses #1653