### PR TITLE
fix: wrap localStorage.setItem in try/catch across 9 files

### DIFF
--- a/client/src/lib/auth.store.ts
+++ b/client/src/lib/auth.store.ts
@@ -24,7 +24,7 @@ export const useAuthStore = create<AuthState>((set) => {
     isAuthenticated: !!storedUser && (() => { try { return !!JSON.parse(storedUser); } catch { return false; } })(),
 
     login: (user) => {
-      localStorage.setItem("user", JSON.stringify(user));
+      try { localStorage.setItem("user", JSON.stringify(user)); } catch { console.warn("Failed to persist to localStorage: user"); }
       set({ user, isAuthenticated: true });
       _queryClient?.clear();
     },
@@ -44,7 +44,7 @@ export const useAuthStore = create<AuthState>((set) => {
     },
 
     setUser: (user) => {
-      localStorage.setItem("user", JSON.stringify(user));
+      try { localStorage.setItem("user", JSON.stringify(user)); } catch { console.warn("Failed to persist to localStorage: user"); }
       set({ user });
     },
   };

--- a/client/src/module/student/html/HtmlLessonDetailPage.tsx
+++ b/client/src/module/student/html/HtmlLessonDetailPage.tsx
@@ -29,7 +29,7 @@ function toggleProgress(lessonId: string): boolean {
   const progress = getLocalProgress();
   const current = progress[lessonId]?.completed ?? false;
   progress[lessonId] = { ...progress[lessonId], completed: !current };
-  localStorage.setItem("html-progress", JSON.stringify(progress));
+  try { localStorage.setItem("html-progress", JSON.stringify(progress)); } catch { console.warn("Failed to persist to localStorage: html-progress"); }
   return !current;
 }
 

--- a/client/src/module/student/interview-prep/interviewProgress.ts
+++ b/client/src/module/student/interview-prep/interviewProgress.ts
@@ -113,14 +113,16 @@ function mergeProgress(
 
 function writeStoredProgress(progress: InterviewServerProgress, userId?: number) {
   if (userId) {
-    localStorage.setItem(progressCacheKey(userId), JSON.stringify(progress));
+    try { localStorage.setItem(progressCacheKey(userId), JSON.stringify(progress)); } catch { console.warn("Failed to persist to localStorage:", progressCacheKey(userId)); }
     return;
   }
 
-  localStorage.setItem(LEGACY_PROGRESS_KEY, JSON.stringify(toProgressMap(progress)));
-  localStorage.setItem(LEGACY_COMPLETED_KEY, JSON.stringify(progress.completedIds));
-  localStorage.setItem(LEGACY_BOOKMARKS_KEY, JSON.stringify(progress.bookmarkedIds));
-  if (progress.lastVisitedId) localStorage.setItem(LEGACY_LAST_VISITED_KEY, progress.lastVisitedId);
+  try { localStorage.setItem(LEGACY_PROGRESS_KEY, JSON.stringify(toProgressMap(progress))); } catch { console.warn("Failed to persist to localStorage:", LEGACY_PROGRESS_KEY); }
+  try { localStorage.setItem(LEGACY_COMPLETED_KEY, JSON.stringify(progress.completedIds)); } catch { console.warn("Failed to persist to localStorage:", LEGACY_COMPLETED_KEY); }
+  try { localStorage.setItem(LEGACY_BOOKMARKS_KEY, JSON.stringify(progress.bookmarkedIds)); } catch { console.warn("Failed to persist to localStorage:", LEGACY_BOOKMARKS_KEY); }
+  if (progress.lastVisitedId) {
+    try { localStorage.setItem(LEGACY_LAST_VISITED_KEY, progress.lastVisitedId); } catch { console.warn("Failed to persist to localStorage:", LEGACY_LAST_VISITED_KEY); }
+  }
 }
 
 async function fetchServerProgress() {

--- a/client/src/module/student/javascript/JsLessonDetailPage.tsx
+++ b/client/src/module/student/javascript/JsLessonDetailPage.tsx
@@ -41,7 +41,7 @@ function toggleProgress(lessonId: string): boolean {
   const progress = getLocalProgress();
   const current = progress[lessonId]?.completed ?? false;
   progress[lessonId] = { ...progress[lessonId], completed: !current };
-  localStorage.setItem("js-progress", JSON.stringify(progress));
+  try { localStorage.setItem("js-progress", JSON.stringify(progress)); } catch { console.warn("Failed to persist to localStorage: js-progress"); }
   return !current;
 }
 

--- a/client/src/module/student/nodejs/NodeLessonDetailPage.tsx
+++ b/client/src/module/student/nodejs/NodeLessonDetailPage.tsx
@@ -37,7 +37,7 @@ function toggleProgress(lessonId: string): boolean {
   const progress = getLocalProgress();
   const current = progress[lessonId]?.completed ?? false;
   progress[lessonId] = { ...progress[lessonId], completed: !current };
-  localStorage.setItem("node-progress", JSON.stringify(progress));
+  try { localStorage.setItem("node-progress", JSON.stringify(progress)); } catch { console.warn("Failed to persist to localStorage: node-progress"); }
   return !current;
 }
 

--- a/client/src/module/student/python/PythonLessonDetailPage.tsx
+++ b/client/src/module/student/python/PythonLessonDetailPage.tsx
@@ -41,7 +41,7 @@ function toggleProgress(lessonId: string): boolean {
   const progress = getLocalProgress();
   const current = progress[lessonId]?.completed ?? false;
   progress[lessonId] = { ...progress[lessonId], completed: !current };
-  localStorage.setItem("python-progress", JSON.stringify(progress));
+  try { localStorage.setItem("python-progress", JSON.stringify(progress)); } catch { console.warn("Failed to persist to localStorage: python-progress"); }
   return !current;
 }
 

--- a/client/src/module/student/react/ReactLessonDetailPage.tsx
+++ b/client/src/module/student/react/ReactLessonDetailPage.tsx
@@ -41,7 +41,7 @@ function toggleProgress(lessonId: string): boolean {
   const progress = getLocalProgress();
   const current = progress[lessonId]?.completed ?? false;
   progress[lessonId] = { ...progress[lessonId], completed: !current };
-  localStorage.setItem("react-progress", JSON.stringify(progress));
+  try { localStorage.setItem("react-progress", JSON.stringify(progress)); } catch { console.warn("Failed to persist to localStorage: react-progress"); }
   return !current;
 }
 

--- a/client/src/module/student/sql/SqlExercisePage.tsx
+++ b/client/src/module/student/sql/SqlExercisePage.tsx
@@ -46,7 +46,7 @@ function getLocalProgress(): SqlProgress {
 function saveLocalProgress(id: string, solved: boolean, code: string) {
   const progress = getLocalProgress();
   progress[id] = { solved, code };
-  localStorage.setItem("sql-progress", JSON.stringify(progress));
+  try { localStorage.setItem("sql-progress", JSON.stringify(progress)); } catch { console.warn("Failed to persist to localStorage: sql-progress"); }
 }
 
 function useSqlProgress() {

--- a/client/src/module/student/typescript/TsLessonDetailPage.tsx
+++ b/client/src/module/student/typescript/TsLessonDetailPage.tsx
@@ -44,7 +44,7 @@ function toggleProgress(lessonId: string): boolean {
   const progress = getLocalProgress();
   const current = progress[lessonId]?.completed ?? false;
   progress[lessonId] = { ...progress[lessonId], completed: !current };
-  localStorage.setItem("ts-progress", JSON.stringify(progress));
+  try { localStorage.setItem("ts-progress", JSON.stringify(progress)); } catch { console.warn("Failed to persist to localStorage: ts-progress"); }
   return !current;
 }
 


### PR DESCRIPTION
## What
Wraps every localStorage.setItem() call in try/catch to prevent crashes in private browsing mode or when quota is exceeded.

## Root cause
Read paths (getItem/JSON.parse) had try/catch protection, but write paths (setItem) were unprotected across auth store, interview progress, and all 7 lesson pages. In incognito/private browsing, setItem throws SecurityError, crashing login and progress saving entirely.

## Changes
- client/src/lib/auth.store.ts — login() and setUser()
- client/src/module/student/interview-prep/interviewProgress.ts — writeStoredProgress() (5 calls)
- client/src/module/student/typescript/TsLessonDetailPage.tsx
- client/src/module/student/python/PythonLessonDetailPage.tsx
- client/src/module/student/javascript/JsLessonDetailPage.tsx
- client/src/module/student/html/HtmlLessonDetailPage.tsx
- client/src/module/student/nodejs/NodeLessonDetailPage.tsx
- client/src/module/student/react/ReactLessonDetailPage.tsx
- client/src/module/student/sql/SqlExercisePage.tsx

## Verification
- [ ] Login works in private/incognito mode
- [ ] Progress saving works in private/incognito mode
- [ ] console.warn logged on failure instead of thrown error

Closes #1834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application reliability with enhanced error handling for local data storage. Authentication and lesson progress tracking across all modules now gracefully manage storage failures instead of crashing, preventing disruptions when storage is unavailable, quota-limited, or restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->