### PR TITLE
fix(auth): prevent email enumeration in register endpoint

### DIFF
--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -28,7 +28,7 @@ export class AuthController {
       return res.status(201).json({ message: "Registration successful. Please verify your email to continue.", user: data.user });
     } catch (error) {
       if (error instanceof Error && error.message === "Email already registered") {
-        return res.status(409).json({ message: error.message });
+        return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });
       }
       console.error(error);
       return res.status(500).json({ message: "Internal Server Error" });


### PR DESCRIPTION
## What
Returns a generic success response for all registration attempts
regardless of whether the email already exists.

## Root cause
The catch block returned a distinct 409 + 'Email already registered'
message, allowing attackers to enumerate registered accounts by
comparing response codes.

## Changes
- server/src/module/auth/auth.controller.ts — replaced 409 branch
  with generic 201 response, consistent with forgotPassword pattern

## Verification
- [ ] Existing email returns same response as new email
- [ ] No account existence information leaked in response
- [ ] Follows forgotPassword generic response pattern
- [ ] No unrelated files changed

Closes #1832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated registration validation messaging to provide consistent feedback when attempting to create an account with an already-registered email address, improving clarity during the signup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->