### PR TITLE
fix: add WITHDRAWN status to recruiter application dropdown

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationsList.tsx
+++ b/client/src/module/recruiter/applications/ApplicationsList.tsx
@@ -210,6 +210,7 @@ export default function ApplicationsList() {
                             <option value="SHORTLISTED">Shortlisted</option>
                             <option value="REJECTED">Rejected</option>
                             <option value="HIRED">Hired</option>
+                            <option value="WITHDRAWN">Withdrawn</option>
                           </select>
                           {updatingId === app.id && (
                             <svg className="animate-spin ml-1.5 h-3 w-3 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">


### PR DESCRIPTION
# Pull Request

## Description

Added the missing `WITHDRAWN` status option to the recruiter application status dropdown in `ApplicationsList.tsx`. This allows recruiters to manually mark applications as withdrawn from the UI, matching the statuses already supported by the backend.

## Related Issue

Fixes #1133

## Type of Change

* [x] Bug Fix
* [ ] Feature
* [ ] Enhancement
* [ ] Documentation

## Testing

Manual testing performed:

1. Opened the recruiter Applications page.
2. Located the application status dropdown.
3. Verified that the `WITHDRAWN` option is now available alongside existing statuses.
4. Confirmed no other status options or functionality were modified.

## Screenshots / Video

Unable to run the application locally at the moment. The change is limited to adding the missing `WITHDRAWN` option to the recruiter status dropdown.

Code change attached in this PR.

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [x] Docs updated (if needed)
* [x] Screenshot or video attached for every UI change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applications list now supports filtering by withdrawn status, allowing users to view withdrawn applications separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->