### PR TITLE
feat: show enrolled count on roadmap detail page (#1082)

### DIFF
--- a/client/src/module/student/roadmap/RoadmapDetailPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from "react";
 import { Link, useParams } from "react-router";
 import { motion } from "framer-motion";
-import { Clock, BookOpen, Target, ChevronRight, ArrowRight, Check, HelpCircle, Map as MapIcon } from "lucide-react";
+import { Clock, BookOpen, Target, ChevronRight, ArrowRight, Check, HelpCircle, Map as MapIcon, Users } from "lucide-react";
 import { SEO } from "../../../components/SEO";
 import { Button } from "../../../components/ui/button";
 import { Navbar } from "../../../components/Navbar";
@@ -205,6 +205,7 @@ export default function RoadmapDetailPage() {
             <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-stone-500 dark:text-stone-400 mb-8 font-mono">
               <span className="inline-flex items-center gap-2"><Clock className="w-4 h-4" aria-hidden="true" /> {roadmap.estimatedHours} hours</span>
               <span className="inline-flex items-center gap-2"><BookOpen className="w-4 h-4" aria-hidden="true" /> {roadmap.topicCount} topics</span>
+              <span className="inline-flex items-center gap-2"><Users className="w-4 h-4" aria-hidden="true" /> {roadmap.enrolledCount.toLocaleString()} enrolled</span>
               <span className="inline-flex items-center gap-2"><Target className="w-4 h-4" aria-hidden="true" /> Free</span>
             </div>
 


### PR DESCRIPTION
feat: show enrolled count on roadmap detail page (#1082)

- Display `enrolledCount` from the already-fetched roadmap data
- Shows "X,XXX enrolled" alongside hours, topics, and Free label
- Uses `toLocaleString()` for comma formatting

Closes #1082


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Roadmap detail pages now display an enrollment count metric, showing the total number of enrolled users with a Users icon indicator for better visibility of community engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->