### PR TITLE
feat: enhance recently viewed repos with count, placeholder, and clear history (#1021)

### DIFF
--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -199,7 +199,7 @@ export default function RepoDiscoveryPage() {
     return Array.from(langs);
   }, [user]);
 
-  const { recentlyViewed, addRepo } = useRecentlyViewedRepos();
+  const { recentlyViewed, addRepo, clearHistory } = useRecentlyViewedRepos();
 
   const handleOpenRepo = (repo: OpenSourceRepo) => {
     addRepo(repo);
@@ -634,7 +634,7 @@ export default function RepoDiscoveryPage() {
         <GuidanceCards />
 
         {/* Recently viewed & recommended */}
-        <RecentlyViewedSection repos={recentlyViewed} onSelect={handleOpenRepo} />
+        <RecentlyViewedSection repos={recentlyViewed} onSelect={handleOpenRepo} onClearHistory={clearHistory} />
 
         {user?.role === "STUDENT" && (
           <RecommendedSection onSelect={handleOpenRepo} />

--- a/client/src/module/student/opensource/_shared/RecentlyViewedSection.tsx
+++ b/client/src/module/student/opensource/_shared/RecentlyViewedSection.tsx
@@ -3,21 +3,33 @@ import type { OpenSourceRepo } from "../../../../lib/types";
 interface RecentlyViewedSectionProps {
   repos: OpenSourceRepo[];
   onSelect: (repo: OpenSourceRepo) => void;
+  onClearHistory?: () => void;
 }
 
-export function RecentlyViewedSection({ repos, onSelect }: RecentlyViewedSectionProps) {
-  if (repos.length === 0) {
-    return null;
-  }
-
+export function RecentlyViewedSection({ repos, onSelect, onClearHistory }: RecentlyViewedSectionProps) {
   return (
     <div className="mb-6">
-      <div className="flex items-center gap-1.5 mb-2">
-        <div className="h-1 w-1 bg-lime-400"></div>
-        <h2 className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
-          Recently Viewed
-        </h2>
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-1.5">
+          <div className="h-1 w-1 bg-lime-400"></div>
+          <h2 className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+            Recently Viewed {repos.length > 0 && `(${repos.length})`}
+          </h2>
+        </div>
+        {repos.length > 0 && onClearHistory && (
+          <button
+            type="button"
+            onClick={onClearHistory}
+            className="border-0 bg-transparent text-[10px] font-mono uppercase tracking-widest text-stone-400 hover:text-red-500 transition-colors cursor-pointer"
+          >
+            Clear history
+          </button>
+        )}
       </div>
+      {repos.length === 0 && (
+        <p className="text-xs text-stone-400 dark:text-stone-500 py-2">Repos you open will appear here.</p>
+      )}
+      {repos.length > 0 && (
       <div className="relative">
         <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-thin scrollbar-thumb-stone-300 dark:scrollbar-thumb-stone-700 scrollbar-track-transparent">
           {repos.map((repo) => (

--- a/client/src/module/student/opensource/useRecentlyViewedRepos.ts
+++ b/client/src/module/student/opensource/useRecentlyViewedRepos.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from "react";
 import type { OpenSourceRepo } from "../../../lib/types";
 
 const STORAGE_KEY = "oss_recently_viewed";
-const MAX_RECENTLY_VIEWED = 5;
+const MAX_RECENTLY_VIEWED = 10;
 
 export function useRecentlyViewedRepos() {
   const [recentlyViewed, setRecentlyViewed] = useState<OpenSourceRepo[]>(() => {
@@ -16,15 +16,31 @@ export function useRecentlyViewedRepos() {
 
   const addRepo = useCallback((repo: OpenSourceRepo) => {
     setRecentlyViewed((prev) => {
-      const newRecentlyViewed = [repo, ...prev.filter((r) => r.id !== repo.id)].slice(0, MAX_RECENTLY_VIEWED);
+      const filtered = prev.filter((r) => r.id !== repo.id);
+      const wasEvicted = filtered.length >= MAX_RECENTLY_VIEWED;
+      const newRecentlyViewed = [repo, ...filtered].slice(0, MAX_RECENTLY_VIEWED);
       try {
         localStorage.setItem(STORAGE_KEY, JSON.stringify(newRecentlyViewed));
       } catch (error) {
         console.error("Failed to save recently viewed repos to localStorage", error);
       }
+      if (wasEvicted) {
+        import("../../../components/ui/toast").then((m) =>
+          m.default.info("Oldest repo removed from recently viewed")
+        );
+      }
       return newRecentlyViewed;
     });
   }, []);
 
-  return { recentlyViewed, addRepo };
+  const clearHistory = useCallback(() => {
+    setRecentlyViewed([]);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      console.error("Failed to clear recently viewed repos", error);
+    }
+  }, []);
+
+  return { recentlyViewed, addRepo, clearHistory };
 }


### PR DESCRIPTION
feat: enhance recently viewed repos with count, placeholder, and clear history (#1021)

- Increase MAX_RECENTLY_VIEWED from 5 to 10
- Show "(N)" count badge in section header
- Show placeholder text when empty: "Repos you open will appear here."
- Add "Clear history" button
- Toast when oldest repo is evicted from the list

Closes #1021
