### PR TITLE
feat: add lesson code execution via Judge0

### DIFF
--- a/client/src/components/LessonCodeRunner.tsx
+++ b/client/src/components/LessonCodeRunner.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Play, Loader2, Terminal, AlertTriangle, RotateCcw } from "lucide-react";
+import { Button } from "./ui/button";
+import api from "../lib/axios";
+
+const LANGUAGES = [
+  { value: "python", label: "Python" },
+  { value: "cpp", label: "C++" },
+  { value: "java", label: "Java" },
+  { value: "javascript", label: "JavaScript" },
+  { value: "typescript", label: "TypeScript" },
+  { value: "go", label: "Go" },
+  { value: "rust", label: "Rust" },
+  { value: "ruby", label: "Ruby" },
+  { value: "swift", label: "Swift" },
+  { value: "kotlin", label: "Kotlin" },
+  { value: "php", label: "PHP" },
+  { value: "csharp", label: "C#" },
+  { value: "scala", label: "Scala" },
+  { value: "r", label: "R" },
+];
+
+interface ExecuteResult {
+  stdout: string;
+  stderr: string;
+  compileOutput: string;
+  status: string;
+  time: string | null;
+  memory: number | null;
+}
+
+export default function LessonCodeRunner() {
+  const [code, setCode] = useState("");
+  const [language, setLanguage] = useState("python");
+  const [stdin, setStdin] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: (body: { language: string; code: string; stdin?: string }) =>
+      api.post("/learn/execute", body).then((r) => r.data as ExecuteResult),
+  });
+
+  const output = mutation.data;
+
+  return (
+    <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Terminal className="w-4 h-4 text-gray-500" />
+          <span className="text-xs font-semibold text-gray-700 dark:text-gray-300">Code Runner</span>
+        </div>
+        <select
+          value={language}
+          onChange={(e) => setLanguage(e.target.value)}
+          className="px-2 py-1 text-xs border border-gray-200 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-lime-500/20"
+        >
+          {LANGUAGES.map((l) => (
+            <option key={l.value} value={l.value}>{l.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <textarea
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        placeholder="Write your code here..."
+        rows={10}
+        className="w-full px-4 py-3 text-sm font-mono border-0 border-b border-gray-100 dark:border-gray-800 focus:outline-none focus:ring-0 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-600 resize-y"
+      />
+
+      <div className="px-4 py-2 border-b border-gray-100 dark:border-gray-800">
+        <label className="block text-[10px] font-semibold text-gray-400 mb-1">stdin (optional)</label>
+        <input
+          type="text"
+          value={stdin}
+          onChange={(e) => setStdin(e.target.value)}
+          placeholder="Input for your program..."
+          className="w-full px-2 py-1.5 text-xs font-mono border border-gray-200 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-lime-500/20 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 placeholder-gray-400"
+        />
+      </div>
+
+      <div className="px-4 py-2.5 flex items-center justify-between bg-gray-50 dark:bg-gray-900/50">
+        <span className="text-[10px] text-gray-400">
+          Runs via Judge0 — {mutation.isPending ? "executing..." : `${code.split("\n").length} lines`}
+        </span>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => mutation.mutate({ language, code, stdin: stdin || undefined })}
+          disabled={mutation.isPending || !code.trim()}
+        >
+          {mutation.isPending ? (
+            <><Loader2 className="w-3 h-3 mr-1.5 animate-spin" /> Running</>
+          ) : (
+            <><Play className="w-3 h-3 mr-1.5" /> Run</>
+          )}
+        </Button>
+      </div>
+
+      {mutation.isError && (
+        <div className="px-4 py-3 bg-red-50 dark:bg-red-900/20 border-t border-red-100 dark:border-red-800">
+          <div className="flex items-center gap-1.5 text-xs text-red-600 dark:text-red-400">
+            <AlertTriangle className="w-3 h-3" />
+            Failed to execute code
+          </div>
+        </div>
+      )}
+
+      {output && (
+        <div className="px-4 py-3 border-t border-gray-100 dark:border-gray-800 space-y-2">
+          <div className="flex items-center gap-2 text-[10px] text-gray-400">
+            <span>Status: {output.status}</span>
+            {output.time && <span>Time: {output.time}s</span>}
+            {output.memory !== null && <span>Memory: {output.memory} KB</span>}
+          </div>
+
+          {output.compileOutput && (
+            <div>
+              <p className="text-[10px] font-semibold text-amber-600 mb-1">Compile Output</p>
+              <pre className="text-xs font-mono bg-gray-50 dark:bg-gray-800 rounded-lg p-3 overflow-x-auto text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{output.compileOutput}</pre>
+            </div>
+          )}
+
+          {output.stdout && (
+            <div>
+              <p className="text-[10px] font-semibold text-gray-500 mb-1">Output</p>
+              <pre className="text-xs font-mono bg-gray-50 dark:bg-gray-800 rounded-lg p-3 overflow-x-auto text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{output.stdout}</pre>
+            </div>
+          )}
+
+          {output.stderr && (
+            <div>
+              <p className="text-[10px] font-semibold text-red-500 mb-1">Stderr</p>
+              <pre className="text-xs font-mono bg-red-50 dark:bg-red-900/20 rounded-lg p-3 overflow-x-auto text-red-600 dark:text-red-400 whitespace-pre-wrap">{output.stderr}</pre>
+            </div>
+          )}
+
+          {!output.stdout && !output.stderr && !output.compileOutput && (
+            <p className="text-xs text-gray-400 italic">No output</p>
+          )}
+
+          <div className="flex justify-end pt-1">
+            <Button variant="ghost" size="sm" onClick={() => mutation.reset()}>
+              <RotateCcw className="w-3 h-3 mr-1" /> Clear
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/module/student/javascript/JsLessonDetailPage.tsx
+++ b/client/src/module/student/javascript/JsLessonDetailPage.tsx
@@ -13,8 +13,10 @@ import {
   Lightbulb,
   Eye,
   Code2,
+  Terminal,
 } from "lucide-react";
 import { CodeBlock } from "../../../components/ui/CodeBlock";
+import LessonCodeRunner from "../../../components/LessonCodeRunner";
 import { sections, lessons } from "./data";
 import type { JsProgress, PracticeExercise } from "./data/types";
 import { jsEngine } from "./lib/js-engine";
@@ -549,6 +551,17 @@ export default function JsLessonDetailPage() {
               <ExerciseSection exercises={exercises} lessonId={lessonId!} />
             </>
           )}
+
+          {/* Code Runner */}
+          <div className="mt-6">
+            <div className="flex items-center gap-2 mb-3">
+              <Terminal className="w-4 h-4 text-stone-500" />
+              <span className="text-sm font-bold tracking-tight text-stone-900 dark:text-stone-50">
+                Code Playground
+              </span>
+            </div>
+            <LessonCodeRunner />
+          </div>
 
           {/* Footer actions */}
           <motion.div

--- a/server/src/module/learn/learn.controller.ts
+++ b/server/src/module/learn/learn.controller.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 import type { LearnService } from "./learn.service.js";
-import { bulkInterviewProgressSchema, interviewProgressActionSchema } from "./learn.validation.js";
+import { bulkInterviewProgressSchema, interviewProgressActionSchema, executeCodeSchema } from "./learn.validation.js";
 
 export class LearnController {
   constructor(private readonly learnService: LearnService) {}
@@ -15,6 +15,79 @@ export class LearnController {
       console.error(error);
       return res.status(500).json({ message: "Internal Server Error" });
     }
+  }
+
+  async updateInterviewProgress(req: Request, res: Response) {
+    try {
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
+      const rawQuestionId = req.params["questionId"];
+      const questionId = Array.isArray(rawQuestionId) ? rawQuestionId[0]?.trim() : rawQuestionId?.trim();
+      if (!questionId) return res.status(400).json({ message: "Question ID is required" });
+      if (questionId.length > 160) return res.status(400).json({ message: "Question ID is too long" });
+
+      const result = interviewProgressActionSchema.safeParse(req.body);
+      if (!result.success) {
+        return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
+      }
+
+      const progress = await this.learnService.updateInterviewProgress(
+        req.user.id,
+        questionId,
+        result.data.action,
+      );
+      return res.json(progress);
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Internal Server Error" });
+    }
+  }
+
+  async bulkMigrateInterviewProgress(req: Request, res: Response) {
+    try {
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
+
+      const result = bulkInterviewProgressSchema.safeParse(req.body);
+      if (!result.success) {
+        return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
+      }
+
+      const progress = await this.learnService.bulkMigrateInterviewProgress(req.user.id, result.data);
+      return res.json(progress);
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Internal Server Error" });
+    }
+  }
+
+  async resetInterviewProgress(req: Request, res: Response) {
+    try {
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
+
+      const progress = await this.learnService.resetInterviewProgress(req.user.id);
+      return res.json(progress);
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Internal Server Error" });
+    }
+  }
+
+  async executeCode(req: Request, res: Response) {
+    try {
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
+
+      const result = executeCodeSchema.safeParse(req.body);
+      if (!result.success) {
+        return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
+      }
+
+      const output = await this.learnService.executeCode(result.data);
+      return res.json(output);
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ message: "Failed to execute code" });
+    }
+  }
+}
   }
 
   async updateInterviewProgress(req: Request, res: Response) {

--- a/server/src/module/learn/learn.routes.ts
+++ b/server/src/module/learn/learn.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
 import { requireRole } from "../../middleware/role.middleware.js";
+import { usageLimit } from "../../middleware/usage-limit.middleware.js";
 import { LearnController } from "./learn.controller.js";
 import { LearnService } from "./learn.service.js";
 
@@ -35,4 +36,12 @@ learnRouter.delete(
   authMiddleware,
   requireRole("STUDENT"),
   (req, res) => learnController.resetInterviewProgress(req, res),
+);
+
+learnRouter.post(
+  "/execute",
+  authMiddleware,
+  requireRole("STUDENT"),
+  usageLimit("CODE_RUN"),
+  (req, res) => learnController.executeCode(req, res),
 );

--- a/server/src/module/learn/learn.service.ts
+++ b/server/src/module/learn/learn.service.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "../../database/db.js";
-import type { InterviewProgressAction, BulkInterviewProgressInput } from "./learn.validation.js";
+import type { InterviewProgressAction, BulkInterviewProgressInput, ExecuteCodeInput } from "./learn.validation.js";
+import { executeCode as judge0Exec, LANGUAGE_IDS } from "../../utils/judge0.utils.js";
 
 export interface InterviewProgressDto {
   completedIds: string[];
@@ -159,5 +160,22 @@ export class LearnService {
   async resetInterviewProgress(userId: number): Promise<InterviewProgressDto> {
     await prisma.userInterviewProgress.deleteMany({ where: { userId } });
     return EMPTY_PROGRESS;
+  }
+
+  async executeCode(input: ExecuteCodeInput) {
+    const languageId = LANGUAGE_IDS[input.language];
+    if (!languageId) {
+      throw new Error(`Unsupported language: ${input.language}`);
+    }
+
+    const result = await judge0Exec(input.code, languageId, input.stdin ?? "");
+    return {
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      compileOutput: result.compile_output ?? "",
+      status: result.status.description,
+      time: result.time,
+      memory: result.memory,
+    };
   }
 }

--- a/server/src/module/learn/learn.validation.ts
+++ b/server/src/module/learn/learn.validation.ts
@@ -13,5 +13,12 @@ export const bulkInterviewProgressSchema = z.object({
   lastVisitedId: questionIdSchema.nullish(),
 });
 
+export const executeCodeSchema = z.object({
+  language: z.enum(["python", "cpp", "java", "javascript", "typescript", "go", "rust", "ruby", "swift", "kotlin", "php", "csharp", "scala", "r"]),
+  code: z.string().min(1, "Code is required").max(50000, "Code too long"),
+  stdin: z.string().max(10000).optional().default(""),
+});
+
 export type InterviewProgressAction = z.infer<typeof interviewProgressActionSchema>["action"];
 export type BulkInterviewProgressInput = z.infer<typeof bulkInterviewProgressSchema>;
+export type ExecuteCodeInput = z.infer<typeof executeCodeSchema>;

--- a/server/src/utils/judge0.utils.ts
+++ b/server/src/utils/judge0.utils.ts
@@ -5,6 +5,17 @@ export const LANGUAGE_IDS: Record<string, number> = {
   python: 71,
   cpp: 54,
   java: 62,
+  javascript: 63,
+  typescript: 74,
+  go: 60,
+  rust: 73,
+  ruby: 72,
+  swift: 83,
+  kotlin: 78,
+  php: 68,
+  csharp: 51,
+  scala: 81,
+  r: 80,
 };
 
 function getRandomApiKey(): string {


### PR DESCRIPTION
﻿## Summary

- Add general-purpose code execution endpoint POST /api/learn/execute for running code in lessons
- Supports 14 languages via Judge0 (Python, C++, Java, JavaScript, TypeScript, Go, Rust, Ruby, Swift, Kotlin, PHP, C#, Scala, R)
- Create reusable LessonCodeRunner component with code editor, language selector, stdin input, and output display
- Integrate into JavaScript lesson detail pages as an inline Code Playground
- Uses existing CODE_RUN usage limit middleware

## Closes

Closes #1053


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Code Playground feature enabling users to write, test, and run code directly within lesson pages
  * Supports multiple programming languages for flexible coding practice
  * Displays comprehensive execution feedback including compilation status, standard output, and error messages
  * Accepts custom input for testing code with specific test cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->