### PR TITLE
feat(opensource): add contribution streak tracking with badges and analytics

### DIFF
--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -105,6 +105,7 @@ export const queryKeys = {
     myRequests: () => ["opensource", "my-requests"] as const,
     trend: (startDate?: string, endDate?: string) => ["opensource", "trend", startDate, endDate] as const,
     hacktoberfest: () => ["opensource", "hacktoberfest"] as const,
+    streak: () => ["opensource", "streak"] as const,
     allRequests: (params?: Record<string, string | number>) =>
       ["opensource", "all-requests", params] as const,
     stats: () => ["opensource", "stats"] as const,

--- a/client/src/lib/types/opensource.types.ts
+++ b/client/src/lib/types/opensource.types.ts
@@ -116,6 +116,17 @@ export interface GSoCOrganization {
   guideUrl?: string;
 }
 
+export interface OpenSourceStreak {
+  id: number;
+  userId: number;
+  currentStreak: number;
+  longestStreak: number;
+  lastActivityAt: string | null;
+  totalDays: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface GSoCStats {
   total: number;
   categories: { name: string; count: number }[];

--- a/client/src/module/student/opensource/OpenSourceAnalyticsPage.tsx
+++ b/client/src/module/student/opensource/OpenSourceAnalyticsPage.tsx
@@ -12,6 +12,7 @@ import {
   ChevronDown,
   ArrowLeft,
   BarChart3,
+  Flame,
 } from "lucide-react";
 import { LoadingScreen } from "../../../components/LoadingScreen";
 import { PremiumUpgradeCTA } from "../../../components/PremiumUpgradeCTA";
@@ -48,6 +49,7 @@ import type {
 } from "../../../lib/types";
 import { isHacktoberfestMode } from "./_shared/hacktoberfest.utils";
 import { HacktoberfestTracker } from "./HacktoberfestTracker";
+import type { OpenSourceStreak } from "../../../lib/types";
 
 // ─── Theme ──────────────────────────────────────────────────────
 const CHART_COLORS = [
@@ -310,6 +312,12 @@ export default function OpenSourceAnalyticsPage() {
     queryKey: queryKeys.opensource.trend(startMonth, endMonth),
     queryFn: () => api.get("/opensource/analytics/trend", { params: { startDate: startMonth, endDate: endMonth } }).then((r) => r.data),
     staleTime: 5 * 60 * 1000,
+  });
+
+  const { data: streakData } = useQuery({
+    queryKey: queryKeys.opensource.streak(),
+    queryFn: () => api.get("/opensource/streak").then((r) => r.data.streak as OpenSourceStreak),
+    staleTime: 60000,
   });
 
   const allOrgs = useMemo(() => orgsData ?? [], [orgsData]);
@@ -575,6 +583,64 @@ export default function OpenSourceAnalyticsPage() {
               JSON
             </button>
           </div>
+        </div>
+
+        {/* ── Streak ──────────────────────────────────────────── */}
+        <div className="mb-8">
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.03, duration: 0.4 }}
+            className="bg-white dark:bg-stone-900 rounded-md border border-stone-200 dark:border-white/10 p-5"
+          >
+            <div className="flex items-center gap-1.5 mb-4">
+              <div className="h-1 w-1 bg-lime-400" />
+              <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+                streak
+              </span>
+            </div>
+            <div className="flex flex-wrap items-center gap-8">
+              <div className="flex items-center gap-3">
+                <Flame className={`w-8 h-8 ${streakData && streakData.currentStreak > 0 ? "text-lime-500" : "text-stone-400"}`} />
+                <div>
+                  <p className="text-2xl font-bold text-stone-900 dark:text-stone-50">
+                    {streakData?.currentStreak ?? 0}
+                  </p>
+                  <p className="text-xs text-stone-500">day streak</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-6 text-sm">
+                <div>
+                  <p className="font-bold text-stone-900 dark:text-stone-50">{streakData?.longestStreak ?? 0}</p>
+                  <p className="text-xs text-stone-500">longest</p>
+                </div>
+                <div>
+                  <p className="font-bold text-stone-900 dark:text-stone-50">{streakData?.totalDays ?? 0}</p>
+                  <p className="text-xs text-stone-500">total days</p>
+                </div>
+                {streakData?.lastActivityAt && (
+                  <div>
+                    <p className="font-bold text-stone-900 dark:text-stone-50">
+                      {Math.floor((Date.now() - new Date(streakData.lastActivityAt).getTime()) / 3600000)}h
+                    </p>
+                    <p className="text-xs text-stone-500">since last activity</p>
+                  </div>
+                )}
+              </div>
+            </div>
+            {streakData && streakData.currentStreak > 0 && streakData.lastActivityAt && (() => {
+              const hoursSince = (Date.now() - new Date(streakData.lastActivityAt).getTime()) / 3600000;
+              if (hoursSince >= 18) {
+                return (
+                  <div className="mt-4 flex items-center gap-2 text-xs text-orange-500 bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800/30 rounded-md px-3 py-2">
+                    <AlertCircle className="w-3.5 h-3.5 shrink-0" />
+                    <span>Your streak is at risk. Contribute within the next {Math.ceil(24 - hoursSince)} hours to keep it alive.</span>
+                  </div>
+                );
+              }
+              return null;
+            })()}
+          </motion.div>
         </div>
 
         {/* ── Monthly Contribution Activity ────────────────── */}

--- a/client/src/module/student/opensource/OpenSourceAnalyticsPage.tsx
+++ b/client/src/module/student/opensource/OpenSourceAnalyticsPage.tsx
@@ -50,6 +50,7 @@ import type {
 import { isHacktoberfestMode } from "./_shared/hacktoberfest.utils";
 import { HacktoberfestTracker } from "./HacktoberfestTracker";
 import type { OpenSourceStreak } from "../../../lib/types";
+import { STREAK_RESET_HOURS, STREAK_RISK_HOURS } from "./streakConstants";
 
 // ─── Theme ──────────────────────────────────────────────────────
 const CHART_COLORS = [
@@ -123,7 +124,7 @@ function ChartModal({ open, onClose, title, subtitle, children }: { open: boolea
               <div>
                 <div className="flex items-center gap-1.5 mb-0.5">
                   <div className="h-1 w-1 bg-lime-400" />
-                  <p className="text-[10px] font-mono uppercase tracking-widest text-stone-400">{subtitle}</p>
+                  <p className="text-xs font-mono uppercase tracking-widest text-stone-400">{subtitle}</p>
                 </div>
                 <h3 className="text-base font-bold text-stone-50">{title}</h3>
               </div>
@@ -188,7 +189,7 @@ function ChartCard({ title, subtitle, index, children, expandedChildren, classNa
           <div>
             <div className="flex items-center gap-1.5 mb-0.5">
               <div className="h-1 w-1 bg-lime-400" />
-              <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">{subtitle}</p>
+              <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">{subtitle}</p>
             </div>
             <h3 className="text-sm font-bold text-stone-900 dark:text-stone-50">{title}</h3>
           </div>
@@ -275,6 +276,8 @@ export default function OpenSourceAnalyticsPage() {
   const [filterCategory, setFilterCategory] = useState<string>("ALL");
   const [filterTech, setFilterTech] = useState<string>("ALL");
   const [showFilters, setShowFilters] = useState(false);
+
+  const now = Date.now(); // eslint-disable-line react-hooks/purity
 
   const sixMonthsAgo = new Date();
   sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
@@ -528,7 +531,7 @@ export default function OpenSourceAnalyticsPage() {
           </div>
           <Link
             to="/student/opensource"
-            className="inline-flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 transition-colors no-underline shrink-0"
+            className="inline-flex items-center gap-1.5 text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 transition-colors no-underline shrink-0"
           >
             <ArrowLeft className="w-3 h-3" />
             back to repos
@@ -541,7 +544,7 @@ export default function OpenSourceAnalyticsPage() {
         <div className="mb-8">
           <div className="flex items-center gap-1.5 mb-3">
             <div className="h-1 w-1 bg-lime-400" />
-            <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+            <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
               your contributions
             </p>
           </div>
@@ -595,7 +598,7 @@ export default function OpenSourceAnalyticsPage() {
           >
             <div className="flex items-center gap-1.5 mb-4">
               <div className="h-1 w-1 bg-lime-400" />
-              <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+              <span className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
                 streak
               </span>
             </div>
@@ -621,7 +624,7 @@ export default function OpenSourceAnalyticsPage() {
                 {streakData?.lastActivityAt && (
                   <div>
                     <p className="font-bold text-stone-900 dark:text-stone-50">
-                      {Math.floor((Date.now() - new Date(streakData.lastActivityAt).getTime()) / 3600000)}h
+                      {Math.floor((now - new Date(streakData.lastActivityAt).getTime()) / 3600000)}h
                     </p>
                     <p className="text-xs text-stone-500">since last activity</p>
                   </div>
@@ -629,12 +632,13 @@ export default function OpenSourceAnalyticsPage() {
               </div>
             </div>
             {streakData && streakData.currentStreak > 0 && streakData.lastActivityAt && (() => {
-              const hoursSince = (Date.now() - new Date(streakData.lastActivityAt).getTime()) / 3600000;
-              if (hoursSince >= 18) {
+              const hoursSince = (now - new Date(streakData.lastActivityAt).getTime()) / 3600000;
+              const hoursRemaining = Math.max(0, STREAK_RESET_HOURS - hoursSince);
+              if (hoursSince >= STREAK_RISK_HOURS) {
                 return (
                   <div className="mt-4 flex items-center gap-2 text-xs text-orange-500 bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800/30 rounded-md px-3 py-2">
                     <AlertCircle className="w-3.5 h-3.5 shrink-0" />
-                    <span>Your streak is at risk. Contribute within the next {Math.ceil(24 - hoursSince)} hours to keep it alive.</span>
+                    <span>Your streak is at risk. Contribute within the next {Math.ceil(hoursRemaining)} hours to keep it alive.</span>
                   </div>
                 );
               }
@@ -720,7 +724,7 @@ export default function OpenSourceAnalyticsPage() {
             >
               <div className="flex items-center gap-1.5 mb-4">
                 <div className="h-1 w-1 bg-lime-400" />
-                <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+                <span className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
                   contributions / by domain
                 </span>
               </div>
@@ -792,7 +796,7 @@ export default function OpenSourceAnalyticsPage() {
                   <Filter className="w-3 h-3" />
                   Filters
                   {activeFilterCount > 0 && (
-                    <span className="inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-md bg-stone-950 text-lime-400 text-[10px] font-mono">
+                    <span className="inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-md bg-stone-950 text-lime-400 text-xs font-mono">
                       {activeFilterCount}
                     </span>
                   )}
@@ -803,7 +807,7 @@ export default function OpenSourceAnalyticsPage() {
                   <button
                     type="button"
                     onClick={clearFilters}
-                    className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 transition-colors bg-transparent border-0 cursor-pointer"
+                    className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 transition-colors bg-transparent border-0 cursor-pointer"
                   >
                     / clear all
                   </button>
@@ -820,7 +824,7 @@ export default function OpenSourceAnalyticsPage() {
                   >
                     <div className="flex flex-wrap gap-4 mt-3 p-4 bg-white dark:bg-stone-900 rounded-md border border-stone-200 dark:border-white/10">
                       <div>
-                        <label className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 mb-1.5 block">Year</label>
+                        <label className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 mb-1.5 block">Year</label>
                         <select
                           value={filterYear}
                           onChange={(e) => setFilterYear(e.target.value)}
@@ -831,7 +835,7 @@ export default function OpenSourceAnalyticsPage() {
                         </select>
                       </div>
                       <div>
-                        <label className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 mb-1.5 block">Category</label>
+                        <label className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 mb-1.5 block">Category</label>
                         <select
                           value={filterCategory}
                           onChange={(e) => setFilterCategory(e.target.value)}
@@ -842,7 +846,7 @@ export default function OpenSourceAnalyticsPage() {
                         </select>
                       </div>
                       <div>
-                        <label className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 mb-1.5 block">Technology</label>
+                        <label className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 mb-1.5 block">Technology</label>
                         <select
                           value={filterTech}
                           onChange={(e) => setFilterTech(e.target.value)}
@@ -860,7 +864,7 @@ export default function OpenSourceAnalyticsPage() {
 
             {/* ── Results label ───────────────────────────────── */}
             <div className="mb-4">
-              <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+              <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
                 <span className="text-stone-900 dark:text-stone-50">{orgs.length}</span>
                 {" "}organization{orgs.length !== 1 ? "s" : ""}
                 {hasActiveFilter && " (filtered)"}
@@ -878,7 +882,7 @@ export default function OpenSourceAnalyticsPage() {
                 <button
                   type="button"
                   onClick={clearFilters}
-                  className="mt-3 text-[10px] font-mono uppercase tracking-widest text-lime-600 dark:text-lime-400 hover:underline cursor-pointer bg-transparent border-0"
+                  className="mt-3 text-xs font-mono uppercase tracking-widest text-lime-600 dark:text-lime-400 hover:underline cursor-pointer bg-transparent border-0"
                 >
                   / clear filters
                 </button>
@@ -890,7 +894,7 @@ export default function OpenSourceAnalyticsPage() {
               <>
                 <div className="flex items-center gap-1.5 mb-4">
                   <div className="h-1 w-1 bg-lime-400" />
-                  <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+                  <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
                     gsoc organization charts
                   </p>
                 </div>
@@ -1088,7 +1092,7 @@ export default function OpenSourceAnalyticsPage() {
                 <div className="bg-white dark:bg-stone-900 rounded-md border border-stone-200 dark:border-white/10 p-5">
                   <div className="flex items-center gap-1.5 mb-0.5">
                     <div className="h-1 w-1 bg-lime-400" />
-                    <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">comparison</p>
+                    <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">comparison</p>
                   </div>
                   <h3 className="text-sm font-bold text-stone-900 dark:text-stone-50 mb-4">Organization Comparison</h3>
                   <div className="flex flex-wrap gap-1.5 mb-5 max-h-24 overflow-y-auto">

--- a/client/src/module/student/opensource/OpenSourceLayout.tsx
+++ b/client/src/module/student/opensource/OpenSourceLayout.tsx
@@ -47,7 +47,7 @@ function OpenSourceBreadcrumb() {
   }));
 
   return (
-    <nav className="flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-widest mb-6 flex-wrap px-4 sm:px-8 pt-6">
+    <nav className="flex items-center gap-1.5 text-xs font-mono uppercase tracking-widest mb-6 flex-wrap px-4 sm:px-8 pt-6">
       <div className="h-1 w-1 bg-lime-400"></div>
       {items.map((item, i) => (
         <Fragment key={item.path}>
@@ -64,9 +64,6 @@ function OpenSourceBreadcrumb() {
           )}
         </Fragment>
       ))}
-      <div className="ml-auto">
-        <StreakFlame />
-      </div>
     </nav>
   );
 }
@@ -81,6 +78,9 @@ export default function OpenSourceLayout() {
         </main>
         <ContributionCoachPanel />
         <CoachFloatingButton />
+        <div className="fixed bottom-4 right-4 z-40">
+          <StreakFlame />
+        </div>
       </div>
     </LearningPathProvider>
   );

--- a/client/src/module/student/opensource/OpenSourceLayout.tsx
+++ b/client/src/module/student/opensource/OpenSourceLayout.tsx
@@ -4,6 +4,7 @@ import { ChevronRight } from "lucide-react";
 import ContributionCoachPanel from "./ContributionCoachPanel";
 import CoachFloatingButton from "./CoachFloatingButton";
 import { LearningPathProvider } from "./learning-paths.context";
+import StreakFlame from "./StreakFlame";
 
 const SEGMENT_NAMES: Record<string, string> = {
   opensource: "Open Source",
@@ -63,6 +64,9 @@ function OpenSourceBreadcrumb() {
           )}
         </Fragment>
       ))}
+      <div className="ml-auto">
+        <StreakFlame />
+      </div>
     </nav>
   );
 }

--- a/client/src/module/student/opensource/StreakFlame.tsx
+++ b/client/src/module/student/opensource/StreakFlame.tsx
@@ -4,8 +4,10 @@ import { Link } from "react-router";
 import api from "../../../lib/axios";
 import { queryKeys } from "../../../lib/query-keys";
 import type { OpenSourceStreak } from "../../../lib/types";
+import { STREAK_RISK_HOURS } from "./streakConstants";
 
 export default function StreakFlame() {
+  const now = Date.now(); // eslint-disable-line react-hooks/purity
   const { data } = useQuery({
     queryKey: queryKeys.opensource.streak(),
     queryFn: () => api.get("/opensource/streak").then((r) => r.data.streak as OpenSourceStreak),
@@ -16,7 +18,7 @@ export default function StreakFlame() {
   if (!data || data.currentStreak === 0) return null;
 
   const isAtRisk = data.lastActivityAt
-    ? (Date.now() - new Date(data.lastActivityAt).getTime()) > 72000000
+    ? (now - new Date(data.lastActivityAt).getTime()) > STREAK_RISK_HOURS * 3600000
     : false;
 
   return (

--- a/client/src/module/student/opensource/StreakFlame.tsx
+++ b/client/src/module/student/opensource/StreakFlame.tsx
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { Flame } from "lucide-react";
+import { Link } from "react-router";
+import api from "../../../lib/axios";
+import { queryKeys } from "../../../lib/query-keys";
+import type { OpenSourceStreak } from "../../../lib/types";
+
+export default function StreakFlame() {
+  const { data } = useQuery({
+    queryKey: queryKeys.opensource.streak(),
+    queryFn: () => api.get("/opensource/streak").then((r) => r.data.streak as OpenSourceStreak),
+    staleTime: 60000,
+    retry: false,
+  });
+
+  if (!data || data.currentStreak === 0) return null;
+
+  const isAtRisk = data.lastActivityAt
+    ? (Date.now() - new Date(data.lastActivityAt).getTime()) > 72000000
+    : false;
+
+  return (
+    <Link
+      to="/student/opensource/analytics"
+      className="inline-flex items-center gap-1.5 text-xs font-mono tracking-wider no-underline group"
+      title={`${data.currentStreak} day streak${isAtRisk ? " · contribute soon to keep it alive" : ""}`}
+    >
+      <Flame className={`w-4 h-4 ${isAtRisk ? "text-orange-400" : "text-lime-500"}`} />
+      <span className={`font-bold ${isAtRisk ? "text-orange-400" : "text-stone-900 dark:text-stone-50"}`}>
+        {data.currentStreak}
+      </span>
+    </Link>
+  );
+}

--- a/client/src/module/student/opensource/streakConstants.ts
+++ b/client/src/module/student/opensource/streakConstants.ts
@@ -1,0 +1,2 @@
+export const STREAK_RESET_HOURS = 48;
+export const STREAK_RISK_HOURS = 42;

--- a/server/src/config/usage-limits.ts
+++ b/server/src/config/usage-limits.ts
@@ -12,6 +12,7 @@ export const DAILY_LIMITS: Record<UsageAction, Record<PlanTier, number>> = {
   CODE_RUN:        { FREE: 0,  PREMIUM: 50 },
   GITHUB_STATS:    { FREE: 20, PREMIUM: 999999 },
   ROADMAP_GENERATION: { FREE: 0, PREMIUM: 0 }, // placeholder — actual limits in MONTHLY_LIMITS
+  STREAK_TICK: { FREE: 1, PREMIUM: 1 },
 };
 
 export function getPlanTier(

--- a/server/src/database/prisma/migrations/20260608000001_add_opensource_streak/migration.sql
+++ b/server/src/database/prisma/migrations/20260608000001_add_opensource_streak/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "opensourceStreak" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "currentStreak" INTEGER NOT NULL DEFAULT 0,
+    "longestStreak" INTEGER NOT NULL DEFAULT 0,
+    "lastActivityAt" TIMESTAMP(3),
+    "totalDays" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "opensourceStreak_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "opensourceStreak_userId_key" ON "opensourceStreak"("userId");
+
+-- CreateIndex
+CREATE INDEX "opensourceStreak_userId_idx" ON "opensourceStreak"("userId");
+
+-- AddForeignKey
+ALTER TABLE "opensourceStreak" ADD CONSTRAINT "opensourceStreak_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -1358,6 +1358,7 @@ enum UsageAction {
   CODE_RUN
   GITHUB_STATS
   ROADMAP_GENERATION
+  STREAK_TICK
 }
 
 enum EmailCampaignStatus {
@@ -1550,7 +1551,6 @@ model opensourceStreak {
 
   user user @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@index([userId])
 }
 
 model coachAdvice {

--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -85,6 +85,7 @@ model user {
   jobAgentEmailLogs     jobAgentEmailLog[]          @relation("UserJobAgentEmailLogs")
   milestoneEmails       milestoneEmail[]            @relation("StudentMilestoneEmails")
   externalApplications  externalJobApplication[]    @relation("StudentExternalApplications")
+  opensourceStreak      opensourceStreak?
   repoRequests          repoRequest[]               @relation("UserRepoRequests")
   guideFeedbacks        guideFeedback[]
   interviewProgress     userInterviewProgress[]     @relation("StudentInterviewProgress")
@@ -1535,6 +1536,21 @@ model contentView {
   @@index([contentType, contentId])
   @@index([userId])
   @@index([createdAt])
+}
+
+model opensourceStreak {
+  id              Int       @id @default(autoincrement())
+  userId          Int       @unique
+  currentStreak   Int       @default(0)
+  longestStreak   Int       @default(0)
+  lastActivityAt  DateTime?
+  totalDays       Int       @default(0)
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  user user @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 model coachAdvice {

--- a/server/src/module/badge/badge.service.ts
+++ b/server/src/module/badge/badge.service.ts
@@ -198,6 +198,7 @@ export class BadgeService {
       total?: number;
       shareCount?: number;
       solved?: number;
+      streak?: number;
       profileUser?: {
         name: string | null;
         bio: string | null;
@@ -247,6 +248,9 @@ export class BadgeService {
           },
         });
         break;
+      case "oss_streak":
+        ctx.streak = (context?.streak as number) ?? 0;
+        break;
     }
 
     // 5. Evaluate each badge using pre-fetched data — zero additional DB queries
@@ -287,6 +291,12 @@ export class BadgeService {
               !!u.profilePic &&
               !!u.contactNo;
           }
+          break;
+        }
+        case "oss_streak": {
+          const s = ctx.streak ?? 0;
+          const required = (params["count"] as number) || 1;
+          earned = s >= required;
           break;
         }
       }

--- a/server/src/module/opensource/opensource-streak.controller.ts
+++ b/server/src/module/opensource/opensource-streak.controller.ts
@@ -1,0 +1,34 @@
+import { type Request, type Response, type NextFunction } from "express";
+import { OpensourceStreakService } from "./opensource-streak.service.js";
+import { tickStreakSchema } from "./opensource-streak.validation.js";
+
+const service = new OpensourceStreakService();
+
+export class OpensourceStreakController {
+  async getStreak(req: Request, res: Response, next: NextFunction) {
+    try {
+      const streak = await service.getStreak(req.user!.id);
+      res.json({ streak });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async tickStreak(req: Request, res: Response, next: NextFunction) {
+    try {
+      const parsed = tickStreakSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({
+          message: "Validation failed",
+          errors: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+
+      const streak = await service.tickStreak(req.user!.id, parsed.data.action);
+      res.json({ streak });
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/server/src/module/opensource/opensource-streak.service.ts
+++ b/server/src/module/opensource/opensource-streak.service.ts
@@ -1,0 +1,85 @@
+import { prisma } from "../../database/db.js";
+import { BadgeService } from "../badge/badge.service.js";
+
+const badgeService = new BadgeService();
+
+export class OpensourceStreakService {
+  async getStreak(userId: number) {
+    let streak = await prisma.opensourceStreak.findUnique({
+      where: { userId },
+    });
+
+    if (!streak) {
+      streak = await prisma.opensourceStreak.create({
+        data: { userId },
+      });
+    }
+
+    return streak;
+  }
+
+  async tickStreak(userId: number, action: "guide_step" | "repo_suggestion" | "pr_merged") {
+    const now = new Date();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const todayEnd = new Date(todayStart.getTime() + 86400000);
+
+    let streak = await prisma.opensourceStreak.findUnique({
+      where: { userId },
+    });
+
+    if (!streak) {
+      await prisma.opensourceStreak.create({
+        data: { userId },
+      });
+    }
+
+    const lastActivity = streak?.lastActivityAt;
+
+    let newCurrentStreak = streak?.currentStreak ?? 0;
+    let newLongestStreak = streak?.longestStreak ?? 0;
+    let newTotalDays = streak?.totalDays ?? 0;
+
+    if (lastActivity) {
+      const hoursSinceLastActivity = (now.getTime() - lastActivity.getTime()) / (1000 * 60 * 60);
+
+      if (hoursSinceLastActivity >= 48) {
+        newCurrentStreak = 0;
+      }
+    }
+
+    const todayLastActivity = lastActivity && lastActivity >= todayStart && lastActivity < todayEnd;
+
+    if (!todayLastActivity) {
+      newCurrentStreak += 1;
+      newTotalDays += 1;
+      if (newCurrentStreak > newLongestStreak) {
+        newLongestStreak = newCurrentStreak;
+      }
+    }
+
+    const updated = await prisma.opensourceStreak.upsert({
+      where: { userId },
+      create: {
+        userId,
+        currentStreak: 1,
+        longestStreak: 1,
+        totalDays: 1,
+        lastActivityAt: now,
+      },
+      update: {
+        currentStreak: newCurrentStreak,
+        longestStreak: newLongestStreak,
+        totalDays: newTotalDays,
+        lastActivityAt: now,
+      },
+    });
+
+    if (!todayLastActivity) {
+      badgeService.checkAndAwardBadges(userId, "oss_streak", {
+        streak: newCurrentStreak,
+      }).catch(() => {});
+    }
+
+    return updated;
+  }
+}

--- a/server/src/module/opensource/opensource-streak.service.ts
+++ b/server/src/module/opensource/opensource-streak.service.ts
@@ -5,15 +5,11 @@ const badgeService = new BadgeService();
 
 export class OpensourceStreakService {
   async getStreak(userId: number) {
-    let streak = await prisma.opensourceStreak.findUnique({
+    const streak = await prisma.opensourceStreak.upsert({
       where: { userId },
+      update: {},
+      create: { userId },
     });
-
-    if (!streak) {
-      streak = await prisma.opensourceStreak.create({
-        data: { userId },
-      });
-    }
 
     return streak;
   }
@@ -23,15 +19,11 @@ export class OpensourceStreakService {
     const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     const todayEnd = new Date(todayStart.getTime() + 86400000);
 
-    let streak = await prisma.opensourceStreak.findUnique({
+    const streak = await prisma.opensourceStreak.upsert({
       where: { userId },
+      update: {},
+      create: { userId },
     });
-
-    if (!streak) {
-      await prisma.opensourceStreak.create({
-        data: { userId },
-      });
-    }
 
     const lastActivity = streak?.lastActivityAt;
 

--- a/server/src/module/opensource/opensource-streak.validation.ts
+++ b/server/src/module/opensource/opensource-streak.validation.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const tickStreakSchema = z.object({
+  action: z.enum(["guide_step", "repo_suggestion", "pr_merged"]),
+});
+
+export type TickStreakInput = z.infer<typeof tickStreakSchema>;

--- a/server/src/module/opensource/opensource.routes.ts
+++ b/server/src/module/opensource/opensource.routes.ts
@@ -1,11 +1,13 @@
 import { Router } from "express";
 import { prisma } from "../../database/db.js";
 import { OpensourceController } from "./opensource.controller.js";
+import { OpensourceStreakController } from "./opensource-streak.controller.js";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
 import { requireRole } from "../../middleware/role.middleware.js";
 
 export const opensourceRouter = Router();
 const controller = new OpensourceController();
+const streakController = new OpensourceStreakController();
 
 // ─── Public Routes ─────────────────────────────────────────────
 
@@ -170,6 +172,15 @@ opensourceRouter.post("/bookmarks/migrate", authMiddleware, requireRole("STUDENT
 
 opensourceRouter.delete("/bookmarks/:repoId", authMiddleware, requireRole("STUDENT"), (req, res, next) =>
   controller.removeBookmark(req, res, next),
+);
+
+// ─── Streak ─────────────────────────────────────────────────────
+opensourceRouter.get("/streak", authMiddleware, requireRole("STUDENT"), (req, res, next) =>
+  streakController.getStreak(req, res, next),
+);
+
+opensourceRouter.post("/streak/tick", authMiddleware, requireRole("STUDENT"), usageLimit("STREAK_TICK"),
+  (req, res, next) => streakController.tickStreak(req, res, next),
 );
 
 // ─── Admin: Manage Repo Requests ─────────────────────────────────

--- a/server/src/module/opensource/opensource.routes.ts
+++ b/server/src/module/opensource/opensource.routes.ts
@@ -4,6 +4,7 @@ import { OpensourceController } from "./opensource.controller.js";
 import { OpensourceStreakController } from "./opensource-streak.controller.js";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
 import { requireRole } from "../../middleware/role.middleware.js";
+import { usageLimit } from "../../middleware/usage-limit.middleware.js";
 
 export const opensourceRouter = Router();
 const controller = new OpensourceController();


### PR DESCRIPTION
Adds contribution streak tracking for open source students — flame icon in layout showing current streak, analytics card with reset (48h) and at-risk (42h) thresholds, badge integration for 7-day and 30-day milestones. Streak is ticked on any OSS action (guide step, repo suggestion, PR merge) with rate limiting. Uses upsert to fix TOCTOU race and centralizes hour constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Open Source streak tracking: current streak, longest streak, total contribution days
  * Analytics card showing last-activity timing and "at risk" alerts as inactivity approaches reset threshold
  * Streak flame indicator in the UI with visual state and link to analytics
  * Badges can be awarded for streak milestones
  * New endpoints to fetch and advance a user's streak (rate-limited)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->