### PR TITLE
feat(recruiter): enforce application status transition validation

### DIFF
--- a/server/src/module/recruiter/recruiter.controller.ts
+++ b/server/src/module/recruiter/recruiter.controller.ts
@@ -183,6 +183,7 @@ export class RecruiterController {
       return res.status(200).json({ message: "Application status updated", application });
     } catch (error) {
       if (error instanceof Error) {
+        if ((error as any).statusCode === 409) return res.status(409).json({ message: error.message });
         if (error.message === "Application not found") return res.status(404).json({ message: error.message });
         if (error.message === "Not authorized") return res.status(403).json({ message: error.message });
       }

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -29,6 +29,16 @@ function isValidS3Url(url: string) {
 
 const logger = createLogger("recruiter.service");
 
+/** Legal manual status transitions for recruiter PATCH /applications/:id/status */
+const ALLOWED_TRANSITIONS: Record<ApplicationStatus, ApplicationStatus[]> = {
+  APPLIED: ["IN_PROGRESS", "REJECTED"],
+  IN_PROGRESS: ["SHORTLISTED", "REJECTED", "HIRED"],
+  SHORTLISTED: ["REJECTED", "HIRED"],
+  REJECTED: [],
+  HIRED: [],
+  WITHDRAWN: [],
+};
+
 interface TalentSearchFilter {
   page: number;
   limit: number;
@@ -372,6 +382,14 @@ export class RecruiterService {
     if (application.status === status) {
       const { job: _job, student: _student, ...current } = application;
       return current;
+    }
+
+    const allowedNext = ALLOWED_TRANSITIONS[application.status];
+    if (!allowedNext.includes(status)) {
+      throw Object.assign(
+        new Error(`Cannot transition application status from ${application.status} to ${status}`),
+        { statusCode: 409 },
+      );
     }
 
     const updated = await prisma.$transaction(async (tx) => {
@@ -860,4 +878,4 @@ export class RecruiterService {
     });
   }
 }
-
+


### PR DESCRIPTION
## Description
Implemented strict application status transition validation within the recruiter service. Previously, application statuses could be updated to any arbitrary value within the `ApplicationStatus` enum without verifying if the state progression was logical. 

This change introduces an `ALLOWED_TRANSITIONS` workflow map leveraging the Prisma enum values (including `IN_PROGRESS`), adds a guard condition to verify the current state before applying updates, and throws an HTTP 409 Conflict exception if an illegal state transition is attempted.

## Related Issue
Fixes #1107

## Type of Change
- [ ] Bug Fix
- [x] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing
- Manually tested changing statuses along valid paths (e.g., APPLIED -> IN_PROGRESS) to ensure they succeed.
- Verified that illegal state updates are caught by the guard condition and return a proper HTTP 409 Conflict response.
- Confirmed that backend linting passes successfully with no additional side effects.

## Screenshots / Video
_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)