### PR TITLE
fix(sql): add onError handler to useMutation to prevent silent progress loss

### DIFF
--- a/client/src/module/student/sql/SqlExercisePage.tsx
+++ b/client/src/module/student/sql/SqlExercisePage.tsx
@@ -28,6 +28,7 @@ import type { TableInfo } from "./lib/sql-engine";
 import { SEO } from "../../../components/SEO";
 import { canonicalUrl } from "../../../lib/seo.utils";
 import { useAuthStore } from "../../../lib/auth.store";
+import { toast } from "react-hot-toast";
 import api from "../../../lib/axios";
 import { queryKeys } from "../../../lib/query-keys";
 import { DIFF_COLOR } from "../../../lib/difficulty-colors";
@@ -63,6 +64,7 @@ function useSqlProgress() {
     mutationFn: (vars: { exerciseId: string; solved: boolean; code: string }) =>
       api.post("/sql/progress", vars),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.sql.progress() }),
+    onError: () => toast.error("Failed to save progress. Please try again."),
   });
 
   const progress: SqlProgress = isAuthenticated ? (serverProgress ?? {}) : getLocalProgress();


### PR DESCRIPTION
## What
Adds onError handler to SQL exercise progress mutation that notifies
the user when the API call fails.

## Root cause
useMutation had onSuccess but no onError — network failures were
silently swallowed. The UI showed a false green checkmark but
progress was never recorded server-side, disappearing on refresh.

## Changes
- client/src/module/student/sql/SqlExercisePage.tsx — added onError
  handler with toast notification

## Verification
- [ ] Failed API call shows error toast
- [ ] Successful save still works correctly
- [ ] No unrelated files changed

Closes #1835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQL exercise progress saving now displays error notifications when the operation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->