### PR TITLE
fix(badge): use .safeParse() in listAllBadges to return 400 on invalid query params

### DIFF
--- a/server/src/module/badge/badge.controller.ts
+++ b/server/src/module/badge/badge.controller.ts
@@ -71,7 +71,12 @@ export class BadgeController {
 
   async listAllBadges(req: Request, res: Response, next: NextFunction) {
     try {
-      const query = badgeQuerySchema.parse(req.query);
+      const queryResult = badgeQuerySchema.safeParse(req.query);
+      if (!queryResult.success) {
+        res.status(400).json({ message: "Invalid query parameters", errors: queryResult.error.flatten() });
+        return;
+      }
+      const query = queryResult.data;
       const data = await this.badgeService.listAllBadges(query.page, query.limit);
       res.json(data);
     } catch (err) {


### PR DESCRIPTION
## What
Returns 400 Bad Request with validation details for invalid query
parameters instead of 500 Internal Server Error.

## Root cause
listAllBadges used .parse() which throws ZodError on failure,
caught by generic catch and forwarded as 500. Other controllers
in the same file already use .safeParse() correctly.

## Changes
- server/src/module/badge/badge.controller.ts — replaced .parse()
  with .safeParse() pattern consistent with createBadge at line 84

## Verification
- [ ] Invalid page/limit returns 400 with error details
- [ ] Valid query still returns badges correctly
- [ ] Matches existing .safeParse() pattern in same file
- [ ] No unrelated files changed

Closes #1836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query parameter validation for badge listing with more robust error handling. Invalid parameters now return clear error messages and appropriate HTTP status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->