### PR TITLE
feat: add salary context cards and salary sort to learn tracks (#1094)

### DIFF
--- a/client/src/module/student/learn/LearnHubPage.tsx
+++ b/client/src/module/student/learn/LearnHubPage.tsx
@@ -72,6 +72,10 @@ const grouped = useMemo(() => {
         return a.title.localeCompare(b.title);
       } else if (sortBy === "recent") {
         return new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime();
+      } else if (sortBy === "salary") {
+        const aVal = a.salary ? parseInt(a.salary.replace(/\D/g, "")) || 0 : 0;
+        const bVal = b.salary ? parseInt(b.salary.replace(/\D/g, "")) || 0 : 0;
+        return bVal - aVal;
       } else {
         return (b.enrolledStudents || 0) - (a.enrolledStudents || 0);
       }
@@ -304,6 +308,7 @@ const grouped = useMemo(() => {
               className="text-sm bg-white dark:bg-stone-900 border border-stone-300 dark:border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:border-lime-400 cursor-pointer"
             >
               <option value="popular">Most Popular</option>
+              <option value="salary">Salary</option>
               <option value="alphabetical">Alphabetical</option>
               <option value="recent">Recently Added</option>
             </select>

--- a/client/src/module/student/learn/TrackCard.tsx
+++ b/client/src/module/student/learn/TrackCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router";
 import { motion } from "framer-motion";
-import { ArrowUpRight, CheckCircle2 } from "lucide-react";
+import { ArrowUpRight, CheckCircle2, IndianRupee } from "lucide-react";
 import type { Track } from "./tracks";
 import { getLessonCount } from "./lesson-counts";
 import type { TrackProgress } from "./useTrackProgress";
@@ -52,6 +52,12 @@ export const TrackCard = React.memo(function TrackCard({ track, index, progress 
             <span className="text-xs font-mono uppercase tracking-widest text-stone-500 mt-0.5 block truncate">
               {statLabel}
             </span>
+            {track.salary && (
+              <span className="inline-flex items-center gap-1 text-xs font-bold text-lime-700 dark:text-lime-400 mt-1 bg-lime-50 dark:bg-lime-900/30 px-1.5 py-0.5 rounded-sm">
+                <IndianRupee className="w-3 h-3" />
+                {track.salary}
+              </span>
+            )}
           </div>
         </div>
 

--- a/client/src/module/student/learn/tracks.ts
+++ b/client/src/module/student/learn/tracks.ts
@@ -41,6 +41,8 @@ export interface Track {
   difficulty?: "Beginner" | "Intermediate" | "Advanced";
   createdAt?: string;
   enrolledStudents?: number;
+  /** Average salary range for this skill in India (e.g. "Avg ₹14 LPA"). Source: Glassdoor, AmbitionBox. */
+  salary?: string;
 }
 
 export const TRACKS: Track[] = [
@@ -101,6 +103,7 @@ export const TRACKS: Track[] = [
     kind: "lesson",
     category: "practice",
     stat: "Animated lessons",
+    salary: "Avg ₹35 LPA",
   },
   {
     id: "aptitude",
@@ -132,6 +135,7 @@ export const TRACKS: Track[] = [
     category: "frontend",
     stat: "Lessons",
     lessonCountKey: "html",
+    salary: "Avg ₹8 LPA",
   },
   {
     id: "css",
@@ -147,6 +151,7 @@ export const TRACKS: Track[] = [
     category: "frontend",
     stat: "Lessons",
     lessonCountKey: "css",
+    salary: "Avg ₹8 LPA",
   },
   {
     id: "javascript",
@@ -162,6 +167,7 @@ export const TRACKS: Track[] = [
     category: "frontend",
     stat: "Lessons",
     lessonCountKey: "javascript",
+    salary: "Avg ₹10 LPA",
   },
   {
     id: "typescript",
@@ -177,6 +183,7 @@ export const TRACKS: Track[] = [
     category: "frontend",
     stat: "Lessons",
     lessonCountKey: "typescript",
+    salary: "Avg ₹13 LPA",
   },
   {
     id: "react",
@@ -192,6 +199,7 @@ export const TRACKS: Track[] = [
     category: "frontend",
     stat: "Lessons",
     lessonCountKey: "react",
+    salary: "Avg ₹14 LPA",
   },
 
   // ── Backend ──
@@ -209,6 +217,7 @@ export const TRACKS: Track[] = [
     category: "backend",
     stat: "Lessons",
     lessonCountKey: "nodejs",
+    salary: "Avg ₹12 LPA",
   },
   {
     id: "python",
@@ -224,6 +233,7 @@ export const TRACKS: Track[] = [
     category: "backend",
     stat: "Lessons",
     lessonCountKey: "python",
+    salary: "Avg ₹13 LPA",
   },
   {
     id: "fastapi",
@@ -239,6 +249,7 @@ export const TRACKS: Track[] = [
     category: "backend",
     stat: "Lessons",
     lessonCountKey: "fastapi",
+    salary: "Avg ₹11 LPA",
   },
   {
     id: "flask",
@@ -254,6 +265,7 @@ export const TRACKS: Track[] = [
     category: "backend",
     stat: "Lessons",
     lessonCountKey: "flask",
+    salary: "Avg ₹10 LPA",
   },
   {
     id: "django",
@@ -269,6 +281,7 @@ export const TRACKS: Track[] = [
     category: "backend",
     stat: "Lessons",
     lessonCountKey: "django",
+    salary: "Avg ₹12 LPA",
   },
 
   // ── Data ──
@@ -285,6 +298,7 @@ export const TRACKS: Track[] = [
     kind: "lesson",
     category: "data",
     stat: "188 Exercises",
+    salary: "Avg ₹8 LPA",
   },
   {
     id: "data-analytics",
@@ -299,6 +313,7 @@ export const TRACKS: Track[] = [
     category: "data",
     stat: "Lessons",
     lessonCountKey: "data-analytics",
+    salary: "Avg ₹15 LPA",
   },
 
   // ── Web3 ──
@@ -316,6 +331,7 @@ export const TRACKS: Track[] = [
     category: "web3",
     stat: "35 Projects",
     difficulty: "Beginner", //mock testing
+    salary: "Avg ₹16 LPA",
   },
 ];
 


### PR DESCRIPTION
feat: add salary context cards and salary sort to learn tracks (#1094)

- Adds optional `salary` field to Track interface in tracks.ts
- Populates salary data (India avg LPA) for 13 skill tracks
- Shows ₹ badge on TrackCard for tracks with salary data
- Adds "Salary" sort option to LearnHubPage (highest → lowest)

Closes #1094


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Track cards now display salary information with currency formatting
  * Learn hub now supports sorting tracks by salary alongside existing sort options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->