### PR TITLE
fix: add safeParse success guards to reimbursement approve/reject/financeApprove

### DIFF
--- a/server/src/module/reimbursement/reimbursement.controller.ts
+++ b/server/src/module/reimbursement/reimbursement.controller.ts
@@ -96,6 +96,7 @@ export class ReimbursementController {
       if (isNaN(id)) return res.status(400).json({ message: "Invalid reimbursement ID" });
 
       const body = approveReimbursementSchema.safeParse(req.body);
+      if (!body.success) return res.status(400).json({ message: "Validation failed", errors: body.error.flatten() });
       const record = await this.reimbursementService.approve(id, body.data?.approverNote);
       return res.json({ message: "Reimbursement approved", record });
     } catch (error) {
@@ -112,6 +113,7 @@ export class ReimbursementController {
       if (isNaN(id)) return res.status(400).json({ message: "Invalid reimbursement ID" });
 
       const body = approveReimbursementSchema.safeParse(req.body);
+      if (!body.success) return res.status(400).json({ message: "Validation failed", errors: body.error.flatten() });
       const record = await this.reimbursementService.reject(id, body.data?.approverNote);
       return res.json({ message: "Reimbursement rejected", record });
     } catch (error) {
@@ -128,6 +130,7 @@ export class ReimbursementController {
       if (isNaN(id)) return res.status(400).json({ message: "Invalid reimbursement ID" });
 
       const body = approveReimbursementSchema.safeParse(req.body);
+      if (!body.success) return res.status(400).json({ message: "Validation failed", errors: body.error.flatten() });
       const record = await this.reimbursementService.financeApprove(id, body.data?.approverNote);
       return res.json({ message: "Reimbursement approved by finance", record });
     } catch (error) {


### PR DESCRIPTION
## What

Adds safeParse success guards to three reimbursement endpoints

## Root cause

approve(), reject(), and financeApprove() called safeParse but never checked .success before using .data

## Changes

- server/src/module/reimbursement/reimbursement.controller.ts — added 3 success guards

## Verification

- [ ] Bug reproduced before fix
- [ ] Fix verified locally
- [ ] git diff upstream/main...HEAD --stat shows only intended file
- [ ] No console.logs or debug logs remaining
- [ ] Build passes

## CI failures (if any)

[pre-existing failures unrelated to this PR - remove if CI green]

## Before / After

Backend only - no UI changes

Closes #1630