### PR TITLE
feat(recruiter): soft-delete rounds and filter out deactivated student accounts

### DIFF
--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -182,6 +182,7 @@ model round {
   activateAt          DateTime?
   createdAt           DateTime          @default(now())
   updatedAt           DateTime          @updatedAt
+  isArchived          Boolean           @default(false)
   job                 job               @relation(fields: [jobId], references: [id], onDelete: Cascade)
   roundSubmissions    roundSubmission[]
 

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -144,7 +144,7 @@ export class RecruiterService {
     if (job.recruiterId !== recruiterId) throw new Error("Not authorized");
 
     return prisma.round.findMany({
-      where: { jobId },
+      where: { jobId, isArchived: false },
       orderBy: { orderIndex: "asc" },
       include: {
         _count: { select: { roundSubmissions: true } },
@@ -193,11 +193,17 @@ export class RecruiterService {
     const round = await prisma.round.findUnique({ where: { id: roundId } });
     if (!round || round.jobId !== jobId) throw new Error("Round not found");
 
-    await prisma.round.delete({ where: { id: roundId } });
+    await prisma.round.update({
+      where: { id: roundId },
+      data: {
+        isArchived: true,
+        orderIndex: -roundId,
+      },
+    });
 
-    // Re-index remaining rounds
+    // Re-index remaining active rounds
     const remainingRounds = await prisma.round.findMany({
-      where: { jobId },
+      where: { jobId, isArchived: false },
       orderBy: { orderIndex: "asc" },
     });
 
@@ -419,7 +425,7 @@ export class RecruiterService {
       }
 
       const rounds = await tx.round.findMany({
-        where: { jobId: application.jobId },
+        where: { jobId: application.jobId, isArchived: false },
         orderBy: { orderIndex: "asc" },
       });
 


### PR DESCRIPTION
This PR resolves issues #1174 and #1167 by supporting soft-deletion of recruiter rounds (adding isArchived to Schema, filtering in service layer, and re-indexing OrderIndex) and verifying that inactive student accounts are excluded from talent search.

Closes #1174
Closes #1167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Round deletion now archives rounds instead of permanently removing them, preserving historical recruitment data. Archived rounds are automatically hidden from all recruitment workflows and operations for a cleaner view of active rounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->