### PR TITLE
fix: remove obsolete dsaSubTopic cleanup step

### DIFF
--- a/server/src/database/clear-dsa.ts
+++ b/server/src/database/clear-dsa.ts
@@ -17,11 +17,8 @@ async function main() {
   const del3 = await prisma.$executeRawUnsafe('DELETE FROM "dsaProblem"');
   console.log("Deleted problems:", del3);
 
-  const del4 = await prisma.$executeRawUnsafe('DELETE FROM "dsaSubTopic"');
-  console.log("Deleted subtopics:", del4);
-
-  const del5 = await prisma.$executeRawUnsafe('DELETE FROM "dsaTopic"');
-  console.log("Deleted topics:", del5);
+  const del4 = await prisma.$executeRawUnsafe('DELETE FROM "dsaTopic"');
+  console.log("Deleted topics:", del4);
 
   console.log("Done!");
   await prisma.$disconnect();


### PR DESCRIPTION
## Summary

This PR removes an obsolete cleanup step from the DSA database maintenance script.

The script was still attempting to delete records from the `dsaSubTopic` table even though that table has been removed from the current Prisma schema by a later migration.

## Changes

* Removed the stale `DELETE FROM "dsaSubTopic"` statement from `clear-dsa.ts`.
* Removed the associated log message.
* Updated variable numbering to keep the cleanup flow consistent.

## Root Cause

The cleanup script contained:

```ts
const del4 = await prisma.$executeRawUnsafe(
  'DELETE FROM "dsaSubTopic"'
);
console.log("Deleted subtopics:", del4);
```

However, the migration:

`20260512140742_add_leetcode_slug_and_source`

contains:

```sql
DROP TABLE "dsaSubTopic";
```

and the current Prisma schema no longer defines a `dsaSubTopic` model.

## Verification

* Verified that the current Prisma schema contains `dsaTopic` and `dsaProblem`.
* Verified that no `dsaSubTopic` model exists in the active schema.
* Confirmed that `clear-dsa.ts` no longer references `dsaSubTopic`.
* Confirmed the branch contains only the intended cleanup change.

## Impact

Keeps the DSA maintenance script aligned with the current database schema and prevents references to a removed table.

Fixes #1737


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database maintenance routines to refine data cleanup operations and ensure proper handling of system data structures during maintenance cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->