### PR TITLE
fix: add safeParse success checks in reimbursement approve/reject/financeApprove

### DIFF
--- a/server/src/module/reimbursement/reimbursement.controller.ts
+++ b/server/src/module/reimbursement/reimbursement.controller.ts
@@ -96,7 +96,9 @@ export class ReimbursementController {
       if (isNaN(id)) return res.status(400).json({ message: "Invalid reimbursement ID" });
 
       const body = approveReimbursementSchema.safeParse(req.body);
-      const record = await this.reimbursementService.approve(id, body.data?.approverNote);
+      if (!body.success) return res.status(400).json({ message: "Validation failed", errors: body.error.flatten() });
+
+      const record = await this.reimbursementService.approve(id, body.data.approverNote);
       return res.json({ message: "Reimbursement approved", record });
     } catch (error) {
       if (error instanceof Error && (error.message === "Reimbursement not found" || error.message.startsWith("Only")))
@@ -112,7 +114,9 @@ export class ReimbursementController {
       if (isNaN(id)) return res.status(400).json({ message: "Invalid reimbursement ID" });
 
       const body = approveReimbursementSchema.safeParse(req.body);
-      const record = await this.reimbursementService.reject(id, body.data?.approverNote);
+      if (!body.success) return res.status(400).json({ message: "Validation failed", errors: body.error.flatten() });
+
+      const record = await this.reimbursementService.reject(id, body.data.approverNote);
       return res.json({ message: "Reimbursement rejected", record });
     } catch (error) {
       if (error instanceof Error && (error.message === "Reimbursement not found" || error.message.startsWith("Only")))
@@ -128,7 +132,9 @@ export class ReimbursementController {
       if (isNaN(id)) return res.status(400).json({ message: "Invalid reimbursement ID" });
 
       const body = approveReimbursementSchema.safeParse(req.body);
-      const record = await this.reimbursementService.financeApprove(id, body.data?.approverNote);
+      if (!body.success) return res.status(400).json({ message: "Validation failed", errors: body.error.flatten() });
+
+      const record = await this.reimbursementService.financeApprove(id, body.data.approverNote);
       return res.json({ message: "Reimbursement approved by finance", record });
     } catch (error) {
       if (error instanceof Error && (error.message === "Reimbursement not found" || error.message.startsWith("Only")))


### PR DESCRIPTION
Closes #1630

## Summary
- Added \if (!body.success) return res.status(400)\ guard after \safeParse\ calls in \pprove()\, \eject()\, and \inanceApprove()\
- Changed \ody.data?.approverNote\ (optional chaining) to \ody.data.approverNote\ since validated data is guaranteed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for reimbursement approval requests with improved error feedback when required information is missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->