### PR TITLE
fix(auth): re-validate confirmPassword when password field changes

### DIFF
--- a/client/src/module/auth/RegisterPage.tsx
+++ b/client/src/module/auth/RegisterPage.tsx
@@ -217,6 +217,14 @@ export default function RegisterPage() {
       } else {
         delete newErrors.password;
       }
+      if (form.confirmPassword) {
+        const confirmPasswordError = validateConfirmPassword(value, form.confirmPassword);
+        if (confirmPasswordError) {
+          newErrors.confirmPassword = confirmPasswordError;
+        } else {
+          delete newErrors.confirmPassword;
+        }
+      }
     } else if (field === "confirmPassword") {
       const confirmPasswordError = validateConfirmPassword(form.password, value);
       if (confirmPasswordError) {


### PR DESCRIPTION
## What
Re-validates confirmPassword immediately when the password field changes,
instead of leaving stale validation state.

## Root cause
RegisterPage.tsx:213-218 — handleFieldChange password branch only
validated the new password and never called validateConfirmPassword
to refresh confirmPassword error state. A user could change their
password after matching confirmPassword and still see a green checkmark.

## Changes
- client/src/module/auth/RegisterPage.tsx — after password validation,
  re-validate confirmPassword against the new password value

## Verification
- [ ] Changing password after matching confirmPassword shows mismatch error immediately
- [ ] Empty confirmPassword after password change shows no error
- [ ] Normal registration flow still works

Closes #1833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced password confirmation validation to provide real-time error feedback when modifying the password field during registration, improving form responsiveness and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->