### PR TITLE
fix: case-insensitive category and tag filter for roadmaps

### DIFF
--- a/client/src/module/student/roadmap/RoadmapsLandingPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapsLandingPage.tsx
@@ -153,12 +153,15 @@ export default function RoadmapsLandingPage() {
     }
     
     if (tag) {
-      result = result.filter(r => r.tags.includes(tag));
-    }
-
+  result = result.filter(r =>
+    r.tags.map(t => t.toLowerCase()).includes(tag.toLowerCase())
+  );
+  }
     if (category) {
-      result = result.filter(r => r.tags.includes(category));
-    }
+  result = result.filter(r =>
+    r.tags.map(t => t.toLowerCase()).includes(category.toLowerCase())
+  );
+  }
     
     return result;
   }, [roadmaps, debouncedSearch, level, tag, category]);
@@ -179,7 +182,7 @@ export default function RoadmapsLandingPage() {
       }
       if (level && level !== "ALL_LEVELS" && r.level && r.level !== level) return false;
       if (tag && !(r.tags ?? []).includes(tag)) return false;
-      if (category && !(r.tags ?? []).includes(category)) return false;
+      if (category && !(r.tags ?? []).map(t => t.toLowerCase()).includes(category.toLowerCase())) return false;
       return true;
     });
   }, [enrollments, debouncedSearch, level, tag, category]);

--- a/client/src/module/student/roadmap/RoadmapsLandingPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapsLandingPage.tsx
@@ -181,7 +181,7 @@ export default function RoadmapsLandingPage() {
         if (!matchesText) return false;
       }
       if (level && level !== "ALL_LEVELS" && r.level && r.level !== level) return false;
-      if (tag && !(r.tags ?? []).includes(tag)) return false;
+      if (tag && !(r.tags ?? []).map(t => t.toLowerCase()).includes(tag.toLowerCase())) return false;
       if (category && !(r.tags ?? []).map(t => t.toLowerCase()).includes(category.toLowerCase())) return false;
       return true;
     });

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -142,12 +142,12 @@ export async function listPublishedRoadmaps(opts: {
     });
   }
 
-  const tagFilters: string[] = [];
-  if (opts.tag) tagFilters.push(opts.tag);
-  if (opts.category) tagFilters.push(opts.category);
-  if (tagFilters.length > 0) {
-    andConditions.push({ tags: { hasSome: tagFilters } });
-  }
+ const tagFilters: string[] = [];
+if (opts.tag) tagFilters.push(opts.tag.toLowerCase());
+if (opts.category) tagFilters.push(opts.category.toLowerCase());
+if (tagFilters.length > 0) {
+  andConditions.push({ tags: { hasSome: tagFilters } });
+}
 
   if (opts.search) {
     const s = opts.search.trim();


### PR DESCRIPTION
# Pull Request

## Description
Fix case-insensitive category and tag filtering on the Roadmaps page.
The filter was sending "Fullstack" but the DB tags store "fullstack" 
(lowercase), causing 0 results when clicking the Fullstack category filter.

## Related Issue
Fixes [#1668](https://github.com/Sachinchaurasiya360/InternHack/issues/1668)

## Type of Change
- [x] Bug Fix   

## Testing
1. Go to /roadmaps page
2. Click "Fullstack" category filter
3. Full-Stack Developer Roadmap now appears correctly

## Screenshots / Video
before
<img width="1513" height="870" alt="image" src="https://github.com/user-attachments/assets/fa0011d5-dacc-446d-a692-5158d08776b3" />

after
<img width="931" height="506" alt="fullstack" src="https://github.com/user-attachments/assets/1632202c-bd75-4fef-b0c5-991023f0cc8d" />


## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tag and category filters now operate case-insensitively across the platform — including roadmap listings and the Roadmaps landing page — so searches, filters, and in-progress enrollment matching work regardless of letter case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->