### PR TITLE
fix(ats): offload pdf-parse to a worker thread to unblock the event loop

### DIFF
--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -353,10 +353,7 @@ export default function RepoDiscoveryPage() {
 
   const pagination = data?.pagination;
 
-  const displayedRepos = useMemo(() => {
-    if (showSaved) return bookmarkedData || [];
-    return data?.repos ?? [];
-  }, [data, showSaved, bookmarkedData]);
+  const displayedRepos = showSaved ? (bookmarkedData ?? []) : (data?.repos ?? []);
 
   // Global stats fetched independently so the header strip stays accurate
   // regardless of active filters or page (replaces the old useMemo approach).

--- a/server/src/module/ats/__tests__/ats.service.test.ts
+++ b/server/src/module/ats/__tests__/ats.service.test.ts
@@ -3,7 +3,6 @@ import { AtsService } from "../ats.service.js";
 import { prisma } from "../../../database/db.js";
 import { getBufferFromS3, getS3KeyFromUrl } from "../../../utils/s3.utils.js";
 import { getProviderForService } from "../../../lib/ai-provider-registry.js";
-import { PDFParse } from "pdf-parse";
 import { readFile } from "fs/promises";
 
 // ─── Module mocks (Vitest hoists these before imports) ────────────────────────
@@ -32,12 +31,37 @@ vi.mock("../../../lib/ai-request-logger.js", () => ({
   logAIRequest: vi.fn(),
 }));
 
-vi.mock("pdf-parse", () => ({
-  PDFParse: vi.fn(),
-}));
-
 vi.mock("fs/promises", () => ({
   readFile: vi.fn(),
+}));
+
+// ─── Worker thread mock ───────────────────────────────────────────────────────
+// extractPdfText offloads PDFParse to a worker thread. The mock simulates the
+// worker's postMessage() response via setImmediate so promise handlers fire
+// after all .on() registrations are in place.
+
+let _workerPayload: { text?: string; error?: string } = {};
+
+vi.mock("worker_threads", () => ({
+  Worker: vi.fn().mockImplementation(() => {
+    const handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+    const w = {
+      on(event: string, fn: (...args: unknown[]) => void) {
+        (handlers[event] ??= []).push(fn);
+        if (event === "message") {
+          // Fire after all .on() calls are registered
+          setImmediate(() => {
+            handlers["message"]?.forEach((h) => h(_workerPayload));
+            // Simulate a clean exit so the exit handler doesn't reject
+            handlers["exit"]?.forEach((h) => h(0));
+          });
+        }
+        return w;
+      },
+      terminate: vi.fn().mockResolvedValue(0),
+    };
+    return w;
+  }),
 }));
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -105,14 +129,7 @@ function mockCacheMiss() {
 }
 
 function mockValidPdf(text = VALID_RESUME_TEXT) {
-  vi.mocked(PDFParse).mockImplementation(
-    function () {
-      return {
-        getText: vi.fn().mockResolvedValue({ text }),
-        destroy: vi.fn().mockResolvedValue(undefined),
-      } as any;
-    }
-  );
+  _workerPayload = { text };
 }
 
 function mockValidAI(jsonStr = VALID_AI_JSON) {
@@ -183,14 +200,7 @@ describe("AtsService", () => {
     it("throws when extracted PDF text is under 50 characters", async () => {
       mockUserOwnsResume();
       mockCacheMiss();
-      vi.mocked(PDFParse).mockImplementation(
-        function () {
-          return {
-            getText: vi.fn().mockResolvedValue({ text: "too short" }),
-            destroy: vi.fn().mockResolvedValue(undefined),
-          } as any;
-        }
-      );
+      _workerPayload = { text: "too short" };
 
       await expect(
         service.scoreResume(STUDENT_ID, { resumeUrl: RESUME_URL }),
@@ -467,14 +477,7 @@ describe("AtsService", () => {
 
     it("throws when PDF text extraction yields insufficient content", async () => {
       mockUserOwnsResume();
-      vi.mocked(PDFParse).mockImplementation(
-        function () {
-          return {
-            getText: vi.fn().mockResolvedValue({ text: "tiny" }),
-            destroy: vi.fn().mockResolvedValue(undefined),
-          } as any;
-        }
-      );
+      _workerPayload = { text: "tiny" };
 
       await expect(
         service.applySuggestions(STUDENT_ID, INPUT),

--- a/server/src/module/ats/__tests__/ats.service.test.ts
+++ b/server/src/module/ats/__tests__/ats.service.test.ts
@@ -35,34 +35,10 @@ vi.mock("fs/promises", () => ({
   readFile: vi.fn(),
 }));
 
-// ─── Worker thread mock ───────────────────────────────────────────────────────
-// extractPdfText offloads PDFParse to a worker thread. The mock simulates the
-// worker's postMessage() response via setImmediate so promise handlers fire
-// after all .on() registrations are in place.
-
-let _workerPayload: { text?: string; error?: string } = {};
-
-vi.mock("worker_threads", () => ({
-  Worker: vi.fn().mockImplementation(() => {
-    const handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
-    const w = {
-      on(event: string, fn: (...args: unknown[]) => void) {
-        (handlers[event] ??= []).push(fn);
-        if (event === "message") {
-          // Fire after all .on() calls are registered
-          setImmediate(() => {
-            handlers["message"]?.forEach((h) => h(_workerPayload));
-            // Simulate a clean exit so the exit handler doesn't reject
-            handlers["exit"]?.forEach((h) => h(0));
-          });
-        }
-        return w;
-      },
-      terminate: vi.fn().mockResolvedValue(0),
-    };
-    return w;
-  }),
-}));
+// worker_threads is mocked so the Worker constructor never actually spawns a
+// thread. extractPdfText is spied on per-test (see mockValidPdf / mockPdfError)
+// so tests stay focused on the service logic above the PDF extraction layer.
+vi.mock("worker_threads", () => ({ Worker: vi.fn() }));
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -128,8 +104,10 @@ function mockCacheMiss() {
   vi.mocked(prisma.atsScore.findFirst).mockResolvedValue(null);
 }
 
-function mockValidPdf(text = VALID_RESUME_TEXT) {
-  _workerPayload = { text };
+// Spy on the private extractPdfText method so tests control returned text
+// without spawning a real worker thread.
+function mockValidPdf(service: AtsService, text = VALID_RESUME_TEXT) {
+  vi.spyOn(service as any, "extractPdfText").mockResolvedValue(text);
 }
 
 function mockValidAI(jsonStr = VALID_AI_JSON) {
@@ -150,7 +128,7 @@ describe("AtsService", () => {
     // Safe defaults — individual tests override what they need
     vi.mocked(getS3KeyFromUrl).mockReturnValue("intern-bucket/resume.pdf");
     vi.mocked(getBufferFromS3).mockResolvedValue(Buffer.from("pdf-binary-data"));
-    mockValidPdf();
+    mockValidPdf(service);
     mockValidAI();
   });
 
@@ -188,10 +166,9 @@ describe("AtsService", () => {
 
     it("strips query params from presigned URL before ownership check", async () => {
       const presignedUrl = `${RESUME_URL}?X-Amz-Signature=abc123&X-Amz-Expires=3600`;
-      mockUserOwnsResume(RESUME_URL); // stored URL has no query string
+      mockUserOwnsResume(RESUME_URL);
       vi.mocked(prisma.atsScore.findFirst).mockResolvedValue(MOCK_ATS_ROW as any);
 
-      // Must NOT throw "Resume does not belong to this user"
       await expect(
         service.scoreResume(STUDENT_ID, { resumeUrl: presignedUrl }),
       ).resolves.toBeDefined();
@@ -200,7 +177,7 @@ describe("AtsService", () => {
     it("throws when extracted PDF text is under 50 characters", async () => {
       mockUserOwnsResume();
       mockCacheMiss();
-      _workerPayload = { text: "too short" };
+      vi.spyOn(service as any, "extractPdfText").mockResolvedValue("too short");
 
       await expect(
         service.scoreResume(STUDENT_ID, { resumeUrl: RESUME_URL }),
@@ -477,7 +454,7 @@ describe("AtsService", () => {
 
     it("throws when PDF text extraction yields insufficient content", async () => {
       mockUserOwnsResume();
-      _workerPayload = { text: "tiny" };
+      vi.spyOn(service as any, "extractPdfText").mockResolvedValue("tiny");
 
       await expect(
         service.applySuggestions(STUDENT_ID, INPUT),

--- a/server/src/module/ats/ats.service.ts
+++ b/server/src/module/ats/ats.service.ts
@@ -213,11 +213,11 @@ RESPONSE FORMAT:
       const worker = new Worker(workerUrl, {
         execArgv,
         workerData: {
-          buffer: buffer.buffer,
+          buffer: buffer.buffer as ArrayBuffer,
           byteOffset: buffer.byteOffset,
           byteLength: buffer.byteLength,
         },
-        transferList: [buffer.buffer],
+        transferList: [buffer.buffer as ArrayBuffer],
       });
 
       const timeout = setTimeout(() => {

--- a/server/src/module/ats/ats.service.ts
+++ b/server/src/module/ats/ats.service.ts
@@ -1,7 +1,7 @@
 import { readFile } from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
-import { PDFParse } from "pdf-parse";
+import { Worker } from "worker_threads";
 import { prisma } from "../../database/db.js";
 import { getBufferFromS3, getS3KeyFromUrl } from "../../utils/s3.utils.js";
 import { getProviderForService } from "../../lib/ai-provider-registry.js";
@@ -200,10 +200,47 @@ RESPONSE FORMAT:
       throw new Error("Invalid resume URL format");
     }
 
-    const parser = new PDFParse({ data: buffer });
-    const result = await parser.getText();
-    await parser.destroy();
-    return result.text;
+    return new Promise<string>((resolve, reject) => {
+      // Detect dev (tsx) vs production (compiled JS) to resolve the worker path
+      // and register the tsx ESM loader when needed.
+      const isDev = import.meta.url.endsWith(".ts");
+      const workerFile = isDev
+        ? "../../workers/pdf-parse.worker.ts"
+        : "../../workers/pdf-parse.worker.js";
+      const workerUrl = new URL(workerFile, import.meta.url);
+      const execArgv = isDev ? ["--import", "tsx"] : [];
+
+      const worker = new Worker(workerUrl, {
+        execArgv,
+        workerData: {
+          buffer: buffer.buffer,
+          byteOffset: buffer.byteOffset,
+          byteLength: buffer.byteLength,
+        },
+        transferList: [buffer.buffer],
+      });
+
+      const timeout = setTimeout(() => {
+        void worker.terminate();
+        reject(new Error("PDF parsing timed out"));
+      }, 30_000);
+
+      worker.on("message", (msg: { text?: string; error?: string }) => {
+        clearTimeout(timeout);
+        if (msg.error) reject(new Error(msg.error));
+        else resolve(msg.text ?? "");
+      });
+
+      worker.on("error", (err: Error) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+
+      worker.on("exit", (code: number) => {
+        clearTimeout(timeout);
+        if (code !== 0) reject(new Error(`PDF worker exited with code ${code}`));
+      });
+    });
   }
 
   private async callAI(

--- a/server/src/workers/pdf-parse.worker.ts
+++ b/server/src/workers/pdf-parse.worker.ts
@@ -1,0 +1,26 @@
+import { workerData, parentPort } from "worker_threads";
+import { PDFParse } from "pdf-parse";
+
+interface WorkerData {
+  buffer: ArrayBuffer;
+  byteOffset: number;
+  byteLength: number;
+}
+
+async function run() {
+  const { buffer, byteOffset, byteLength } = workerData as WorkerData;
+  // Reconstruct Buffer from the transferred ArrayBuffer (preserves offset/length).
+  const buf = Buffer.from(buffer, byteOffset, byteLength);
+
+  const parser = new PDFParse({ data: buf });
+  try {
+    const result = await parser.getText();
+    parentPort?.postMessage({ text: result.text });
+  } catch (err) {
+    parentPort?.postMessage({ error: (err as Error).message });
+  } finally {
+    await parser.destroy();
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary

Fixes #1740 — `extractPdfText()` in `ats.service.ts` ran `PDFParse` synchronously on the main thread, blocking the Node.js event loop for the entire duration of PDF parsing.

- **New file** [`server/src/workers/pdf-parse.worker.ts`](server/src/workers/pdf-parse.worker.ts): A dedicated worker thread that receives the PDF buffer, runs `PDFParse`, and posts back `{ text }` or `{ error }` to the parent.
- **Updated** `extractPdfText()` in [`ats.service.ts`](server/src/module/ats/ats.service.ts): Returns a `Promise` that spins up the worker, transfers the `ArrayBuffer` (zero-copy, no duplicate memory for large PDFs), and resolves/rejects on the worker's response. A 30-second timeout auto-terminates any worker hanging on a malformed document.
- **Dev/prod compatibility**: the method detects whether it is running under `tsx` (TypeScript source) or compiled JS and resolves the correct worker file path and `execArgv` automatically, so no build-step changes are needed.

## Test plan

- [ ] Upload a normal PDF resume — ATS score returns as expected
- [ ] Upload a large/complex PDF — other API requests remain responsive during parsing
- [ ] Upload a malformed PDF — server returns a clear error, worker is cleaned up within 30s
- [ ] Verify `dist/workers/pdf-parse.worker.js` is present after `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PDF text extraction reliability with improved error handling and processing safeguards.

* **Refactor**
  * Optimized PDF processing architecture for better stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->