### PR TITLE
feat: suggest repo modal rate-limiting tracking and UI feedback (#1005)

### DIFF
--- a/client/src/module/student/opensource/SuggestRepoModal.tsx
+++ b/client/src/module/student/opensource/SuggestRepoModal.tsx
@@ -113,6 +113,9 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
     };
   }, [open, onClose]);
 
+  const [remaining, setRemaining] = useState<number>(5);
+  const [rateLimitError, setRateLimitError] = useState<string | null>(null);
+
   const mutation = useMutation({
     mutationFn: async (data: SuggestRepoForm) => {
       const payload = {
@@ -128,7 +131,11 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
       };
       return api.post("/opensource/requests", payload);
     },
-    onSuccess: () => {
+    onSuccess: (response) => {
+      const rem = response.headers["x-ratelimit-remaining"];
+      if (rem !== undefined) {
+        setRemaining(parseInt(rem, 10));
+      }
       setSuccess(true);
       queryClient.invalidateQueries({
         queryKey: queryKeys.opensource.myRequests(),
@@ -137,7 +144,24 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
         setSuccess(false);
         setForm(INITIAL_FORM);
         onClose();
-      }, 2000);
+        setTimeout(() => setRemaining(5), 300);
+      }, 2500);
+    },
+    onError: (error: any) => {
+      if (error?.response?.status === 429) {
+        const resetHeader = error.response?.headers?.["x-ratelimit-reset"] as string | undefined;
+        if (resetHeader) {
+          const resetMs = new Date(resetHeader).getTime() - Date.now();
+          const hoursLeft = Math.ceil(resetMs / (1000 * 60 * 60));
+          setRateLimitError(`You've reached your daily limit. Resets in ${hoursLeft} hour${hoursLeft !== 1 ? "s" : ""}.`);
+          setRemaining(0);
+        } else {
+          setRateLimitError("You've reached your daily limit. Please try again tomorrow.");
+          setRemaining(0);
+        }
+      } else {
+        setRateLimitError(null);
+      }
     },
   });
 
