### PR TITLE
feat: replace mailto with modal navigation on OpenSourceLandingPage (#1015)

### DIFF
--- a/client/src/module/student/opensource/OpenSourceLandingPage.tsx
+++ b/client/src/module/student/opensource/OpenSourceLandingPage.tsx
@@ -425,20 +425,21 @@ export default function OpenSourceLandingPage() {
             ))}
 
             {/* Add Your Repo */}
-            <motion.a
-              href="mailto:mrsachinchaurasiya@gmail.com?subject=Add%20My%20Repo%20to%20InternHack%20Open%20Source&body=Hi%20InternHack%20Team%2C%0A%0AI%27d%20like%20to%20submit%20my%20open-source%20repo%20for%20listing%20on%20the%20platform.%0A%0ARepo%20Name%3A%20%0AGitHub%20URL%3A%20%0ALanguage%3A%20%0AShort%20Description%3A%20%0AWhy%20it%27s%20great%20for%20contributors%3A%20%0A%0AThanks!"
+            <motion.button
+              type="button"
+              onClick={() => navigate(isAuthenticated ? "/student/opensource" : "/login?redirectTo=/student/opensource")}
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: 0.5, duration: 0.4 }}
-              className="rounded-xl border border-dashed border-stone-300 dark:border-white/15 p-4 hover:border-lime-400 dark:hover:border-lime-400 transition-all flex flex-col items-center justify-center gap-2 no-underline cursor-pointer group"
+              className="rounded-xl border border-dashed border-stone-300 dark:border-white/15 p-4 hover:border-lime-400 dark:hover:border-lime-400 transition-all flex flex-col items-center justify-center gap-2 cursor-pointer group text-left"
             >
               <div className="w-9 h-9 rounded-lg bg-stone-100 dark:bg-stone-800 flex items-center justify-center group-hover:bg-lime-400/20 transition-colors">
                 <Plus className="w-4 h-4 text-stone-400 group-hover:text-lime-600 dark:group-hover:text-lime-400 transition-colors" />
               </div>
               <h4 className="text-xs font-semibold text-stone-500 group-hover:text-stone-900 dark:group-hover:text-stone-50 transition-colors text-center">Add Your Repo</h4>
               <p className="text-[10px] text-stone-400 text-center">Request to list your project</p>
-            </motion.a>
+            </motion.button>
           </div>
         </div>
       </section>


### PR DESCRIPTION
feat: replace mailto with modal navigation on OpenSourceLandingPage (#1015)

Change the 'Add Your Repo' button from `mailto:` email link to
navigating authenticated users to `/student/opensource` (where
the SuggestRepoModal is available) and unauthenticated users to
the login page with a redirect back.

Closes #1015
