### PR TITLE
fix: replace orphaned setTimeout cleanup with useRef pattern in ProfilePageHeader

### DIFF
--- a/client/src/module/student/profile/components/ProfilePageHeader.tsx
+++ b/client/src/module/student/profile/components/ProfilePageHeader.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Save, Loader2 } from "lucide-react";
 
 interface ProfilePageHeaderProps {
@@ -10,17 +10,18 @@ interface ProfilePageHeaderProps {
 
 export function ProfilePageHeader({ profileCompletion, saving, onSave }: ProfilePageHeaderProps) {
   const [showSuccess, setShowSuccess] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
 
   const handleSave = async () => {
     try {
       await onSave();
       setShowSuccess(true);
 
-      const timer = setTimeout(() => {
-        setShowSuccess(false);
-      }, 3000);
-
-      return () => clearTimeout(timer);
+      timerRef.current = setTimeout(() => setShowSuccess(false), 3000);
     } catch (error) {
       console.error("Save failed:", error);
     }


### PR DESCRIPTION
## What

Replaces orphaned return cleanup with proper useRef pattern for setTimeout in ProfilePageHeader

## Root cause

handleSave was async but contained \eturn () => clearTimeout(timer)\ which was an orphaned return that never executed as cleanup

## Changes

- client/src/module/student/profile/components/ProfilePageHeader.tsx — added useRef/useEffect pattern for timer cleanup

## Verification

- [ ] Bug reproduced before fix
- [ ] Fix verified locally
- [ ] git diff upstream/main...HEAD --stat shows only intended file
- [ ] No console.logs or debug logs remaining
- [ ] Build passes

## CI failures (if any)

[pre-existing failures unrelated to this PR - remove if CI green]

## Before / After

Backend only - no UI changes
(add screenshots if UI is affected)

Closes #1646