### PR TITLE
feat: add continue-where-you-left-off banner for guides (#1019)

### DIFF
--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -44,6 +44,7 @@ import { RecentlyViewedSection } from "./_shared/RecentlyViewedSection";
 import { Button } from "../../../components/ui/button";
 import { useCoachStore } from "./stores/coach.store";
 import { markLearningPathMilestone } from "./learning-paths.data";
+import { useGuideProgress } from "./useGuideProgress";
 
 const BOOKMARK_KEY = "oss_bookmarks";
 
@@ -106,6 +107,7 @@ export default function RepoDiscoveryPage() {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const triggerCoach = useCoachStore((s) => s.triggerCoach);
+  const { current: currentGuide, dismiss } = useGuideProgress();
 
   // Initialize filter states directly from the URL
   const search = searchParams.get("q") || "";
@@ -430,6 +432,34 @@ export default function RepoDiscoveryPage() {
           keywords="open source, first contribution, good first issue, github, beginner friendly, GSoC, hacktoberfest"
           canonicalUrl={canonicalUrl("/student/opensource")}
         />
+      )}
+
+      {currentGuide && (
+        <div className="sticky top-0 z-40 bg-gradient-to-r from-lime-50 to-emerald-50 dark:from-lime-950/40 dark:to-emerald-950/40 border-b border-lime-200 dark:border-lime-800/40 px-4 sm:px-8">
+          <div className="max-w-6xl mx-auto py-2.5 flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 min-w-0">
+              <BookOpen className="w-4 h-4 text-emerald-600 dark:text-emerald-400 shrink-0" />
+              <p className="text-xs font-medium text-stone-800 dark:text-stone-200 truncate">
+                Continue: {currentGuide.title} — Step {currentGuide.step} of {currentGuide.totalSteps}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <Link
+                to={currentGuide.sectionSlug ? `${currentGuide.basePath}/${currentGuide.sectionSlug}` : currentGuide.basePath}
+                className="text-xs font-semibold text-white bg-emerald-600 hover:bg-emerald-700 dark:bg-emerald-500 dark:hover:bg-emerald-600 px-3 py-1.5 rounded-md transition-colors"
+              >
+                Continue &rarr;
+              </Link>
+              <button
+                type="button"
+                onClick={dismiss}
+                className="text-xs text-stone-400 hover:text-stone-600 dark:hover:text-stone-300 transition-colors bg-transparent border-0 cursor-pointer"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       <div className="max-w-6xl mx-auto px-4 sm:px-8 py-8">

--- a/client/src/module/student/opensource/components/GuideSectionPage.tsx
+++ b/client/src/module/student/opensource/components/GuideSectionPage.tsx
@@ -11,6 +11,7 @@ import { CodeBlock } from "../../../../components/ui/CodeBlock";
 import { canonicalUrl } from "../../../../lib/seo.utils";
 import api from "../../../../lib/axios";
 import { notifyLearningPathProgressChanged } from "../learning-paths.data";
+import { useGuideProgress } from "../useGuideProgress";
 
 interface Resource { title: string; url: string; type: string }
 interface Command { label: string; code: string }
@@ -50,7 +51,23 @@ export default function GuideSectionPage({ steps, storageKey, basePath, seoSuffi
   });
   const [rating, setRating] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
+  const { saveProgress } = useGuideProgress();
 
+  const GUIDE_SLUGS: Record<string, string> = {
+    "/student/opensource/first-pr": "first-pr",
+    "/student/opensource/git-guide": "git-guide",
+    "/student/opensource/gsoc-proposal": "gsoc-proposal",
+    "/student/opensource/read-codebase": "read-codebase",
+    "/student/opensource/communication": "communication",
+    "/student/opensource/cicd": "cicd",
+  };
+
+  useEffect(() => {
+    const slug = GUIDE_SLUGS[basePath];
+    if (slug && step) {
+      saveProgress(slug, step.step, steps.length, step.title, step.id);
+    }
+  }, [step, basePath, steps.length, saveProgress]);
 
   const toggleComplete = useCallback(() => {
     setCompleted((prev) => {

--- a/client/src/module/student/opensource/useGuideProgress.ts
+++ b/client/src/module/student/opensource/useGuideProgress.ts
@@ -1,0 +1,71 @@
+import { useState } from "react";
+
+const PROGRESS_KEY = "oss_guide_progress";
+const DISMISS_KEY = "oss_guide_dismissed";
+
+interface GuideProgress {
+  slug: string;
+  title: string;
+  step: number;
+  totalSteps: number;
+  stepTitle: string;
+  basePath: string;
+  sectionSlug?: string;
+}
+
+const GUIDE_META: Record<string, { title: string; basePath: string }> = {
+  "first-pr": { title: "Your First Contribution", basePath: "/student/opensource/first-pr" },
+  "git-guide": { title: "Git for Open Source", basePath: "/student/opensource/git-guide" },
+  "gsoc-proposal": { title: "GSoC Proposal Guide", basePath: "/student/opensource/gsoc-proposal" },
+  "read-codebase": { title: "Read a Codebase", basePath: "/student/opensource/read-codebase" },
+  "communication": { title: "Communication Templates", basePath: "/student/opensource/communication" },
+  "cicd": { title: "CI / CD Basics", basePath: "/student/opensource/cicd" },
+};
+
+export function useGuideProgress() {
+  const [progress] = useState<GuideProgress[]>(() => {
+    try {
+      const stored = localStorage.getItem(PROGRESS_KEY);
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  const saveProgress = (slug: string, step: number, totalSteps: number, stepTitle: string, sectionSlug?: string) => {
+    const meta = GUIDE_META[slug];
+    if (!meta) return;
+    try {
+      const existing: GuideProgress[] = JSON.parse(localStorage.getItem(PROGRESS_KEY) || "[]");
+      const updated: GuideProgress[] = [
+        { slug, ...meta, step, totalSteps, stepTitle, sectionSlug },
+        ...existing.filter((g: GuideProgress) => g.slug !== slug),
+      ];
+      localStorage.setItem(PROGRESS_KEY, JSON.stringify(updated));
+    } catch { /* ignore */ }
+  };
+
+  const current: GuideProgress | null = (() => {
+    if (progress.length === 0) return null;
+    const dismissed = localStorage.getItem(DISMISS_KEY);
+    if (dismissed) {
+      try {
+        const until = parseInt(dismissed, 10);
+        if (Date.now() < until) return null;
+        localStorage.removeItem(DISMISS_KEY);
+      } catch {
+        localStorage.removeItem(DISMISS_KEY);
+      }
+    }
+    const inProgress = progress.filter((g) => g.step < g.totalSteps);
+    return inProgress.length > 0 ? inProgress[0] : null;
+  })();
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, String(Date.now() + 24 * 60 * 60 * 1000));
+    } catch { /* ignore */ }
+  };
+
+  return { current, saveProgress, dismiss };
+}


### PR DESCRIPTION
feat: add continue-where-you-left-off banner for guides (#1019)

- Track guide step progress in localStorage via useGuideProgress hook
- Show sticky banner on /student/opensource when a guide is in progress
- Shows guide title, step number, and total steps
- "Continue →" links to the exact step page
- "Dismiss" hides banner for 24 hours
- Auto-saves progress from every guide section page via GuideSectionPage

Closes #1019
