### PR TITLE
feat: add contributor portfolio page for open source showcase

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import { LoadingScreen } from "./components/LoadingScreen";
 import BackToTopButton from "./components/common/BackToTopButton";
 import ScrollToTop from "./components/common/ScrollToTop";
 const ContributorsPage = lazyWithRetry(() => import("./module/contributors/ContributorsPage"));
+const PortfolioPage = lazyWithRetry(() => import("./module/student/portfolio/PortfolioPage"));
 
 function lazyWithRetry(factory: () => Promise<{ default: ComponentType<unknown> }>) {
   return lazy(() =>
@@ -361,6 +362,7 @@ function App() {
           <Route path="/learn/roadmaps/:slug/:topicSlug" element={<ProtectedRoute role="STUDENT"><RoadmapTopicPage /></ProtectedRoute>} />
           <Route path="/blog" element={<BlogListPage />} />
           <Route path="/contributors" element={<ContributorsPage />} />
+          <Route path="/portfolio/:slug" element={<PortfolioPage />} />
           <Route path="/blog/:slug" element={<BlogPostPage />} />
           {/* Legal Pages */}
           <Route path="/terms" element={<TermsPage />} />

--- a/client/src/module/student/portfolio/PortfolioPage.tsx
+++ b/client/src/module/student/portfolio/PortfolioPage.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { motion } from "framer-motion";
 import {
   MapPin, GraduationCap, Linkedin, Github, Globe, ExternalLink,
-  Calendar, User, Sparkles, Star, BookOpen, Folder, Award,
+  Calendar, User, Trophy, Star, BookOpen, Folder, Award,
 } from "lucide-react";
 import api from "../../../lib/axios";
 import { LoadingScreen } from "../../../components/LoadingScreen";
@@ -46,7 +46,7 @@ const fadeInUp = {
 function SocialIcon({ url, icon }: { url: string | null; icon: React.ReactNode }) {
   if (!url) return null;
   return (
-    <a href={url} target="_blank" rel="noopener noreferrer" className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-500 hover:text-lime-600 hover:bg-lime-50 dark:hover:bg-lime-900/20 transition-colors">
+    <a href={url} target="_blank" rel="noopener noreferrer" className="p-2 rounded-md bg-stone-100 dark:bg-stone-800 text-stone-500 hover:text-lime-600 hover:bg-lime-50 dark:hover:bg-lime-900/20 transition-colors">
       {icon}
     </a>
   );
@@ -57,11 +57,11 @@ function JobStatusBadge({ status }: { status: string | null }) {
   const map: Record<string, { label: string; cls: string }> = {
     LOOKING: { label: "Looking for job", cls: "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400" },
     OPEN_TO_OFFER: { label: "Open to offer", cls: "bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400" },
-    NO_OFFER: { label: "No offer", cls: "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400" },
+    NO_OFFER: { label: "No offer", cls: "bg-stone-100 text-stone-500 dark:bg-stone-800 dark:text-stone-400" },
   };
   const info = map[status];
   if (!info) return null;
-  return <span className={`px-2.5 py-1 rounded-lg text-xs font-semibold ${info.cls}`}>{info.label}</span>;
+  return <span className={`px-2.5 py-1 rounded-md text-xs font-semibold ${info.cls}`}>{info.label}</span>;
 }
 
 export default function PortfolioPage() {
@@ -81,9 +81,9 @@ export default function PortfolioPage() {
     return (
       <div className="min-h-[60vh] flex items-center justify-center">
         <div className="text-center">
-          <User className="w-12 h-12 text-gray-200 mx-auto mb-3" />
-          <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">Portfolio not found</h2>
-          <p className="text-sm text-gray-500 mb-4">This portfolio does not exist or is not public.</p>
+          <User className="w-12 h-12 text-stone-200 mx-auto mb-3" />
+          <h2 className="text-lg font-bold text-stone-900 dark:text-white mb-1">Portfolio not found</h2>
+          <p className="text-sm text-stone-500 mb-4">This portfolio does not exist or is not public.</p>
           <Link to="/" className="text-sm text-lime-600 hover:underline">Go home</Link>
         </div>
       </div>
@@ -102,34 +102,34 @@ export default function PortfolioPage() {
 
       <div className="max-w-5xl mx-auto px-4 py-8">
         <motion.div
-          className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm"
+          className="bg-white dark:bg-stone-900 rounded-2xl border border-stone-200 dark:border-stone-700 overflow-hidden shadow-sm"
           initial="hidden" animate="visible" custom={0} variants={fadeInUp}
         >
           {p.coverImage ? (
             <div className="h-32 sm:h-44 bg-cover bg-center" style={{ backgroundImage: `url(${p.coverImage})` }} />
           ) : (
-            <div className="h-32 sm:h-44 bg-gradient-to-r from-lime-400 via-emerald-400 to-cyan-400" />
+            <div className="h-32 sm:h-44 bg-stone-900 dark:bg-stone-800" />
           )}
           <div className="px-6 pb-6">
             <div className="flex flex-col sm:flex-row sm:items-end gap-4 -mt-12 sm:-mt-16 mb-4">
               {p.profilePic ? (
-                <img src={p.profilePic} alt={p.name} className="w-24 h-24 sm:w-28 sm:h-28 rounded-xl border-4 border-white dark:border-gray-900 object-cover shadow-lg" />
+                <img src={p.profilePic} alt={p.name} className="w-24 h-24 sm:w-28 sm:h-28 rounded-md border-4 border-white dark:border-stone-900 object-cover shadow-lg" />
               ) : (
-                <div className="w-24 h-24 sm:w-28 sm:h-28 rounded-xl border-4 border-white dark:border-gray-900 shadow-lg bg-lime-100 dark:bg-lime-900/30 flex items-center justify-center">
+                <div className="w-24 h-24 sm:w-28 sm:h-28 rounded-md border-4 border-white dark:border-stone-900 shadow-lg bg-lime-100 dark:bg-lime-900/30 flex items-center justify-center">
                   <span className="text-2xl sm:text-3xl font-bold text-lime-600 dark:text-lime-400">{initials}</span>
                 </div>
               )}
               <div className="flex-1 min-w-0 sm:pb-1">
-                <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white truncate">{p.name}</h1>
-                {p.designation && <p className="text-sm text-gray-500">{p.designation}{p.company ? ` at ${p.company}` : ""}</p>}
+                <h1 className="text-xl sm:text-2xl font-bold text-stone-900 dark:text-white truncate">{p.name}</h1>
+                {p.designation && <p className="text-sm text-stone-500">{p.designation}{p.company ? ` at ${p.company}` : ""}</p>}
                 <div className="flex flex-wrap items-center gap-2 mt-1">
                   {p.location && (
-                    <span className="text-xs text-gray-400 flex items-center gap-1"><MapPin className="w-3 h-3" />{p.location}</span>
+                    <span className="text-xs text-stone-400 flex items-center gap-1"><MapPin className="w-3 h-3" />{p.location}</span>
                   )}
                   {p.college && (
-                    <span className="text-xs text-gray-400 flex items-center gap-1"><GraduationCap className="w-3 h-3" />{p.college}{p.graduationYear ? ` (${p.graduationYear})` : ""}</span>
+                    <span className="text-xs text-stone-400 flex items-center gap-1"><GraduationCap className="w-3 h-3" />{p.college}{p.graduationYear ? ` (${p.graduationYear})` : ""}</span>
                   )}
-                  <span className="text-xs text-gray-400 flex items-center gap-1"><Calendar className="w-3 h-3" />{p.memberSinceMonths} mo</span>
+                  <span className="text-xs text-stone-400 flex items-center gap-1"><Calendar className="w-3 h-3" />{p.memberSinceMonths} mo</span>
                 </div>
               </div>
               {p.jobStatus && (
@@ -137,7 +137,7 @@ export default function PortfolioPage() {
               )}
             </div>
 
-            {p.bio && <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed mb-4 max-w-2xl">{p.bio}</p>}
+            {p.bio && <p className="text-sm text-stone-600 dark:text-stone-400 leading-relaxed mb-4 max-w-2xl">{p.bio}</p>}
 
             <div className="flex flex-wrap items-center gap-1.5">
               <SocialIcon url={p.githubUrl} icon={<Github className="w-4 h-4" />} />
@@ -150,26 +150,26 @@ export default function PortfolioPage() {
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">
           <div className="space-y-4">
-            <motion.div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-5" initial="hidden" animate="visible" custom={1} variants={fadeInUp}>
-              <h2 className="text-xs font-bold text-gray-500 mb-3 flex items-center gap-1.5"><Sparkles className="w-3.5 h-3.5" />Stats</h2>
+            <motion.div className="bg-white dark:bg-stone-900 rounded-2xl border border-stone-200 dark:border-stone-700 shadow-sm p-5" initial="hidden" animate="visible" custom={1} variants={fadeInUp}>
+              <h2 className="text-xs font-bold text-stone-500 mb-3 flex items-center gap-1.5"><Trophy className="w-3.5 h-3.5" />Stats</h2>
               <div className="grid grid-cols-2 gap-3">
-                <div className="text-center p-3 rounded-xl bg-gray-50 dark:bg-gray-800">
-                  <p className="text-lg font-bold text-gray-900 dark:text-white">{p.badgeCount}</p>
-                  <p className="text-[10px] text-gray-500">Badges</p>
+                <div className="text-center p-3 rounded-md bg-stone-50 dark:bg-stone-800">
+                  <p className="text-lg font-bold text-stone-900 dark:text-white">{p.badgeCount}</p>
+                  <p className="text-[10px] text-stone-500">Badges</p>
                 </div>
-                <div className="text-center p-3 rounded-xl bg-gray-50 dark:bg-gray-800">
-                  <p className="text-lg font-bold text-gray-900 dark:text-white">{p.projects?.length || 0}</p>
-                  <p className="text-[10px] text-gray-500">Projects</p>
+                <div className="text-center p-3 rounded-md bg-stone-50 dark:bg-stone-800">
+                  <p className="text-lg font-bold text-stone-900 dark:text-white">{p.projects?.length || 0}</p>
+                  <p className="text-[10px] text-stone-500">Projects</p>
                 </div>
               </div>
             </motion.div>
 
             {p.skills && p.skills.length > 0 && (
-              <motion.div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-5" initial="hidden" animate="visible" custom={2} variants={fadeInUp}>
-                <h2 className="text-xs font-bold text-gray-500 mb-3 flex items-center gap-1.5"><Star className="w-3.5 h-3.5" />Skills</h2>
+              <motion.div className="bg-white dark:bg-stone-900 rounded-2xl border border-stone-200 dark:border-stone-700 shadow-sm p-5" initial="hidden" animate="visible" custom={2} variants={fadeInUp}>
+                <h2 className="text-xs font-bold text-stone-500 mb-3 flex items-center gap-1.5"><Star className="w-3.5 h-3.5" />Skills</h2>
                 <div className="flex flex-wrap gap-1.5">
                   {p.skills.map((skill: string) => (
-                    <span key={skill} className="px-2.5 py-1 rounded-lg text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700">
+                    <span key={skill} className="px-2.5 py-1 rounded-md text-xs font-medium bg-stone-100 dark:bg-stone-800 text-stone-700 dark:text-stone-300 border border-stone-200 dark:border-stone-700">
                       {skill}
                     </span>
                   ))}
@@ -180,18 +180,18 @@ export default function PortfolioPage() {
 
           <div className="lg:col-span-2 space-y-4">
             {p.projects && p.projects.length > 0 && (
-              <motion.div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-5" initial="hidden" animate="visible" custom={3} variants={fadeInUp}>
-                <h2 className="text-xs font-bold text-gray-500 mb-3 flex items-center gap-1.5"><Folder className="w-3.5 h-3.5" />Featured Projects</h2>
+              <motion.div className="bg-white dark:bg-stone-900 rounded-2xl border border-stone-200 dark:border-stone-700 shadow-sm p-5" initial="hidden" animate="visible" custom={3} variants={fadeInUp}>
+                <h2 className="text-xs font-bold text-stone-500 mb-3 flex items-center gap-1.5"><Folder className="w-3.5 h-3.5" />Featured Projects</h2>
                 <div className="space-y-3">
                   {p.projects.map((proj: any, idx: number) => (
-                    <div key={idx} className="p-3 rounded-xl bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700">
+                    <div key={idx} className="p-3 rounded-md bg-stone-50 dark:bg-stone-800 border border-stone-100 dark:border-stone-700">
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0">
-                          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">{proj.title || proj.name}</h3>
-                          {proj.description && <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">{proj.description}</p>}
+                          <h3 className="text-sm font-semibold text-stone-900 dark:text-white">{proj.title || proj.name}</h3>
+                          {proj.description && <p className="text-xs text-stone-500 mt-0.5 line-clamp-2">{proj.description}</p>}
                         </div>
                         {proj.link && (
-                          <a href={proj.link} target="_blank" rel="noopener noreferrer" className="shrink-0 p-1.5 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 transition-colors">
+                          <a href={proj.link} target="_blank" rel="noopener noreferrer" className="shrink-0 p-1.5 rounded-md hover:bg-stone-200 dark:hover:bg-stone-700 text-stone-400 transition-colors">
                             <ExternalLink className="w-3.5 h-3.5" />
                           </a>
                         )}
@@ -199,7 +199,7 @@ export default function PortfolioPage() {
                       {proj.techStack && (
                         <div className="flex flex-wrap gap-1 mt-2">
                           {proj.techStack.map((tech: string) => (
-                            <span key={tech} className="text-[10px] px-1.5 py-0.5 rounded bg-white dark:bg-gray-900 text-gray-500 border border-gray-200 dark:border-gray-700">{tech}</span>
+                            <span key={tech} className="text-[10px] px-1.5 py-0.5 rounded bg-white dark:bg-stone-900 text-stone-500 border border-stone-200 dark:border-stone-700">{tech}</span>
                           ))}
                         </div>
                       )}
@@ -210,17 +210,17 @@ export default function PortfolioPage() {
             )}
 
             {p.achievements && p.achievements.length > 0 && (
-              <motion.div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-5" initial="hidden" animate="visible" custom={4} variants={fadeInUp}>
-                <h2 className="text-xs font-bold text-gray-500 mb-3 flex items-center gap-1.5"><Award className="w-3.5 h-3.5" />Achievements</h2>
+              <motion.div className="bg-white dark:bg-stone-900 rounded-2xl border border-stone-200 dark:border-stone-700 shadow-sm p-5" initial="hidden" animate="visible" custom={4} variants={fadeInUp}>
+                <h2 className="text-xs font-bold text-stone-500 mb-3 flex items-center gap-1.5"><Award className="w-3.5 h-3.5" />Achievements</h2>
                 <div className="space-y-2">
                   {p.achievements.map((ach: any, idx: number) => (
-                    <div key={idx} className="flex items-start gap-3 p-3 rounded-xl bg-gray-50 dark:bg-gray-800">
-                      <div className="w-8 h-8 rounded-lg bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center shrink-0">
+                    <div key={idx} className="flex items-start gap-3 p-3 rounded-md bg-stone-50 dark:bg-stone-800">
+                      <div className="w-8 h-8 rounded-md bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center shrink-0">
                         <Award className="w-4 h-4 text-amber-600 dark:text-amber-400" />
                       </div>
                       <div>
-                        <p className="text-sm font-semibold text-gray-900 dark:text-white">{ach.title || ach.name}</p>
-                        {ach.description && <p className="text-xs text-gray-500 mt-0.5">{ach.description}</p>}
+                        <p className="text-sm font-semibold text-stone-900 dark:text-white">{ach.title || ach.name}</p>
+                        {ach.description && <p className="text-xs text-stone-500 mt-0.5">{ach.description}</p>}
                       </div>
                     </div>
                   ))}
@@ -229,9 +229,9 @@ export default function PortfolioPage() {
             )}
 
             {p.badgeCount > 0 && (
-              <motion.div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-5 text-center" initial="hidden" animate="visible" custom={5} variants={fadeInUp}>
-                <p className="text-sm text-gray-500">
-                  <span className="font-semibold text-gray-900 dark:text-white">{p.badgeCount}</span> badge{p.badgeCount !== 1 ? "s" : ""} earned
+              <motion.div className="bg-white dark:bg-stone-900 rounded-2xl border border-stone-200 dark:border-stone-700 shadow-sm p-5 text-center" initial="hidden" animate="visible" custom={5} variants={fadeInUp}>
+                <p className="text-sm text-stone-500">
+                  <span className="font-semibold text-stone-900 dark:text-white">{p.badgeCount}</span> badge{p.badgeCount !== 1 ? "s" : ""} earned
                 </p>
               </motion.div>
             )}

--- a/client/src/module/student/portfolio/PortfolioPage.tsx
+++ b/client/src/module/student/portfolio/PortfolioPage.tsx
@@ -1,0 +1,243 @@
+import { useParams, Link } from "react-router";
+import { useQuery } from "@tanstack/react-query";
+import { motion } from "framer-motion";
+import {
+  MapPin, GraduationCap, Linkedin, Github, Globe, ExternalLink,
+  Calendar, User, Sparkles, Star, BookOpen, Folder, Award,
+} from "lucide-react";
+import api from "../../../lib/axios";
+import { LoadingScreen } from "../../../components/LoadingScreen";
+import { SEO } from "../../../components/SEO";
+import { canonicalUrl } from "../../../lib/seo.utils";
+
+interface PortfolioData {
+  id: number;
+  name: string;
+  profileSlug: string | null;
+  profilePic: string | null;
+  coverImage: string | null;
+  bio: string | null;
+  college: string | null;
+  graduationYear: number | null;
+  skills: string[];
+  location: string | null;
+  linkedinUrl: string | null;
+  githubUrl: string | null;
+  portfolioUrl: string | null;
+  leetcodeUrl: string | null;
+  jobStatus: string | null;
+  projects: any[];
+  achievements: any[];
+  company: string | null;
+  designation: string | null;
+  memberSinceMonths: number;
+  badgeCount: number;
+  createdAt: string;
+}
+
+const fadeInUp = {
+  hidden: { opacity: 0, y: 20 },
+  visible: (i: number) => ({
+    opacity: 1, y: 0,
+    transition: { delay: i * 0.06, duration: 0.4, ease: [0.22, 1, 0.36, 1] },
+  }),
+};
+
+function SocialIcon({ url, icon }: { url: string | null; icon: React.ReactNode }) {
+  if (!url) return null;
+  return (
+    <a href={url} target="_blank" rel="noopener noreferrer" className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-500 hover:text-lime-600 hover:bg-lime-50 dark:hover:bg-lime-900/20 transition-colors">
+      {icon}
+    </a>
+  );
+}
+
+function JobStatusBadge({ status }: { status: string | null }) {
+  if (!status) return null;
+  const map: Record<string, { label: string; cls: string }> = {
+    LOOKING: { label: "Looking for job", cls: "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400" },
+    OPEN_TO_OFFER: { label: "Open to offer", cls: "bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400" },
+    NO_OFFER: { label: "No offer", cls: "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400" },
+  };
+  const info = map[status];
+  if (!info) return null;
+  return <span className={`px-2.5 py-1 rounded-lg text-xs font-semibold ${info.cls}`}>{info.label}</span>;
+}
+
+export default function PortfolioPage() {
+  const { slug } = useParams<{ slug: string }>();
+
+  const { data: portfolio, isLoading, error } = useQuery({
+    queryKey: ["portfolio", slug],
+    queryFn: () => api.get(`/portfolio/${slug}`).then((r) => r.data),
+    enabled: !!slug,
+  });
+
+  const p = portfolio as PortfolioData | undefined;
+
+  if (isLoading) return <LoadingScreen />;
+
+  if (error || !p) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center">
+        <div className="text-center">
+          <User className="w-12 h-12 text-gray-200 mx-auto mb-3" />
+          <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">Portfolio not found</h2>
+          <p className="text-sm text-gray-500 mb-4">This portfolio does not exist or is not public.</p>
+          <Link to="/" className="text-sm text-lime-600 hover:underline">Go home</Link>
+        </div>
+      </div>
+    );
+  }
+
+  const initials = p.name.split(" ").map((n: string) => n[0]).join("").toUpperCase().slice(0, 2);
+
+  return (
+    <>
+      <SEO
+        title={`${p.name} — Open Source Portfolio`}
+        description={p.bio || `${p.name}'s open source contributor portfolio on InternHack`}
+        canonicalUrl={canonicalUrl(`/portfolio/${slug}`)}
+      />
+
+      <div className="max-w-5xl mx-auto px-4 py-8">
+        <motion.div
+          className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 overflow-hidden shadow-sm"
+          initial="hidden" animate="visible" custom={0} variants={fadeInUp}
+        >
+          {p.coverImage ? (
+            <div className="h-32 sm:h-44 bg-cover bg-center" style={{ backgroundImage: `url(${p.coverImage})` }} />
+          ) : (
+            <div className="h-32 sm:h-44 bg-gradient-to-r from-lime-400 via-emerald-400 to-cyan-400" />
+          )}
+          <div className="px-6 pb-6">
+            <div className="flex flex-col sm:flex-row sm:items-end gap-4 -mt-12 sm:-mt-16 mb-4">
+              {p.profilePic ? (
+                <img src={p.profilePic} alt={p.name} className="w-24 h-24 sm:w-28 sm:h-28 rounded-xl border-4 border-white dark:border-gray-900 object-cover shadow-lg" />
+              ) : (
+                <div className="w-24 h-24 sm:w-28 sm:h-28 rounded-xl border-4 border-white dark:border-gray-900 shadow-lg bg-lime-100 dark:bg-lime-900/30 flex items-center justify-center">
+                  <span className="text-2xl sm:text-3xl font-bold text-lime-600 dark:text-lime-400">{initials}</span>
+                </div>
+              )}
+              <div className="flex-1 min-w-0 sm:pb-1">
+                <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white truncate">{p.name}</h1>
+                {p.designation && <p className="text-sm text-gray-500">{p.designation}{p.company ? ` at ${p.company}` : ""}</p>}
+                <div className="flex flex-wrap items-center gap-2 mt-1">
+                  {p.location && (
+                    <span className="text-xs text-gray-400 flex items-center gap-1"><MapPin className="w-3 h-3" />{p.location}</span>
+                  )}
+                  {p.college && (
+                    <span className="text-xs text-gray-400 flex items-center gap-1"><GraduationCap className="w-3 h-3" />{p.college}{p.graduationYear ? ` (${p.graduationYear})` : ""}</span>
+                  )}
+                  <span className="text-xs text-gray-400 flex items-center gap-1"><Calendar className="w-3 h-3" />{p.memberSinceMonths} mo</span>
+                </div>
+              </div>
+              {p.jobStatus && (
+                <div className="sm:pb-1"><JobStatusBadge status={p.jobStatus} /></div>
+              )}
+            </div>
+
+            {p.bio && <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed mb-4 max-w-2xl">{p.bio}</p>}
+
+            <div className="flex flex-wrap items-center gap-1.5">
+              <SocialIcon url={p.githubUrl} icon={<Github className="w-4 h-4" />} />
+              <SocialIcon url={p.linkedinUrl} icon={<Linkedin className="w-4 h-4" />} />
+              <SocialIcon url={p.portfolioUrl} icon={<Globe className="w-4 h-4" />} />
+              <SocialIcon url={p.leetcodeUrl} icon={<BookOpen className="w-4 h-4" />} />
+            </div>
+          </div>
+        </motion.div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">
+          <div className="space-y-4">
+            <motion.div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-5" initial="hidden" animate="visible" custom={1} variants={fadeInUp}>
+              <h2 className="text-xs font-bold text-gray-500 mb-3 flex items-center gap-1.5"><Sparkles className="w-3.5 h-3.5" />Stats</h2>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="text-center p-3 rounded-xl bg-gray-50 dark:bg-gray-800">
+                  <p className="text-lg font-bold text-gray-900 dark:text-white">{p.badgeCount}</p>
+                  <p className="text-[10px] text-gray-500">Badges</p>
+                </div>
+                <div className="text-center p-3 rounded-xl bg-gray-50 dark:bg-gray-800">
+                  <p className="text-lg font-bold text-gray-900 dark:text-white">{p.projects?.length || 0}</p>
+                  <p className="text-[10px] text-gray-500">Projects</p>
+                </div>
+              </div>
+            </motion.div>
+
+            {p.skills && p.skills.length > 0 && (
+              <motion.div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-5" initial="hidden" animate="visible" custom={2} variants={fadeInUp}>
+                <h2 className="text-xs font-bold text-gray-500 mb-3 flex items-center gap-1.5"><Star className="w-3.5 h-3.5" />Skills</h2>
+                <div className="flex flex-wrap gap-1.5">
+                  {p.skills.map((skill: string) => (
+                    <span key={skill} className="px-2.5 py-1 rounded-lg text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700">
+                      {skill}
+                    </span>
+                  ))}
+                </div>
+              </motion.div>
+            )}
+          </div>
+
+          <div className="lg:col-span-2 space-y-4">
+            {p.projects && p.projects.length > 0 && (
+              <motion.div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-5" initial="hidden" animate="visible" custom={3} variants={fadeInUp}>
+                <h2 className="text-xs font-bold text-gray-500 mb-3 flex items-center gap-1.5"><Folder className="w-3.5 h-3.5" />Featured Projects</h2>
+                <div className="space-y-3">
+                  {p.projects.map((proj: any, idx: number) => (
+                    <div key={idx} className="p-3 rounded-xl bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">{proj.title || proj.name}</h3>
+                          {proj.description && <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">{proj.description}</p>}
+                        </div>
+                        {proj.link && (
+                          <a href={proj.link} target="_blank" rel="noopener noreferrer" className="shrink-0 p-1.5 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 transition-colors">
+                            <ExternalLink className="w-3.5 h-3.5" />
+                          </a>
+                        )}
+                      </div>
+                      {proj.techStack && (
+                        <div className="flex flex-wrap gap-1 mt-2">
+                          {proj.techStack.map((tech: string) => (
+                            <span key={tech} className="text-[10px] px-1.5 py-0.5 rounded bg-white dark:bg-gray-900 text-gray-500 border border-gray-200 dark:border-gray-700">{tech}</span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </motion.div>
+            )}
+
+            {p.achievements && p.achievements.length > 0 && (
+              <motion.div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-5" initial="hidden" animate="visible" custom={4} variants={fadeInUp}>
+                <h2 className="text-xs font-bold text-gray-500 mb-3 flex items-center gap-1.5"><Award className="w-3.5 h-3.5" />Achievements</h2>
+                <div className="space-y-2">
+                  {p.achievements.map((ach: any, idx: number) => (
+                    <div key={idx} className="flex items-start gap-3 p-3 rounded-xl bg-gray-50 dark:bg-gray-800">
+                      <div className="w-8 h-8 rounded-lg bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center shrink-0">
+                        <Award className="w-4 h-4 text-amber-600 dark:text-amber-400" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold text-gray-900 dark:text-white">{ach.title || ach.name}</p>
+                        {ach.description && <p className="text-xs text-gray-500 mt-0.5">{ach.description}</p>}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </motion.div>
+            )}
+
+            {p.badgeCount > 0 && (
+              <motion.div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm p-5 text-center" initial="hidden" animate="visible" custom={5} variants={fadeInUp}>
+                <p className="text-sm text-gray-500">
+                  <span className="font-semibold text-gray-900 dark:text-white">{p.badgeCount}</span> badge{p.badgeCount !== 1 ? "s" : ""} earned
+                </p>
+              </motion.div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -64,6 +64,7 @@ import { roadmapRouter } from "./module/roadmap/roadmap.routes.js";
 import { recommendationRouter } from "./module/recommendation/recommendation.routes.js";
 import { learnRouter } from "./module/learn/learn.routes.js";
 import { coachRouter } from "./module/coach/coach.routes.js";
+import { portfolioRouter } from "./module/portfolio/portfolio.routes.js";
 import analyticsRouter from "./module/analytics/analytics.routes.js";
 import { healthRouter } from "./module/health/health.routes.js";
 import { botSeoMiddleware } from "./middleware/bot-seo.middleware.js";
@@ -293,6 +294,7 @@ app.use("/api/roadmaps", roadmapRouter);
 app.use("/api/analytics", analyticsRouter);
 app.use("/api/learn", learnRouter);
 app.use("/api/coach", coachRouter);
+app.use("/api/portfolio", portfolioRouter);
 
 // Contact form (public, no auth)
 app.use("/api/contact", contactRouter);

--- a/server/src/module/portfolio/portfolio.controller.ts
+++ b/server/src/module/portfolio/portfolio.controller.ts
@@ -6,7 +6,7 @@ const service = new PortfolioService();
 export class PortfolioController {
   async getBySlug(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const { slug } = req.params;
+      const slug = req.params.slug as string;
       const portfolio = await service.getPortfolio(slug);
       if (!portfolio) {
         res.status(404).json({ error: "Portfolio not found" });

--- a/server/src/module/portfolio/portfolio.controller.ts
+++ b/server/src/module/portfolio/portfolio.controller.ts
@@ -1,0 +1,20 @@
+import type { Request, Response, NextFunction } from "express";
+import { PortfolioService } from "./portfolio.service.js";
+
+const service = new PortfolioService();
+
+export class PortfolioController {
+  async getBySlug(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const { slug } = req.params;
+      const portfolio = await service.getPortfolio(slug);
+      if (!portfolio) {
+        res.status(404).json({ error: "Portfolio not found" });
+        return;
+      }
+      res.json(portfolio);
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/server/src/module/portfolio/portfolio.routes.ts
+++ b/server/src/module/portfolio/portfolio.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { PortfolioController } from "./portfolio.controller.js";
+
+const controller = new PortfolioController();
+
+export const portfolioRouter = Router();
+
+portfolioRouter.get("/:slug", (req, res, next) => controller.getBySlug(req, res, next));

--- a/server/src/module/portfolio/portfolio.service.ts
+++ b/server/src/module/portfolio/portfolio.service.ts
@@ -1,0 +1,92 @@
+import { prisma } from "../../database/db.js";
+import { cacheGet, cacheSet } from "../../utils/cache.js";
+
+const PORTFOLIO_TTL = 300;
+
+export class PortfolioService {
+  async getPortfolio(slug: string) {
+    const cacheKey = `portfolio:${slug}`;
+    const cached = await cacheGet(cacheKey);
+    if (cached) return cached;
+
+    let user: any;
+    user = await prisma.user.findUnique({
+      where: { profileSlug: slug },
+      select: {
+        id: true,
+        name: true,
+        profileSlug: true,
+        profilePic: true,
+        coverImage: true,
+        bio: true,
+        college: true,
+        graduationYear: true,
+        skills: true,
+        location: true,
+        linkedinUrl: true,
+        githubUrl: true,
+        portfolioUrl: true,
+        leetcodeUrl: true,
+        jobStatus: true,
+        isProfilePublic: true,
+        projects: true,
+        achievements: true,
+        company: true,
+        designation: true,
+        createdAt: true,
+      },
+    });
+
+    if (!user && /^\d+$/.test(slug)) {
+      user = await prisma.user.findUnique({
+        where: { id: Number(slug) },
+        select: {
+          id: true,
+          name: true,
+          profileSlug: true,
+          profilePic: true,
+          coverImage: true,
+          bio: true,
+          college: true,
+          graduationYear: true,
+          skills: true,
+          location: true,
+          linkedinUrl: true,
+          githubUrl: true,
+          portfolioUrl: true,
+          leetcodeUrl: true,
+          jobStatus: true,
+          isProfilePublic: true,
+          projects: true,
+          achievements: true,
+          company: true,
+          designation: true,
+          createdAt: true,
+        },
+      });
+    }
+
+    if (!user || !user.isProfilePublic) return null;
+
+    const now = new Date();
+    const memberSince = Math.floor((now.getTime() - new Date(user.createdAt).getTime()) / (1000 * 60 * 60 * 24 * 30));
+
+    const badges = await prisma.studentBadge.findMany({
+      where: { studentId: user.id },
+      select: {
+        badge: { select: { id: true, name: true, iconUrl: true, description: true, category: true } },
+        earnedAt: true,
+      },
+      orderBy: { earnedAt: "desc" },
+    });
+
+    const result = {
+      ...user,
+      memberSinceMonths: memberSince,
+      badgeCount: badges.length,
+    };
+
+    await cacheSet(cacheKey, result, PORTFOLIO_TTL);
+    return result;
+  }
+}

--- a/server/src/module/portfolio/portfolio.service.ts
+++ b/server/src/module/portfolio/portfolio.service.ts
@@ -1,16 +1,41 @@
 import { prisma } from "../../database/db.js";
 import { cacheGet, cacheSet } from "../../utils/cache.js";
 
+interface PortfolioResult {
+  id: number;
+  name: string;
+  profileSlug: string | null;
+  profilePic: string | null;
+  coverImage: string | null;
+  bio: string | null;
+  college: string | null;
+  graduationYear: number | null;
+  skills: string[];
+  location: string | null;
+  linkedinUrl: string | null;
+  githubUrl: string | null;
+  portfolioUrl: string | null;
+  leetcodeUrl: string | null;
+  jobStatus: string | null;
+  isProfilePublic: boolean;
+  projects: unknown;
+  achievements: unknown;
+  company: string | null;
+  designation: string | null;
+  createdAt: Date;
+  memberSinceMonths: number;
+  badgeCount: number;
+}
+
 const PORTFOLIO_TTL = 300;
 
 export class PortfolioService {
-  async getPortfolio(slug: string) {
+  async getPortfolio(slug: string): Promise<PortfolioResult | null> {
     const cacheKey = `portfolio:${slug}`;
     const cached = await cacheGet(cacheKey);
-    if (cached) return cached;
+    if (cached) return cached as PortfolioResult;
 
-    let user: any;
-    user = await prisma.user.findUnique({
+    const user = await prisma.user.findUnique({
       where: { profileSlug: slug },
       select: {
         id: true,
@@ -37,35 +62,6 @@ export class PortfolioService {
       },
     });
 
-    if (!user && /^\d+$/.test(slug)) {
-      user = await prisma.user.findUnique({
-        where: { id: Number(slug) },
-        select: {
-          id: true,
-          name: true,
-          profileSlug: true,
-          profilePic: true,
-          coverImage: true,
-          bio: true,
-          college: true,
-          graduationYear: true,
-          skills: true,
-          location: true,
-          linkedinUrl: true,
-          githubUrl: true,
-          portfolioUrl: true,
-          leetcodeUrl: true,
-          jobStatus: true,
-          isProfilePublic: true,
-          projects: true,
-          achievements: true,
-          company: true,
-          designation: true,
-          createdAt: true,
-        },
-      });
-    }
-
     if (!user || !user.isProfilePublic) return null;
 
     const now = new Date();
@@ -80,7 +76,7 @@ export class PortfolioService {
       orderBy: { earnedAt: "desc" },
     });
 
-    const result = {
+    const result: PortfolioResult = {
       ...user,
       memberSinceMonths: memberSince,
       badgeCount: badges.length,


### PR DESCRIPTION
## Summary

- Add contributor portfolio page at `/portfolio/:slug` showcasing open source contributions
- Server endpoint aggregates user public profile, skills, projects, achievements, badge count, and member tenure
- Clean, modern UI with hero section (cover image, avatar, bio, social links), stats card, skills grid, featured projects, and achievements
- Uses existing `profileSlug` for public portfolio URLs - students can enable by setting `isProfilePublic` true and `profileSlug` in their profile settings

## Changes

**Server:**
- New `portfolio` module with `GET /api/portfolio/:slug` endpoint
- Returns user profile data + badge count + member tenure in one call
- Cached for 5 minutes

**Client:**
- New `PortfolioPage` at `/portfolio/:slug` with:
  - Hero section (cover, avatar, name, designation, location, college, social links)
  - Stats card (badges count, projects count)
  - Skills section
  - Featured projects with tech stack tags
  - Achievements section

## Closes

Closes #953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added student portfolio pages displaying comprehensive profile information including cover images, profile pictures, designations, locations, member duration, skills as tags, featured projects with technology stacks, achievements with descriptions, and earned badges.
  * Implemented server-side caching with 5-minute TTL for optimized portfolio retrieval and performance.
  * Added SEO support with dynamic page titles, descriptions, and canonical URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->