### PR TITLE
fix: remove duplicate ownerUserId declaration

### DIFF
--- a/client/src/lib/types/roadmap.types.ts
+++ b/client/src/lib/types/roadmap.types.ts
@@ -182,7 +182,6 @@ export interface RoadmapEnrollmentListItem {
     tags?: string[];
     isAiGenerated?: boolean;
     ownerUserId?: number | null;
-    ownerUserId: number | null;
   };
   createdAt: string;
 }


### PR DESCRIPTION
### Summary

This PR resolves the TypeScript compilation failure caused by duplicate `ownerUserId` declarations inside the nested `roadmap` object of `RoadmapEnrollmentListItem`.

### Changes

* Removed the duplicate `ownerUserId` declaration.
* Retained a single `ownerUserId?: number | null` property.
* Eliminated the TypeScript duplicate identifier errors.

### Verification

Ran:

```bash
npx tsc -b
```

The following errors are no longer produced:

```text
TS2300: Duplicate identifier 'ownerUserId'
TS2687: All declarations of 'ownerUserId' must have identical modifiers
TS2717: Subsequent property declarations must have the same type
```

Fixes #1736


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated roadmap data structure to handle cases where owner information may not be available, improving flexibility in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->