### PR TITLE
feat: add GSoC alumni network and success stories API

### DIFF
--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -80,6 +80,7 @@ model user {
   externalApplications  externalJobApplication[]    @relation("StudentExternalApplications")
   repoRequests          repoRequest[]               @relation("UserRepoRequests")
   guideFeedbacks        guideFeedback[]
+  gsocSuccesses         gsocSuccess[]               @relation("UserGsocSuccesses")
   interviewProgress     userInterviewProgress[]     @relation("StudentInterviewProgress")
   interviewExperiences  interviewExperience[]       @relation("UserInterviewExperiences")
   interviewUpvotes      interviewExperienceUpvote[] @relation("UserInterviewUpvotes")
@@ -532,8 +533,31 @@ model gsocOrganization {
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 
+  successStories    gsocSuccess[]
   @@index([category])
   @@index([name])
+}
+
+model gsocSuccess {
+  id           Int      @id @default(autoincrement())
+  userId       Int
+  orgId        Int
+  projectTitle String
+  quote        String
+  country      String?
+  year         Int
+  verified     Boolean  @default(false)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  user user @relation("UserGsocSuccesses", fields: [userId], references: [id], onDelete: Cascade)
+
+  org gsocOrganization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([orgId])
+  @@index([year])
+  @@index([verified])
 }
 
 model ycCompany {

--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -3,6 +3,7 @@ import { OpensourceService } from "./opensource.service.js";
 import {
   opensourceListQuerySchema,
   gsocOrgsQuerySchema,
+  gsocAlumniQuerySchema,
   submitRepoRequestSchema,
   approveRequestOverrideSchema,
   repoIdSchema,
@@ -165,4 +166,36 @@ export class OpensourceController {
       next(err);
     }
   }
+
+
+  async getGsocAlumni(req: Request, res: Response, next: NextFunction) {
+    try {
+      const parsed = gsocAlumniQuerySchema.safeParse(req.query);
+
+      if (!parsed.success) {
+        res.status(400).json({
+          message: "Invalid query parameters",
+          errors: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const result = await service.getGsocAlumni(parsed.data);
+
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async getGsocAlumniStats(_req: Request, res: Response, next: NextFunction) {
+    try {
+      const result = await service.getGsocAlumniStats();
+
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  }
 }
+  

--- a/server/src/module/opensource/opensource.routes.ts
+++ b/server/src/module/opensource/opensource.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { OpensourceController } from "./opensource.controller.js";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
 import { requireRole } from "../../middleware/role.middleware.js";
+import { prisma } from "../../database/db.js";
 
 export const opensourceRouter = Router();
 const controller = new OpensourceController();
@@ -16,6 +17,16 @@ opensourceRouter.get("/languages", (req, res, next) => controller.getLanguages(r
 
 // Get GSoC organizations
 opensourceRouter.get("/gsoc/orgs", (req, res, next) => controller.getGsocOrgs(req, res, next));
+
+opensourceRouter.get(
+  "/gsoc/alumni",
+  (req, res, next) => controller.getGsocAlumni(req, res, next)
+);
+
+opensourceRouter.get(
+  "/gsoc/alumni/stats",
+  (req, res, next) => controller.getGsocAlumniStats(req, res, next)
+);
 
 // ─── Repo Requests (Student-authenticated) ─────────────────────
 // NOTE: these must be registered BEFORE /:id to avoid route conflicts

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -147,7 +147,96 @@ export class OpensourceService {
       totalPages: Math.ceil(total / limit),
     };
   }
+  async getGsocAlumni(query: {
+  page: number;
+  limit: number;
+  org?: string;
+  country?: string;
+  year?: number;
+}) {
+  const { page, limit, org, country, year } = query;
 
+  const skip = (page - 1) * limit;
+
+  const where: Record<string, any> = {
+    verified: true,
+  };
+
+  if (country) {
+    where.country = {
+      contains: country,
+      mode: "insensitive",
+    };
+  }
+
+  if (year) {
+    where.year = year;
+  }
+
+  if (org) {
+    where.org = {
+      name: {
+        contains: org,
+        mode: "insensitive",
+      },
+    };
+  }
+
+  const [alumni, total] = await Promise.all([
+    prisma.gsocSuccess.findMany({
+      where,
+      skip,
+      take: limit,
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            profilePic: true,
+          },
+        },
+        org: {
+          select: {
+            id: true,
+            name: true,
+            slug: true,
+          },
+        },
+      },
+      orderBy: {
+        year: "desc",
+      },
+    }),
+    prisma.gsocSuccess.count({ where }),
+  ]);
+
+  return {
+    alumni,
+    total,
+    page,
+    totalPages: Math.ceil(total / limit),
+  };
+}
+
+async getGsocAlumniStats() {
+  const alumni = await prisma.gsocSuccess.findMany({
+    where: {
+      verified: true,
+    },
+    select: {
+      orgId: true,
+    },
+  });
+
+  const uniqueOrgs = new Set(alumni.map((a) => a.orgId));
+
+  return {
+    totalStudents: alumni.length,
+    totalOrganizations: uniqueOrgs.size,
+  };
+}
+
+  
   async submitRepoRequest(userId: number, data: any) {
     const existing = await prisma.repoRequest.findFirst({
       where: { url: data.url, status: { in: ["PENDING", "APPROVED"] } },

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -58,3 +58,11 @@ export const approveRequestOverrideSchema = z.object({
   difficulty: z.enum(["BEGINNER", "INTERMEDIATE", "ADVANCED"]).optional(),
   tags: z.array(z.string()).optional(),
 });
+
+export const gsocAlumniQuerySchema = z.object({
+  page: z.coerce.number().int().positive().optional().default(1),
+  limit: z.coerce.number().int().positive().max(100).optional().default(20),
+  org: z.string().optional(),
+  country: z.string().optional(),
+  year: z.coerce.number().int().optional(),
+});


### PR DESCRIPTION
## Summary

Implements the backend foundation for the GSoC Success Stories & Alumni Network feature.

**Closes #964**

### Changes

* [x] Added `gsocSuccess` Prisma model
* [x] Added `GET /api/opensource/gsoc/alumni`
* [x] Added filtering by organization, country, and year
* [x] Added `GET /api/opensource/gsoc/alumni/stats`
* [x] Added validation schemas
* [x] Added controller methods
* [x] Added service methods
* [x] Added route integration

### Alumni API Includes

* Student profile information
* Organization information
* Project title
* Success quote
* Country
* Year
* Verification status

### Stats API

Returns:

* Total verified GSoC alumni
* Total participating organizations

This establishes the backend infrastructure required for future alumni spotlight UI, badge integration, and success-story collection workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GSoC success stories section enabling users to browse verified alumni profiles with pagination.
  * Implemented filtering options by organization, country, and participation year.
  * Added statistics view displaying total GSoC alumni and unique organizations represented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->