### PR TITLE
fix: use dynamic viewport height for DSA code editor on mobile (#1061)

### DIFF
--- a/client/src/module/student/dsa/components/DsaCodeEditor.tsx
+++ b/client/src/module/student/dsa/components/DsaCodeEditor.tsx
@@ -33,7 +33,7 @@ export function DsaCodeEditor({ value, onChange, onRun, language, onLanguageChan
   const handleChange = useCallback((val: string) => onChange(val), [onChange]);
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-dvh">
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
         <select


### PR DESCRIPTION
fix: use dynamic viewport height for DSA code editor on mobile (#1061)

Change `h-full` to `h-dvh` on the editor container so it uses
the dynamic viewport height that accounts for the on-screen
keyboard on mobile devices, preventing the editor from being
pushed off-screen.

Closes #1061
