### PR TITLE
fix: properly clean up setTimeout in ProfilePageHeader handleSave using useRef

### DIFF
--- a/client/src/module/student/profile/components/ProfilePageHeader.tsx
+++ b/client/src/module/student/profile/components/ProfilePageHeader.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Save, Loader2 } from "lucide-react";
 
 interface ProfilePageHeaderProps {
@@ -10,17 +10,17 @@ interface ProfilePageHeaderProps {
 
 export function ProfilePageHeader({ profileCompletion, saving, onSave }: ProfilePageHeaderProps) {
   const [showSuccess, setShowSuccess] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
 
   const handleSave = async () => {
     try {
       await onSave();
       setShowSuccess(true);
-
-      const timer = setTimeout(() => {
-        setShowSuccess(false);
-      }, 3000);
-
-      return () => clearTimeout(timer);
+      timerRef.current = setTimeout(() => setShowSuccess(false), 3000);
     } catch (error) {
       console.error("Save failed:", error);
     }


### PR DESCRIPTION
Closes #1646

## Summary
- Moved \setTimeout\ into a \useRef<ReturnType<typeof setTimeout>>()\ to store the timer reference
- Added \useEffect\ cleanup to clear the timer on unmount
- Removed orphaned \eturn () => clearTimeout(timer)\ that was never executed by React (event handler, not useEffect)