@@ -206,10 +230,17 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
         className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl w-full max-w-lg max-h-[85vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="sticky top-0 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 px-6 py-4 rounded-t-2xl flex items-center justify-between z-10">
-          <h2 className="text-lg font-bold text-gray-900 dark:text-white">
-            Suggest a Repository
-          </h2>
+        <div className="sticky top-0 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 px-6 py-4 rounded-t-2xl flex items-start justify-between z-10">
+          <div>
+            <h2 className="text-lg font-bold text-gray-900 dark:text-white">
+              Suggest a Repository
+            </h2>
+            {typeof remaining === 'number' && (
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                Suggestions remaining today: <span className="font-semibold text-indigo-600 dark:text-indigo-400">{remaining}/5</span>
+              </p>
+            )}
+          </div>
           <Button
             variant="ghost"
             mode="icon"
@@ -229,9 +260,14 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
               Request Submitted!
             </h3>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-gray-500 mb-2">
               You'll receive an email once it's reviewed.
             </p>
+            {remaining !== null && (
+              <p className="text-xs font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 inline-block px-3 py-1 rounded-full">
+                {remaining} of 5 suggestions remaining today
+              </p>
+            )}
           </div>
         ) : (
           <form className="px-6 py-5 space-y-4" onSubmit={handleSubmit}>
@@ -431,12 +467,11 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
               </div>
             </div>
 
-            {mutation.isError && (
+            {(mutation.isError || rateLimitError) && (
               <p className="text-sm text-red-500">
-                {(mutation.error as { response?: { status?: number; data?: { message?: string } } })?.response?.status === 429
-                  ? (mutation.error as { response?: { data?: { message?: string } } })?.response?.data?.message
-                  : (mutation.error as { response?: { data?: { message?: string } } })?.response?.data?.message ||
-                  "Failed to submit. Please try again."}
+                {rateLimitError ??
+                  ((mutation.error as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+                    "Failed to submit. Please try again.")}
               </p>
             )}
 
@@ -444,7 +479,7 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
               type="submit"
               variant="mono"
               size="lg"
-              disabled={mutation.isPending || !parsedRepo}
+              disabled={mutation.isPending || !parsedRepo || remaining === 0}
               className="w-full rounded-xl"
             >
               {mutation.isPending ? (
@@ -456,6 +491,11 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
                 "Submit Request"
               )}
             </Button>
+            {remaining === 0 && (
+              <p className="text-center text-xs font-medium text-amber-600 dark:text-amber-400">
+                Daily limit reached. Come back tomorrow.
+              </p>
+            )}
           </form>
         )}
       </motion.div>

--- a/client/src/module/student/opensource/SuggestRepoModal.tsx
+++ b/client/src/module/student/opensource/SuggestRepoModal.tsx
@@ -237,7 +237,7 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
             </h2>
             {typeof remaining === 'number' && (
               <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                Suggestions remaining today: <span className="font-semibold text-indigo-600 dark:text-indigo-400">{remaining}/5</span>
+                Suggestions remaining today: <span className="font-semibold text-lime-600 dark:text-lime-400">{remaining}/5</span>
               </p>
             )}
           </div>
@@ -264,7 +264,7 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
               You'll receive an email once it's reviewed.
             </p>
             {remaining !== null && (
-              <p className="text-xs font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 inline-block px-3 py-1 rounded-full">
+              <p className="text-xs font-medium inline-block px-3 py-1 rounded-md bg-stone-100 dark:bg-white/5 text-stone-700 dark:text-stone-300">
                 {remaining} of 5 suggestions remaining today
               </p>
             )}
@@ -492,7 +492,7 @@ export function SuggestRepoModal({ open, onClose }: SuggestRepoModalProps) {
               )}
             </Button>
             {remaining === 0 && (
-              <p className="text-center text-xs font-medium text-amber-600 dark:text-amber-400">
+              <p className="text-center text-xs font-medium text-stone-500 dark:text-stone-400">
                 Daily limit reached. Come back tomorrow.
               </p>
             )}

--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -1,4 +1,5 @@
 import { type Request, type Response, type NextFunction } from "express";
+import { prisma } from "../../database/db.js";
 import { OpensourceService } from "./opensource.service.js";
 import {
   opensourceListQuerySchema,
@@ -143,10 +144,35 @@ export class OpensourceController {
         return;
       }
 
+      const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const requestCount = await prisma.repoRequest.count({
+        where: {
+          userId: req.user!.id,
+          createdAt: { gte: twentyFourHoursAgo },
+        },
+      });
+
+      if (requestCount >= 5) {
+        res.setHeader("X-RateLimit-Remaining", "0");
+        res.setHeader(
+          "X-RateLimit-Reset",
+          new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+        );
+        res.status(429).json({ message: "You have reached the limit of 5 suggestions per 24 hours. Please try again later." });
+        return;
+      }
+
       const request = await service.submitRepoRequest(
         req.user!.id,
         parsed.data,
       );
+
+      res.setHeader("X-RateLimit-Remaining", String(4 - requestCount));
+      res.setHeader(
+        "X-RateLimit-Reset",
+        new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+      );
+
       res
         .status(201)
         .json({


### PR DESCRIPTION
## Description
This PR resolves #1005 by implementing active rate-limiting tracking and clear user feedback within the repository suggestion workflow. Instead of encountering generic submission crashes when the threshold is hit, users now see an informative counter showing their remaining quota in real-time, accompanied by strict UI disabling rules when their allowance runs dry.

## Related Issue
Fixes #1005

## Type of Change
- [x] Feature
- [x] Enhancement

## Proposed Changes

### 1. Backend Rate-Limit Detection & Headers
- **Quota Validation:** Integrated a Prisma count check inside `opensource.controller.ts` to calculate active user suggestions submitted within a sliding 24-hour window.
- **Dynamic Headers:** Configured the API response lifecycle to dynamically dispatch structural tracking data via `X-RateLimit-Remaining` and `X-RateLimit-Reset` headers.
- **Graceful 429 Failures:** Blocks requests exceeding the limit of 5 submissions per day early, returning a `429 Too Many Requests` status code alongside the calculated cooldown window.

### 2. Frontend Modal Refinement (`SuggestRepoModal.tsx`)
- **Live Counter Banner:** Initialized a local `remaining` quota state to default elegantly to `5`, displaying an explicit status notice (`Suggestions remaining today: 5/5`) immediately beneath the modal's main header title.
- **Header Synchronization:** Wired React Query's `onSuccess` hook to capture the custom incoming response headers, dynamically ticking down the matching template rows on valid submissions.
- **429 Cooldown Parsing:** Implemented hours-remaining parsing within the `onError` block to translate raw API timestamps into an intuitive countdown message: `"You've reached your daily limit. Resets in X hour(s)."`
- **Interaction Gating:** Tied the submit button directly to a native `disabled` state when the remaining threshold hits `0`, backed by a supportive warning legend: `"Daily limit reached. Come back tomorrow."`

## Screenshot
<img width="642" height="781" alt="image" src="https://github.com/user-attachments/assets/8662cc2d-1293-4447-8fd8-103bf341130a" />

## Testing Checklist
- [x] Verified that opening the modal instantly displays the baseline `5/5` quota text row before any network activity takes place.
- [x] Verified that a successful submission reads the payload headers and updates the remaining balance banners seamlessly.
- [x] Simulating a 429 response accurately disables the core submission action button and computes the precise hourly countdown message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily suggestion quota (5 submissions per user) with enforcement.
  * Displays remaining suggestions in the modal and a “remaining today” indicator after submission.
  * Disables submit when quota is exhausted and shows a clear “Daily limit reached” notice.
  * Surfaces rate-limit errors with reset-time info and provides visual feedback after successful submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->