### PR TITLE
feat: add progress indicators to LearnHub track cards (#1055)

### DIFF
--- a/client/src/module/student/learn/LearnHubPage.tsx
+++ b/client/src/module/student/learn/LearnHubPage.tsx
@@ -19,6 +19,7 @@ import {
 } from "./components/RecommendationCard";
 import api from "../../../lib/axios";
 import { Button } from "../../../components/ui/button";
+import { useTrackProgress } from "./useTrackProgress";
 
 const CATEGORY_DESCRIPTION: Record<TrackCategory, string> = {
   practice: "Curated questions, animated lessons, and roadmaps to ace placements.",
@@ -41,6 +42,7 @@ export default function LearnHubPage() {
     retry: false,
   });
   const weakAreas = recData?.weakAreas ?? [];
+  const { progressMap } = useTrackProgress();
 
 const grouped = useMemo(() => {
     let filtered = TRACKS;
@@ -331,7 +333,7 @@ const grouped = useMemo(() => {
 
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {group.tracks.map((track, idx) => (
-                  <TrackCard key={track.id} track={track} index={idx} />
+                  <TrackCard key={track.id} track={track} index={idx} progress={progressMap[track.id]} />
                 ))}
               </div>
             </section>

--- a/client/src/module/student/learn/TrackCard.tsx
+++ b/client/src/module/student/learn/TrackCard.tsx
@@ -1,23 +1,27 @@
 import React from "react";
 import { Link } from "react-router";
 import { motion } from "framer-motion";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowUpRight, CheckCircle2 } from "lucide-react";
 import type { Track } from "./tracks";
 import { getLessonCount } from "./lesson-counts";
+import type { TrackProgress } from "./useTrackProgress";
 
 interface TrackCardProps {
   track: Track;
   index: number;
+  progress?: TrackProgress | null;
 }
 
 const MAX_STAGGER_INDEX = 8;
 const STAGGER_STEP = 0.04;
 const BASE_DELAY = 0.05;
 
-export const TrackCard = React.memo(function TrackCard({ track, index }: TrackCardProps) {
+export const TrackCard = React.memo(function TrackCard({ track, index, progress }: TrackCardProps) {
   const delay = BASE_DELAY + Math.min(index, MAX_STAGGER_INDEX) * STAGGER_STEP;
   const liveCount = getLessonCount(track.lessonCountKey);
   const statLabel = liveCount != null ? `${liveCount} lessons` : track.stat;
+  const pct = progress && progress.total > 0 ? Math.round((progress.completed / progress.total) * 100) : null;
+  const isComplete = pct !== null && pct >= 100;
 
   return (
     <motion.div
@@ -50,6 +54,30 @@ export const TrackCard = React.memo(function TrackCard({ track, index }: TrackCa
             </span>
           </div>
         </div>
+
+        {progress && (
+          <div className="mb-3">
+            {isComplete ? (
+              <span className="inline-flex items-center gap-1 text-xs font-semibold text-emerald-600 dark:text-emerald-400">
+                <CheckCircle2 className="w-3.5 h-3.5" />
+                Completed
+              </span>
+            ) : (
+              <div className="space-y-1">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-stone-500 font-mono">{progress.completed}/{progress.total} {progress.label}</span>
+                  <span className="text-stone-500 font-mono">{pct}%</span>
+                </div>
+                <div className="w-full h-1.5 bg-stone-100 dark:bg-stone-800 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-lime-500 rounded-full transition-all duration-500"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
 
         <p className="text-sm text-stone-600 dark:text-stone-400 line-clamp-2 mb-4 leading-relaxed">
           {track.description}

--- a/client/src/module/student/learn/useTrackProgress.ts
+++ b/client/src/module/student/learn/useTrackProgress.ts
@@ -1,0 +1,65 @@
+import { useQuery } from "@tanstack/react-query";
+import api from "../../../lib/axios";
+
+export interface TrackProgress {
+  completed: number;
+  total: number;
+  label: string;
+}
+
+export function useTrackProgress() {
+  const dsa = useQuery({
+    queryKey: ["dsa-progress-summary"],
+    queryFn: () => api.get("/dsa/my-progress").then((r) => r.data),
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const aptitude = useQuery({
+    queryKey: ["aptitude-progress-summary"],
+    queryFn: () => api.get("/aptitude/progress").then((r) => r.data),
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const interview = useQuery({
+    queryKey: ["interview-progress-summary"],
+    queryFn: () => api.get("/learn/interview/progress").then((r) => r.data),
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const roadmaps = useQuery({
+    queryKey: ["roadmap-enrollments-summary"],
+    queryFn: () => api.get("/roadmaps/me/enrollments").then((r) => r.data),
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const sql = useQuery({
+    queryKey: ["sql-progress-summary"],
+    queryFn: () => api.get("/sql/progress").then((r) => r.data),
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const progressMap: Record<string, TrackProgress | null> = {
+    interview: interview.data
+      ? { completed: interview.data.completedIds?.length ?? 0, total: 300, label: "questions answered" }
+      : null,
+    "dsa-foundations": dsa.data
+      ? { completed: dsa.data.totalSolved ?? 0, total: dsa.data.totalProblems ?? 2500, label: "problems solved" }
+      : null,
+    aptitude: aptitude.data
+      ? { completed: aptitude.data.totalAnswered ?? 0, total: aptitude.data.totalQuestions ?? 500, label: "questions answered" }
+      : null,
+    sql: sql.data
+      ? { completed: sql.data.length ?? 0, total: 188, label: "exercises done" }
+      : null,
+    roadmaps: roadmaps.data?.enrollments
+      ? { completed: roadmaps.data.enrollments.length, total: 0, label: "roadmaps enrolled" }
+      : null,
+  };
+
+  return { progressMap, isLoading: dsa.isLoading || aptitude.isLoading || interview.isLoading || roadmaps.isLoading };
+}


### PR DESCRIPTION
feat: add progress indicators to LearnHub track cards (#1055)

- New useTrackProgress hook fetches from DSA, Aptitude, Interview,
  Roadmap, and SQL progress endpoints in parallel
- TrackCard shows progress bar + "X of Y" label when progress is available
- Completed state shows green checkmark badge
- Covers DSA, Aptitude, Interview, SQL, and Roadmap tracks
- Lesson tracks (HTML, CSS, JS, etc.) without server progress unchanged

Closes #1055


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Track progress is now visible on learning paths, displaying the number of completed lessons against total lessons with a progress bar
  * Tracks that are fully completed are marked with a checkmark indicator
  * Progress metrics update dynamically as you complete lessons across all available learning tracks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->