### PR TITLE
fix: add isNaN guard and Zod validation to aptitude submitAnswer

### DIFF
--- a/server/src/module/aptitude/aptitude.controller.ts
+++ b/server/src/module/aptitude/aptitude.controller.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from "express";
+import { z } from "zod";
 import { AptitudeService } from "./aptitude.service.js";
 import { parsePagination } from "../../utils/pagination.utils.js";
 
@@ -31,10 +32,13 @@ export class AptitudeController {
   async submitAnswer(req: Request, res: Response, next: NextFunction) {
     try {
       const questionId = parseInt(req.params.id as string);
+      if (isNaN(questionId)) return res.status(400).json({ error: "Invalid question ID" });
       const studentId = req.user!.id;
-      const { answer } = req.body;
-      if (!answer) return res.status(400).json({ error: "Answer is required" });
-      const result = await this.service.submitAnswer(studentId, questionId, answer);
+      const body = z.object({
+        answer: z.union([z.string(), z.number()])
+      }).safeParse(req.body);
+      if (!body.success) return res.status(400).json({ error: "Invalid answer format", errors: body.error.flatten() });
+      const result = await this.service.submitAnswer(studentId, questionId, body.data.answer);
       res.json(result);
     } catch (err) {
       next(err);


### PR DESCRIPTION
## What

Adds isNaN guard and Zod validation to the aptitude submitAnswer endpoint

## Root cause

submitAnswer was missing isNaN check on questionId and used manual truthy check instead of Zod validation

## Changes

- server/src/module/aptitude/aptitude.controller.ts — added isNaN guard and Zod safeParse for answer body

## Verification

- [ ] Bug reproduced before fix
- [ ] Fix verified locally
- [ ] git diff upstream/main...HEAD --stat shows only intended file
- [ ] No console.logs or debug logs remaining
- [ ] Build passes

## CI failures (if any)

[pre-existing failures unrelated to this PR - remove if CI green]

## Before / After

Backend only - no UI changes

Closes #1643