### PR TITLE
feat: CSV export with date range picker + JSON export (#1009)

### DIFF
--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -103,7 +103,7 @@ export const queryKeys = {
       ["opensource", "list", params] as const,
     detail: (id: number) => ["opensource", "detail", id] as const,
     myRequests: () => ["opensource", "my-requests"] as const,
-    trend: () => ["opensource", "trend"] as const,
+    trend: (startDate?: string, endDate?: string) => ["opensource", "trend", startDate, endDate] as const,
     hacktoberfest: () => ["opensource", "hacktoberfest"] as const,
     allRequests: (params?: Record<string, string | number>) =>
       ["opensource", "all-requests", params] as const,

--- a/client/src/module/student/opensource/OpenSourceAnalyticsPage.tsx
+++ b/client/src/module/student/opensource/OpenSourceAnalyticsPage.tsx
@@ -274,6 +274,13 @@ export default function OpenSourceAnalyticsPage() {
   const [filterTech, setFilterTech] = useState<string>("ALL");
   const [showFilters, setShowFilters] = useState(false);
 
+  const sixMonthsAgo = new Date();
+  sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+  const defaultStart = sixMonthsAgo.toISOString().slice(0, 7);
+  const today = new Date().toISOString().slice(0, 7);
+  const [startMonth, setStartMonth] = useState(defaultStart);
+  const [endMonth, setEndMonth] = useState(today);
+
   if (!isPremium) {
     return (
       <div className="max-w-2xl mx-auto px-4 py-16">
@@ -308,8 +315,8 @@ export default function OpenSourceAnalyticsPage() {
   });
 
   const { data: contributionTrendData, isLoading: trendIsLoading, isError: trendIsError } = useQuery<OpenSourceContributionTrendResponse>({
-    queryKey: queryKeys.opensource.trend(),
-    queryFn: () => api.get("/opensource/analytics/trend").then((r) => r.data),
+    queryKey: queryKeys.opensource.trend(startMonth, endMonth),
+    queryFn: () => api.get("/opensource/analytics/trend", { params: { startDate: startMonth, endDate: endMonth } }).then((r) => r.data),
     staleTime: 5 * 60 * 1000,
   });
 
@@ -322,22 +329,29 @@ export default function OpenSourceAnalyticsPage() {
   contributionTrend.length > 0 &&
   contributionTrend.every((entry) => entry.count === 0);
 
-  const handleExportCSV = () => {
-    if (!contributionTrend || contributionTrend.length === 0) return;
-
-    const header = "Month,Label,Contributions";
-    const rows = contributionTrend.map(m => `${m.month},${m.label},${m.count}`);
-    const csv = [header, ...rows].join("\n");
-
-    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const downloadBlob = (content: string, filename: string, type: string) => {
+    const blob = new Blob([content], { type });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "my-oss-contributions.csv";
+    a.download = filename;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
+  };
+
+  const handleExportCSV = () => {
+    if (!contributionTrend || contributionTrend.length === 0) return;
+    const header = "Month,Label,Contributions";
+    const rows = contributionTrend.map(m => `${m.month},${m.label},${m.count}`);
+    downloadBlob([header, ...rows].join("\n"), `oss-contributions-${startMonth}-${endMonth}.csv`, "text/csv;charset=utf-8;");
+  };
+
+  const handleExportJSON = () => {
+    if (!contributionTrend || contributionTrend.length === 0) return;
+    const json = JSON.stringify({ range: { start: startMonth, end: endMonth }, contributions: contributionTrend }, null, 2);
+    downloadBlob(json, `oss-contributions-${startMonth}-${endMonth}.json`, "application/json");
   };
 
   const years = useMemo(() => {
@@ -525,14 +539,40 @@ export default function OpenSourceAnalyticsPage() {
           </div>
           <OssContributionHeatmap />
 
-          <div className="mt-3 flex items-center gap-3">
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <label className="flex items-center gap-1.5 text-xs font-mono text-stone-500">
+              From
+              <input
+                type="month"
+                value={startMonth}
+                onChange={(e) => setStartMonth(e.target.value)}
+                className="border border-stone-200 dark:border-white/10 rounded px-2 py-1.5 text-xs bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-100"
+              />
+            </label>
+            <label className="flex items-center gap-1.5 text-xs font-mono text-stone-500">
+              To
+              <input
+                type="month"
+                value={endMonth}
+                onChange={(e) => setEndMonth(e.target.value)}
+                className="border border-stone-200 dark:border-white/10 rounded px-2 py-1.5 text-xs bg-white dark:bg-stone-900 text-stone-900 dark:text-stone-100"
+              />
+            </label>
             <button
               onClick={handleExportCSV}
               disabled={trendIsLoading || !contributionTrend || contributionTrend.length === 0}
               className="border border-stone-200 dark:border-white/10 text-xs font-mono uppercase tracking-widest px-3 py-2 rounded-md hover:border-stone-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1.5 text-stone-600 dark:text-stone-400 bg-white dark:bg-stone-900 shadow-sm cursor-pointer"
             >
               <Download className="w-3.5 h-3.5" />
-              Export CSV
+              CSV
+            </button>
+            <button
+              onClick={handleExportJSON}
+              disabled={trendIsLoading || !contributionTrend || contributionTrend.length === 0}
+              className="border border-stone-200 dark:border-white/10 text-xs font-mono uppercase tracking-widest px-3 py-2 rounded-md hover:border-stone-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center gap-1.5 text-stone-600 dark:text-stone-400 bg-white dark:bg-stone-900 shadow-sm cursor-pointer"
+            >
+              <Download className="w-3.5 h-3.5" />
+              JSON
             </button>
           </div>
         </div>
@@ -544,7 +584,7 @@ export default function OpenSourceAnalyticsPage() {
             subtitle={
               trendIsLoading
                 ? "loading your approved open source contribution history"
-                : `approved repo requests in the last 6 months${contributionTotal ? ` · ${contributionTotal} total` : ""}`
+                : `approved repo requests ${startMonth}–${endMonth}${contributionTotal ? ` · ${contributionTotal} total` : ""}`
             }
             index={0}
             expandedChildren={

--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -255,7 +255,8 @@ export class OpensourceController {
     next: NextFunction,
   ) {
     try {
-      const result = await service.getStudentContributionTrend(req.user!.id);
+      const { startDate, endDate } = req.query as { startDate?: string; endDate?: string };
+      const result = await service.getStudentContributionTrend(req.user!.id, startDate, endDate);
       res.json(result);
     } catch (err) {
       next(err);

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -460,13 +460,13 @@ where["OR"] = [
     };
   }
 
-  async getStudentContributionTrend(userId: number) {
+  async getStudentContributionTrend(userId: number, startDate?: string, endDate?: string) {
     const now = new Date();
     const currentMonthStart = new Date(
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
     );
-    const startMonth = this.addMonthsUTC(currentMonthStart, -5);
-    const endMonth = this.addMonthsUTC(currentMonthStart, 1);
+    const startMonth = startDate ? new Date(startDate) : this.addMonthsUTC(currentMonthStart, -5);
+    const endMonth = endDate ? new Date(endDate) : this.addMonthsUTC(currentMonthStart, 1);
     const approvedRequests = await prisma.repoRequest.findMany({
       where: {
         userId,
@@ -482,7 +482,10 @@ where["OR"] = [
       countsByMonth.set(monthKey, (countsByMonth.get(monthKey) ?? 0) + 1);
     }
 
-    const trend = Array.from({ length: 6 }, (_, index) => {
+    const monthDiff = (endMonth.getUTCFullYear() - startMonth.getUTCFullYear()) * 12
+      + (endMonth.getUTCMonth() - startMonth.getUTCMonth());
+    const numMonths = Math.max(monthDiff, 1);
+    const trend = Array.from({ length: numMonths }, (_, index) => {
       const monthStart = this.addMonthsUTC(startMonth, index);
       const monthKey = this.getMonthKeyUTC(monthStart);
       return {


### PR DESCRIPTION
feat: CSV export with date range picker + JSON export (#1009)

- Add date range picker (From/To month select) above export buttons
- Pass startDate/endDate to /opensource/analytics/trend API
- Server accepts optional startDate/endDate query params
- Dynamic month count based on selected range
- JSON export option alongside existing CSV
- Filenames include date range

Closes #1009


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date range selector (From/To month inputs) for open-source contribution analytics, replacing the fixed 6-month view.
  * Chart subtitle now displays the selected date range and total contributions.
  * Export files now include the selected date range in their filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->