### PR TITLE
feat: add print-friendly CSS with data-print-hide support (#1027)

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -322,18 +322,30 @@ body::-webkit-scrollbar-thumb:hover {
     color: #030712;
   }
 
-  /* Hide navigation and sidebar */
+  /* Hide navigation, sidebar, and print-hidden elements */
   nav,
   aside,
   .navbar,
   .sidebar,
-  .student-sidebar {
+  .student-sidebar,
+  [data-print-hide] {
     display: none !important;
   }
 
   /* Hide print button and other action buttons */
   .print\:hidden {
     display: none !important;
+  }
+
+  /* Show link URLs after anchor text */
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #666;
+  }
+  a[href^="#"]::after,
+  a[href^="javascript"]::after {
+    content: none;
   }
 
   /* ATS Report section — full width and clean */


### PR DESCRIPTION
feat: add print-friendly CSS with data-print-hide support (#1027)

Add `@media print` styles for guide section pages: hide navigation,
sidebar, and elements with `data-print-hide` attribute; show link
URLs after anchor text; force white backgrounds and dark text for
readable printed output.

Closes #1027
