### PR TITLE
Fix/hr self service idor regression

### DIFF
--- a/server/src/module/leave/__tests__/leave.controller.test.ts
+++ b/server/src/module/leave/__tests__/leave.controller.test.ts
@@ -1,0 +1,73 @@
+import type { Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { LeaveController } from "../leave.controller.js";
+import type { LeaveService } from "../leave.service.js";
+
+function mockRes(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+describe("LeaveController self-service identity binding", () => {
+  it("creates leave requests for the authenticated user and ignores query employeeId", async () => {
+    const service = {
+      createRequest: vi.fn().mockResolvedValue({ id: 1 }),
+    } as unknown as LeaveService;
+    const controller = new LeaveController(service);
+    const req = {
+      user: { id: 42, email: "student@example.com", role: "STUDENT" },
+      query: { employeeId: "777" },
+      body: {
+        leaveType: "CASUAL",
+        startDate: "2026-06-08T00:00:00.000Z",
+        endDate: "2026-06-09T00:00:00.000Z",
+        totalDays: 2,
+        reason: "Family event",
+      },
+    } as unknown as Request;
+    const res = mockRes();
+
+    await controller.createRequest(req, res);
+
+    expect(service.createRequest).toHaveBeenCalledWith(42, req.body);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("lists only the authenticated user's leave requests and drops query employeeId", async () => {
+    const service = {
+      getMyRequests: vi.fn().mockResolvedValue({ requests: [], pagination: { page: 1, limit: 20, total: 0, totalPages: 0 } }),
+    } as unknown as LeaveService;
+    const controller = new LeaveController(service);
+    const req = {
+      user: { id: 42, email: "student@example.com", role: "STUDENT" },
+      query: { employeeId: "777", status: "PENDING" },
+    } as unknown as Request;
+    const res = mockRes();
+
+    await controller.getMyRequests(req, res);
+
+    expect(service.getMyRequests).toHaveBeenCalledWith(42, {
+      page: 1,
+      limit: 20,
+      status: "PENDING",
+    });
+  });
+
+  it("reads leave balance for the authenticated user and ignores query employeeId", async () => {
+    const service = {
+      getBalance: vi.fn().mockResolvedValue([]),
+    } as unknown as LeaveService;
+    const controller = new LeaveController(service);
+    const req = {
+      user: { id: 42, email: "student@example.com", role: "STUDENT" },
+      query: { employeeId: "777", year: "2026" },
+    } as unknown as Request;
+    const res = mockRes();
+
+    await controller.getBalance(req, res);
+
+    expect(service.getBalance).toHaveBeenCalledWith(42, 2026);
+  });
+});

--- a/server/src/module/leave/leave.controller.ts
+++ b/server/src/module/leave/leave.controller.ts
@@ -34,7 +34,7 @@ export class LeaveController {
       if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
       const employeeId = req.user.id;
-      const query = leaveQuerySchema.parse(req.query);
+      const { employeeId: _ignoredEmployeeId, ...query } = leaveQuerySchema.parse(req.query);
       const data = await this.leaveService.getMyRequests(employeeId, query);
       return res.json(data);
     } catch (error) {

--- a/server/src/module/leave/leave.controller.ts
+++ b/server/src/module/leave/leave.controller.ts
@@ -16,7 +16,7 @@ export class LeaveController {
       const result = createLeaveRequestSchema.safeParse(req.body);
       if (!result.success) return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
 
-      const employeeId = Number(req.query["employeeId"] ?? req.user.id);
+      const employeeId = req.user.id;
       const request = await this.leaveService.createRequest(employeeId, result.data);
       return res.status(201).json({ message: "Leave request submitted", request });
     } catch (error) {
@@ -31,9 +31,9 @@ export class LeaveController {
 
   async getMyRequests(req: Request, res: Response) {
     try {
-      const employeeId = Number(req.query["employeeId"]);
-      if (isNaN(employeeId)) return res.status(400).json({ message: "employeeId query param required" });
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
+      const employeeId = req.user.id;
       const query = leaveQuerySchema.parse(req.query);
       const data = await this.leaveService.getMyRequests(employeeId, query);
       return res.json(data);
@@ -112,9 +112,9 @@ export class LeaveController {
 
   async getBalance(req: Request, res: Response) {
     try {
-      const employeeId = Number(req.query["employeeId"]);
-      if (isNaN(employeeId)) return res.status(400).json({ message: "employeeId required" });
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
+      const employeeId = req.user.id;
       const year = req.query["year"] ? Number(req.query["year"]) : undefined;
       const balances = await this.leaveService.getBalance(employeeId, year);
       return res.json({ balances });

--- a/server/src/module/payroll/__tests__/payroll.controller.test.ts
+++ b/server/src/module/payroll/__tests__/payroll.controller.test.ts
@@ -1,0 +1,30 @@
+import type { Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { PayrollController } from "../payroll.controller.js";
+import type { PayrollService } from "../payroll.service.js";
+
+function mockRes(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+describe("PayrollController self-service identity binding", () => {
+  it("lists payslips for the authenticated user and ignores query employeeId", async () => {
+    const service = {
+      getMyPayslips: vi.fn().mockResolvedValue([]),
+    } as unknown as PayrollService;
+    const controller = new PayrollController(service);
+    const req = {
+      user: { id: 42, email: "student@example.com", role: "STUDENT" },
+      query: { employeeId: "777" },
+    } as unknown as Request;
+    const res = mockRes();
+
+    await controller.getMyPayslips(req, res);
+
+    expect(service.getMyPayslips).toHaveBeenCalledWith(42);
+    expect(res.json).toHaveBeenCalledWith({ payslips: [] });
+  });
+});

--- a/server/src/module/payroll/payroll.controller.ts
+++ b/server/src/module/payroll/payroll.controller.ts
@@ -63,9 +63,9 @@ export class PayrollController {
 
   async getMyPayslips(req: Request, res: Response) {
     try {
-      const employeeId = Number(req.query["employeeId"]);
-      if (isNaN(employeeId)) return res.status(400).json({ message: "employeeId required" });
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
+      const employeeId = req.user.id;
       const payslips = await this.payrollService.getMyPayslips(employeeId);
       return res.json({ payslips });
     } catch (error) {


### PR DESCRIPTION
Use this PR content:

```md
# Pull Request

## Description
Fixed an IDOR vulnerability in HR self-service leave and payroll endpoints by deriving employee identity from the authenticated user instead of request input.

Updated:
- Leave request creation uses `req.user.id`
- Leave “my requests” uses `req.user.id`
- Leave balance uses `req.user.id`
- Payroll “my payslips” uses `req.user.id`
- Added regression tests to ensure query `employeeId` cannot override authenticated identity
- Dropped parsed `employeeId` from the leave “my requests” query before calling the service

## Related Issue
Fixes #1797

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
Ran focused server tests:

```bash
cd server
npm test -- src/module/leave/__tests__/leave.controller.test.ts src/module/payroll/__tests__/payroll.controller.test.ts
```

Result: 2 test files passed, 4 tests passed.

Also ran:

```bash
cd server
npm run typecheck
```

Result: passed with no TypeScript errors.

## Screenshots / Video

_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by fixing identity binding in leave and payroll modules—users can now only access their own data through proper authentication validation.

* **Tests**
  * Added comprehensive test coverage for leave and payroll modules to verify proper identity validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->