### PR TITLE
fix : IDOR — employeeId accepted from request input instead of authenticated user in Leave and Payroll endpoints  

### DIFF
--- a/server/src/module/leave/leave.controller.ts
+++ b/server/src/module/leave/leave.controller.ts
@@ -16,7 +16,7 @@ export class LeaveController {
       const result = createLeaveRequestSchema.safeParse(req.body);
       if (!result.success) return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
 
-      const employeeId = Number(req.query["employeeId"] ?? req.user.id);
+      const employeeId = req.user.id;
       const request = await this.leaveService.createRequest(employeeId, result.data);
       return res.status(201).json({ message: "Leave request submitted", request });
     } catch (error) {
@@ -31,9 +31,9 @@ export class LeaveController {
 
   async getMyRequests(req: Request, res: Response) {
     try {
-      const employeeId = Number(req.query["employeeId"]);
-      if (isNaN(employeeId)) return res.status(400).json({ message: "employeeId query param required" });
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
+      const employeeId = req.user.id;
       const query = leaveQuerySchema.parse(req.query);
       const data = await this.leaveService.getMyRequests(employeeId, query);
       return res.json(data);
@@ -112,9 +112,9 @@ export class LeaveController {
 
   async getBalance(req: Request, res: Response) {
     try {
-      const employeeId = Number(req.query["employeeId"]);
-      if (isNaN(employeeId)) return res.status(400).json({ message: "employeeId required" });
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
+      const employeeId = req.user.id;
       const year = req.query["year"] ? Number(req.query["year"]) : undefined;
       const balances = await this.leaveService.getBalance(employeeId, year);
       return res.json({ balances });

--- a/server/src/module/payroll/payroll.controller.ts
+++ b/server/src/module/payroll/payroll.controller.ts
@@ -63,9 +63,9 @@ export class PayrollController {
 
   async getMyPayslips(req: Request, res: Response) {
     try {
-      const employeeId = Number(req.query["employeeId"]);
-      if (isNaN(employeeId)) return res.status(400).json({ message: "employeeId required" });
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
+      const employeeId = req.user.id;
       const payslips = await this.payrollService.getMyPayslips(employeeId);
       return res.json({ payslips });
     } catch (error) {


### PR DESCRIPTION
# Pull Request

## Description
Fixed an IDOR vulnerability in HR self-service endpoints by ensuring employee-scoped actions derive `employeeId` exclusively from the authenticated user identity.

Updated:
- Leave request creation now uses `req.user.id`
- Leave “my requests” now uses `req.user.id`
- Leave balance now uses `req.user.id`
- Payroll “my payslips” now uses `req.user.id`

User-controlled `employeeId` query params can no longer override the authenticated employee identity on these self-service endpoints.

## Related Issue
Fixes #1797 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
- Verified the affected controllers no longer read `employeeId` from query params for self-service endpoints.
- Searched the leave/payroll modules for the vulnerable `employeeId` query access patterns.
- Attempted to run `npm run typecheck` in `server`, but local verification was blocked because `tsc` is not available in the installed package binaries in this workspace.


## Checklist
- [x] Code follows project guidelines
- [ ] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for leave and payroll features by enforcing authentication and ensuring employees can only access their own data through authenticated identity verification, rather than parameter-based requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->