### PR TITLE
fix: call loadData() after mutations to refresh recruiter UI state (#1654)

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationDetail.tsx
+++ b/client/src/module/recruiter/applications/ApplicationDetail.tsx
@@ -121,11 +121,18 @@ const fetchDetail = useCallback(async (signal) => {
     }
   }, [applicationId]);
 
+  const loadData = useCallback(async () => {
+    const applicationData = await fetchDetail();
+    if (applicationData) {
+      setApplication(applicationData);
+    }
+  }, [fetchDetail]);
+
   useEffect(() => {
     const controller = new AbortController();
     let isMounted = true;
 
-    const loadData = async () => {
+    const initialLoad = async () => {
       try {
         setLoading(true);
         const applicationData = await fetchDetail(controller.signal);
@@ -133,8 +140,8 @@ const fetchDetail = useCallback(async (signal) => {
         if (isMounted) {
           setApplication(applicationData);
         }
-      } catch (err) {
-        // Errors are already logged in fetchDetail, handled here to prevent crashes
+      } catch {
+        // errors already logged in fetchDetail
       } finally {
         if (isMounted) {
           setLoading(false);
@@ -142,7 +149,7 @@ const fetchDetail = useCallback(async (signal) => {
       }
     };
 
-    loadData();
+    initialLoad();
 
     return () => {
       isMounted = false;
@@ -163,7 +170,7 @@ const fetchDetail = useCallback(async (signal) => {
   const handleAdvance = async () => {
     try {
       await api.patch(`/recruiter/applications/${applicationId}/advance`);
-      fetchDetail();
+      await loadData();
       toast.success("Application advanced");
     } catch {
       toast.error("Failed to advance");
@@ -175,7 +182,7 @@ const fetchDetail = useCallback(async (signal) => {
       await api.patch(`/recruiter/applications/${applicationId}/status`, {
         status,
       });
-      fetchDetail();
+      await loadData();
       toast.success("Status updated");
     } catch {
       toast.error("Failed to update status");
@@ -441,7 +448,7 @@ const fetchDetail = useCallback(async (signal) => {
                     criteria={sub.round?.evaluationCriteria || []}
                     onComplete={() => {
                       setEvaluatingRoundId(null);
-                      fetchDetail();
+                      loadData();
                     }}
                   />
                 </div>


### PR DESCRIPTION
## What\nFix stale UI in ApplicationDetail by replacing fetchDetail() calls (which discarded results) with loadData() calls that properly update state via setApplication.\n\n## Why\nCloses #1654 — after advancing a candidate, changing status, or completing evaluation, the UI continued showing stale data because fetchDetail() returned data but never passed it to setApplication().\n\n## Changes\n- ApplicationDetail.tsx — extracted loadData as useCallback, updated handleAdvance/handleStatusChange/evaluation onComplete to await loadData()\n\n## Verification\nAfter any mutation, the UI now immediately reflects the updated application state.\n\nCloses #1654