### PR TITLE
fix(usage-limit): eliminate TOCTOU race condition in usageLimit middleware

### DIFF
--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -353,10 +353,7 @@ export default function RepoDiscoveryPage() {
 
   const pagination = data?.pagination;
 
-  const displayedRepos = useMemo(() => {
-    if (showSaved) return bookmarkedData || [];
-    return data?.repos ?? [];
-  }, [data, showSaved, bookmarkedData]);
+  const displayedRepos = showSaved ? (bookmarkedData ?? []) : (data?.repos ?? []);
 
   // Global stats fetched independently so the header strip stays accurate
   // regardless of active filters or page (replaces the old useMemo approach).

--- a/server/src/middleware/usage-limit.middleware.ts
+++ b/server/src/middleware/usage-limit.middleware.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from "express";
-import type { UsageAction } from "@prisma/client";
+import { Prisma, PrismaClientKnownRequestError, type UsageAction } from "@prisma/client";
 import { prisma } from "../database/db.js";
 import { DAILY_LIMITS, getPlanTier } from "../config/usage-limits.js";
 
@@ -10,46 +10,68 @@ export function usageLimit(action: UsageAction) {
       return;
     }
 
+    const userId = req.user.id;
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+
     try {
-      const startOfDay = new Date();
-      startOfDay.setHours(0, 0, 0, 0);
+      // Serializable transaction prevents TOCTOU race: concurrent requests that
+      // race through the count→insert path will cause one to get a P2034
+      // serialization failure rather than both slipping past the daily cap.
+      type TxResult =
+        | { ok: true; used: number; limit: number; tier: string }
+        | { ok: false; reason: "user_missing" | "limit_reached"; used: number; limit: number; tier: string };
 
-      // Run both DB calls in parallel - they are fully independent.
-      const [user, used] = await Promise.all([
-        prisma.user.findUnique({
-          where: { id: req.user.id },
-          select: { subscriptionPlan: true, subscriptionStatus: true, subscriptionEndDate: true },
-        }),
-        prisma.usageLog.count({
-          where: {
-            userId: req.user.id,
-            action,
-            createdAt: { gte: startOfDay },
-          },
-        }),
-      ]);
+      const result: TxResult = await prisma.$transaction(
+        async (tx: Prisma.TransactionClient) => {
+          const [user, used] = await Promise.all([
+            tx.user.findUnique({
+              where: { id: userId },
+              select: { subscriptionPlan: true, subscriptionStatus: true, subscriptionEndDate: true },
+            }),
+            tx.usageLog.count({
+              where: { userId, action, createdAt: { gte: startOfDay } },
+            }),
+          ]);
 
-      if (!user) {
-        res.status(401).json({ message: "User not found" });
-        return;
-      }
+          if (!user) return { ok: false, reason: "user_missing", used: 0, limit: 0, tier: "FREE" } as const;
 
-      const tier = getPlanTier(user.subscriptionPlan, user.subscriptionStatus, user.subscriptionEndDate);
-      const limit = DAILY_LIMITS[action][tier];
+          const tier = getPlanTier(user.subscriptionPlan, user.subscriptionStatus, user.subscriptionEndDate);
+          const limit = DAILY_LIMITS[action][tier];
 
-      if (used >= limit) {
+          if (used >= limit) return { ok: false, reason: "limit_reached", used, limit, tier } as const;
+
+          await tx.usageLog.create({ data: { userId, action } });
+          return { ok: true, used, limit, tier } as const;
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+
+      if (!result.ok) {
+        if (result.reason === "user_missing") {
+          res.status(401).json({ message: "User not found" });
+          return;
+        }
         res.status(429).json({
-          message: tier === "FREE"
+          message: result.tier === "FREE"
             ? "Daily limit reached. Upgrade to Premium for higher limits."
             : "Daily limit reached. Try again tomorrow.",
-          usage: { used, limit, action, tier },
+          usage: { used: result.used, limit: result.limit, action, tier: result.tier },
         });
         return;
       }
 
-      (req as any).usageInfo = { used, limit, action, tier };
+      (req as any).usageInfo = { used: result.used, limit: result.limit, action, tier: result.tier };
       next();
     } catch (err) {
+      if (err instanceof PrismaClientKnownRequestError && err.code === "P2034") {
+        // Serialization failure from a concurrent request hitting the same limit window.
+        res.status(429).json({
+          message: "Too many concurrent requests. Please try again in a moment.",
+          usage: { action },
+        });
+        return;
+      }
       next(err);
     }
   };

--- a/server/src/middleware/usage-limit.middleware.ts
+++ b/server/src/middleware/usage-limit.middleware.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from "express";
-import { Prisma, PrismaClientKnownRequestError, type UsageAction } from "@prisma/client";
+import { Prisma, type UsageAction } from "@prisma/client";
 import { prisma } from "../database/db.js";
 import { DAILY_LIMITS, getPlanTier } from "../config/usage-limits.js";
 
@@ -64,8 +64,13 @@ export function usageLimit(action: UsageAction) {
       (req as any).usageInfo = { used: result.used, limit: result.limit, action, tier: result.tier };
       next();
     } catch (err) {
-      if (err instanceof PrismaClientKnownRequestError && err.code === "P2034") {
-        // Serialization failure from a concurrent request hitting the same limit window.
+      // P2034 = Prisma serialization failure — a concurrent request won the race.
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        "code" in err &&
+        (err as { code: unknown }).code === "P2034"
+      ) {
         res.status(429).json({
           message: "Too many concurrent requests. Please try again in a moment.",
           usage: { action },

--- a/server/src/module/ats/ats.controller.ts
+++ b/server/src/module/ats/ats.controller.ts
@@ -30,8 +30,6 @@ export class AtsController {
 
       const score = await this.atsService.scoreResume(req.user.id, result.data);
 
-      await prisma.usageLog.create({ data: { userId: req.user.id, action: "ATS_SCORE" } });
-
       const usage = req.usageInfo
         ? { used: req.usageInfo.used + 1, limit: req.usageInfo.limit }
         : undefined;
@@ -83,8 +81,6 @@ export class AtsController {
       }
 
       const response = await this.atsService.applySuggestions(req.user.id, result.data);
-
-      await prisma.usageLog.create({ data: { userId: req.user.id, action: "GENERATE_RESUME" } });
 
       res.json(response);
     } catch (err) {

--- a/server/src/module/ats/cover-letter.controller.ts
+++ b/server/src/module/ats/cover-letter.controller.ts
@@ -3,7 +3,6 @@ import type { CoverLetterService } from "./cover-letter.service.js";
 import { generateCoverLetterSchema } from "./cover-letter.validation.js";
 import type { UserProfile } from "./cover-letter.validation.js";
 import { prisma } from "../../database/db.js";
-import type { UsageAction } from "@prisma/client";
 
 export class CoverLetterController {
   constructor(private readonly coverLetterService: CoverLetterService) {}
@@ -70,8 +69,6 @@ export class CoverLetterController {
         length:         result.data.length,
         targetWords:    result.data.targetWords ?? 300,
       }).catch(() => {});
-
-      await prisma.usageLog.create({ data: { userId: req.user.id, action: "COVER_LETTER" as UsageAction } });
 
       const usage = req.usageInfo
         ? { used: req.usageInfo.used + 1, limit: req.usageInfo.limit }

--- a/server/src/module/ats/resume-gen.controller.ts
+++ b/server/src/module/ats/resume-gen.controller.ts
@@ -3,7 +3,6 @@ import type { ResumeGenService } from "./resume-gen.service.js";
 import { generateResumeSchema } from "./resume-gen.validation.js";
 import type { UserProfile } from "./resume-gen.validation.js";
 import { prisma } from "../../database/db.js";
-import type { UsageAction } from "@prisma/client";
 
 export class ResumeGenController {
   constructor(private readonly resumeGenService: ResumeGenService) {}
@@ -70,8 +69,6 @@ export class ResumeGenController {
     latexContent: latex,
   },
 });
-
-      await prisma.usageLog.create({ data: { userId: req.user.id, action: "GENERATE_RESUME" as UsageAction } });
 
       const usage = req.usageInfo
         ? { used: req.usageInfo.used + 1, limit: req.usageInfo.limit }

--- a/server/src/module/dsa/dsa.service.ts
+++ b/server/src/module/dsa/dsa.service.ts
@@ -782,11 +782,6 @@ Return ONLY a JSON array, no markdown fences:
       });
     }
 
-    // Log usage for rate limiting
-    await prisma.usageLog.create({
-      data: { userId: studentId, action: "CODE_RUN" },
-    });
-
     // Track engagement — fire-and-forget, never blocks the submission response
     void prisma.contentView.create({
       data: {

--- a/server/src/module/job-agent/job-agent.controller.ts
+++ b/server/src/module/job-agent/job-agent.controller.ts
@@ -1,8 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
-import { prisma } from "../../database/db.js";
 import { JobAgentEmailError, jobAgentService } from "./job-agent.service.js";
 import { chatMessageSchema, emailJobsSchema } from "./job-agent.validation.js";
-import type { UsageAction } from "@prisma/client";
 
 export class JobAgentController {
   chat = async (req: Request, res: Response, next: NextFunction) => {
@@ -15,10 +13,6 @@ export class JobAgentController {
         return;
       }
       const result = await jobAgentService.chat(req.user.id, parsed.data.message);
-
-      await prisma.usageLog.create({
-        data: { userId: req.user.id, action: "AI_JOB_CHAT" as UsageAction },
-      });
 
       res.json(result);
     } catch (err) { next(err); }
@@ -61,11 +55,6 @@ export class JobAgentController {
           },
           abortController.signal,
         );
-
-        // Log usage once per request (not per token)
-        await prisma.usageLog.create({
-          data: { userId: req.user.id, action: "AI_JOB_CHAT" as UsageAction },
-        });
 
         send("done", {});
       } catch (err) {

--- a/server/src/module/student/student.controller.ts
+++ b/server/src/module/student/student.controller.ts
@@ -22,7 +22,6 @@ export class StudentController {
 
       const application = await this.studentService.applyToJob(jobId, req.user.id, result.data);
 
-      await prisma.usageLog.create({ data: { userId: req.user.id, action: "JOB_APPLICATION" } });
       const usage = req.usageInfo ? { used: req.usageInfo.used + 1, limit: req.usageInfo.limit } : undefined;
 
       return res.status(201).json({ message: "Application submitted successfully", application, usage });

--- a/server/src/module/student/student.external-application.service.test.ts
+++ b/server/src/module/student/student.external-application.service.test.ts
@@ -64,10 +64,9 @@ describe("StudentService.applyToExternalJob", () => {
     mocks.prisma.$transaction.mockImplementation(async (callback) => callback(mocks.tx));
   });
 
-  it("creates the application and usage log in one transaction", async () => {
+  it("creates the application in a transaction (usage logging is handled by middleware)", async () => {
     mocks.prisma.adminJob.findUnique.mockResolvedValue(activeJob);
     mocks.tx.externalJobApplication.create.mockResolvedValue(createdApplication);
-    mocks.tx.usageLog.create.mockResolvedValue({ id: 401 });
 
     await expect(service.applyToExternalJob(44, 23)).resolves.toEqual(createdApplication);
 
@@ -80,19 +79,16 @@ describe("StudentService.applyToExternalJob", () => {
         },
       },
     });
-    expect(mocks.tx.usageLog.create).toHaveBeenCalledWith({
-      data: { userId: 44, action: "JOB_APPLICATION" },
-    });
+    expect(mocks.tx.usageLog.create).not.toHaveBeenCalled();
     expect(mocks.prisma.externalJobApplication.create).not.toHaveBeenCalled();
     expect(mocks.prisma.usageLog.create).not.toHaveBeenCalled();
   });
 
-  it("does not run post-commit work when usage logging fails", async () => {
+  it("does not run post-commit work when application creation fails", async () => {
     mocks.prisma.adminJob.findUnique.mockResolvedValue(activeJob);
-    mocks.tx.externalJobApplication.create.mockResolvedValue(createdApplication);
-    mocks.tx.usageLog.create.mockRejectedValue(new Error("Usage log unavailable"));
+    mocks.tx.externalJobApplication.create.mockRejectedValue(new Error("DB write failed"));
 
-    await expect(service.applyToExternalJob(44, 23)).rejects.toThrow("Usage log unavailable");
+    await expect(service.applyToExternalJob(44, 23)).rejects.toThrow("DB write failed");
     expect(mocks.badgeService.checkAndAwardBadges).not.toHaveBeenCalled();
     expect(checkApplicationMilestoneSpy).not.toHaveBeenCalled();
   });

--- a/server/src/module/student/student.service.ts
+++ b/server/src/module/student/student.service.ts
@@ -264,9 +264,6 @@ Rules:
             },
           },
         });
-        await tx.usageLog.create({
-          data: { userId: studentId, action: "JOB_APPLICATION" },
-        });
         return createdApplication;
       });
 

--- a/server/src/module/upload/upload.controller.ts
+++ b/server/src/module/upload/upload.controller.ts
@@ -197,14 +197,6 @@ export class UploadController {
         select: { id: true, name: true, email: true, role: true, contactNo: true, profilePic: true, resumes: true, company: true, designation: true, createdAt: true },
       });
 
-      // Log daily quota usage for resume generation/upload
-      await prisma.usageLog.create({
-        data: {
-          userId: req.user.id,
-          action: "GENERATE_RESUME",
-        },
-      });
-
       const signedResumes = await signUrls(user.resumes);
       return res.status(200).json({
         message: "Resume updated",


### PR DESCRIPTION
## Summary

Fixes #1741 — TOCTOU race condition in `usageLimit` middleware that allowed concurrent requests to bypass the daily cap.

- **Root cause**: `usageLog.count` (middleware) and `usageLog.create` (controller) were two separate, non-atomic DB operations. Concurrent requests all read the same count before any one of them wrote a new log entry, so all passed the limit check.
- **Fix**: Moved `usageLog.create` from individual controllers into the `usageLimit` middleware, wrapped in a `Prisma.$transaction` with `Serializable` isolation level. The count-check and log-insert now execute atomically. Any concurrent transaction that races through the same window will fail with a P2034 serialization error, which is surfaced as a 429 response.
- **Scope**: Removed the scattered `usageLog.create` calls from `ats.controller.ts`, `cover-letter.controller.ts`, `resume-gen.controller.ts`, `job-agent.controller.ts`, `student.controller.ts`, `student.service.ts`, `dsa.service.ts`, and `upload.controller.ts`. The `bookMockInterview` flow (which has its own independent count logic) and `latex-chat` (not middleware-gated) are intentionally left unchanged.

## Test plan

- [ ] Fire concurrent ATS score requests at the daily limit boundary — only the expected number should succeed
- [ ] Verify a single request still works normally under the limit
- [ ] Verify 429 is returned once the limit is reached
- [ ] Confirm serialization failure (concurrent burst) returns a 429 with a clear message
- [ ] Smoke-test cover letter, resume generation, job application, code run, and AI job chat endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Daily usage enforcement now prevents race conditions and returns proper 429 for concurrent requests with clearer tier-specific messaging.

* **Refactor**
  * Usage accounting centralized to middleware; controllers and services no longer emit duplicate per-request usage entries.
  * Coding problem engagement is tracked via improved content-view recording (better time/completion data).
* **Behavior**
  * Responses now include consistent usage info when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->