### PR TITLE
fix: normalize skills to lowercase on profile update (#1303)

### DIFF
--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -457,7 +457,7 @@ export class AuthService {
       updateData.graduationYear = data.graduationYear ? Number(data.graduationYear) : null;
     }
     if ("skills" in data) {
-      updateData.skills = Array.isArray(data.skills) ? data.skills : [];
+      updateData.skills = Array.isArray(data.skills) ? data.skills.map((s) => s.trim().toLowerCase()) : [];
     }
     if ("jobStatus" in data) {
       updateData.jobStatus = data.jobStatus || null;


### PR DESCRIPTION
## Description
The talent search on the recruiter side already normalizes skills to lowercase when querying (via .toLowerCase()). However, the profile update endpoint stores skills as-is, so a search for "javascript" could miss candidates whose stored skills contain "JavaScript".

## Change
- auth.service.ts: When saving skills in updateProfile, normalize to lowercase (data.skills.map((s) => s.trim().toLowerCase())).

This ensures skills are always stored in normalized form, making the search effectively case-insensitive end-to-end.

Fixes #1303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved profile skill entry handling to properly normalize whitespace and formatting when saving user profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->