### PR TITLE
fix: prevent unique constraint violation on partial round reorder (#1305)

### DIFF
--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -239,6 +239,11 @@ export class RecruiterService {
       throw new Error("Invalid round IDs");
     }
 
+    const totalRounds = await prisma.round.count({ where: { jobId } });
+    if (rounds.length !== totalRounds) {
+      throw new Error("All rounds must be included in the reorder request");
+    }
+
     // Use a transaction with temporary high indices to avoid unique constraint conflicts
     await prisma.$transaction(async (tx) => {
       // First, set all to temporary high values


### PR DESCRIPTION
fix: prevent unique constraint violation on partial round reorder (#1305)

Add a check that all rounds for a job are included in the reorder
request. Previously, omitting even one round caused the remaining
round's `orderIndex` to collide with newly assigned values,
triggering a `@@unique([jobId, orderIndex])` constraint failure
and a 500 error.

Closes #1305
