### PR TITLE
feat(opensource): add community contributions feed

### DIFF
--- a/client/src/lib/types/opensource.types.ts
+++ b/client/src/lib/types/opensource.types.ts
@@ -83,6 +83,23 @@ export interface HacktoberfestProgressResponse {
   };
 }
 
+// Community Feed
+export type CommunityFeedEventType = "repo_contribution" | "repo_bookmarked";
+
+export interface CommunityFeedEvent {
+  type: CommunityFeedEventType;
+  message: string;
+  timestamp: string;
+}
+
+export interface CommunityFeedResponse {
+  events: CommunityFeedEvent[];
+  total: number;
+  page: number;
+  totalPages: number;
+  limit: number;
+}
+
 // GSoC Organizations
 export interface GSoCOrganization {
   id: number;

--- a/client/src/module/student/opensource/CommunityFeed.tsx
+++ b/client/src/module/student/opensource/CommunityFeed.tsx
@@ -1,0 +1,70 @@
+import { useQuery } from "@tanstack/react-query";
+import { Users, GitPullRequest, Bookmark } from "lucide-react";
+import api from "../../../lib/axios";
+import { queryKeys } from "../../../lib/query-keys";
+import type { CommunityFeedResponse, CommunityFeedEventType } from "../../../lib/types";
+
+const FEED_ICONS: Record<CommunityFeedEventType, typeof Users> = {
+  repo_contribution: GitPullRequest,
+  repo_bookmarked: Bookmark,
+};
+
+export function CommunityFeed() {
+  const { data, isLoading } = useQuery<CommunityFeedResponse>({
+    queryKey: ["opensource", "community-feed"],
+    queryFn: () =>
+      api.get("/opensource/community-feed", { params: { limit: 10 } }).then((r) => r.data),
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  });
+
+  const events = data?.events ?? [];
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center gap-2 mb-3">
+        <Users className="w-3.5 h-3.5 text-stone-400" />
+        <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+          Community Contributions
+        </span>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2.5">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-10 rounded-md bg-stone-100 dark:bg-stone-900 animate-pulse"
+            />
+          ))}
+        </div>
+      ) : events.length > 0 ? (
+        <div className="space-y-1.5">
+          {events.map((event, i) => {
+            const Icon = FEED_ICONS[event.type];
+            return (
+              <div
+                key={`${event.type}-${i}`}
+                className="flex items-start gap-2.5 px-3 py-2 rounded-md bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10"
+              >
+                <Icon className="w-3.5 h-3.5 mt-0.5 text-stone-400 shrink-0" />
+                <p className="text-xs text-stone-700 dark:text-stone-300 leading-relaxed">
+                  {event.message}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded-md border border-dashed border-stone-200 dark:border-white/10 bg-white/60 dark:bg-stone-900/50 px-4 py-3">
+          <p className="text-sm font-medium text-stone-700 dark:text-stone-200">
+            No community activity yet.
+          </p>
+          <p className="mt-1 text-xs text-stone-500 dark:text-stone-400">
+            Be the first to contribute to a repo!
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -44,6 +44,7 @@ import { RecentlyViewedSection } from "./_shared/RecentlyViewedSection";
 import { Button } from "../../../components/ui/button";
 import { useCoachStore } from "./stores/coach.store";
 import { markLearningPathMilestone } from "./learning-paths.data";
+import { CommunityFeed } from "./CommunityFeed";
 
 const BOOKMARK_KEY = "oss_bookmarks";
 
@@ -632,6 +633,9 @@ export default function RepoDiscoveryPage() {
 
         {/* Guidance Cards */}
         <GuidanceCards />
+
+        {/* Community feed */}
+        <CommunityFeed />
 
         {/* Recently viewed & recommended */}
         <RecentlyViewedSection repos={recentlyViewed} onSelect={handleOpenRepo} />

--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -328,6 +328,20 @@ export class OpensourceController {
     }
   }
 
+  // ─── Community Feed ───────────────────────────────────────────
+
+  async getCommunityFeed(req: Request, res: Response, next: NextFunction) {
+    try {
+      const page = Math.max(1, Number(req.query.page) || 1);
+      const limit = Math.min(50, Math.max(1, Number(req.query.limit) || 20));
+      const result = await service.getCommunityFeed(page, limit);
+      res.setHeader("Cache-Control", "public, max-age=60, stale-while-revalidate=300");
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  }
+
   // ─── Bookmarks ─────────────────────────────────────────────────
 
   async getBookmarks(req: Request, res: Response, next: NextFunction) {

--- a/server/src/module/opensource/opensource.routes.ts
+++ b/server/src/module/opensource/opensource.routes.ts
@@ -18,6 +18,11 @@ opensourceRouter.get("/", (req, res, next) => controller.listRepos(req, res, nex
 // Get all unique languages
 opensourceRouter.get("/languages", (req, res, next) => controller.getLanguages(req, res, next));
 
+// Community feed (public, cached 60s)
+opensourceRouter.get("/community-feed", (req, res, next) =>
+  controller.getCommunityFeed(req, res, next),
+);
+
 // Get GSoC organizations
 opensourceRouter.get("/gsoc/orgs", (req, res, next) => controller.getGsocOrgs(req, res, next));
 

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -587,6 +587,80 @@ where["OR"] = [
     return repos;
   }
 
+  // ─── Community Feed ───────────────────────────────────────────
+
+  async getCommunityFeed(page: number, limit: number) {
+    const skip = (page - 1) * limit;
+
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+    const [contributions, bookmarkGroups] = await Promise.all([
+      prisma.repoRequest.findMany({
+        where: { status: "APPROVED", updatedAt: { gte: thirtyDaysAgo } },
+        select: {
+          updatedAt: true,
+          name: true,
+          owner: true,
+          user: { select: { id: true, name: true } },
+        },
+        orderBy: { updatedAt: "desc" },
+        take: limit,
+      }),
+      prisma.opensourceBookmark.groupBy({
+        by: ["repoId"],
+        where: { createdAt: { gte: thirtyDaysAgo } },
+        _count: { id: true },
+        orderBy: { _count: { id: "desc" } },
+        take: limit,
+      }),
+    ]);
+
+    const bookmarkRepos =
+      bookmarkGroups.length > 0
+        ? await prisma.opensourceRepo.findMany({
+            where: { id: { in: bookmarkGroups.map((b) => b.repoId) } },
+            select: { id: true, name: true, owner: true },
+          })
+        : [];
+
+    const repoMap = new Map(bookmarkRepos.map((r) => [r.id, r]));
+
+    const raw: {
+      type: "repo_contribution" | "repo_bookmarked";
+      message: string;
+      timestamp: Date;
+      sortKey: string;
+    }[] = [];
+
+    for (const c of contributions) {
+      const firstName = c.user.name.split(" ")[0] ?? c.user.name;
+      raw.push({
+        type: "repo_contribution",
+        message: `${firstName} just made their first contribution to ${c.owner}/${c.name}`,
+        timestamp: c.updatedAt,
+        sortKey: c.updatedAt.toISOString(),
+      });
+    }
+
+    for (const g of bookmarkGroups) {
+      const repo = repoMap.get(g.repoId);
+      if (!repo) continue;
+      raw.push({
+        type: "repo_bookmarked",
+        message: `${g._count.id} student${g._count.id > 1 ? "s" : ""} bookmarked ${repo.owner}/${repo.name} this week`,
+        timestamp: new Date(),
+        sortKey: `B${String(g._count.id).padStart(6, "0")}`,
+      });
+    }
+
+    raw.sort((a, b) => b.sortKey.localeCompare(a.sortKey));
+
+    const total = raw.length;
+    const events = raw.slice(skip, skip + limit);
+
+    return { events, total, page, totalPages: Math.ceil(total / limit), limit };
+  }
+
   // ─── Bookmarks ────────────────────────────────────────────────
 
   async getBookmarkedRepoIds(userId: number): Promise<number[]> {


### PR DESCRIPTION
## What
Adds a live 'Community Contributions' feed to the Repo Discovery page showing recent activity across InternHack, providing social proof for students.

## Implementation

### Server
- **GET /api/opensource/community-feed** — Public endpoint, cached 60s
  - Sources: approved repo requests (first contributions) + recent bookmarks (aggregated)
  - Privacy: shows first name only (e.g. 'Priya just made their first contribution to...')
  - Returns paginated events with type, message, and timestamp

### Client
- **CommunityFeed.tsx** — New component with 60s auto-refresh polling
  - Shows the last 10 events from the API
  - Loading skeleton while fetching, empty state when no activity
  - Displays distinct icons per event type (PR for contributions, bookmark icon for bookmarks)

### Data Sources
1. **First contributions** — Approved repo requests from the last 30 days
2. **Repo bookmarks** — Aggregated bookmark counts per repo (e.g. '5 students bookmarked... this week')

### Privacy
- Only first name shown for individual events (no last names or emails)
- Aggregated bookmark events show only a count, no user data

## Verification
- [x] API returns events correctly
- [x] Feed auto-refreshes every 60s
- [x] Empty state shown when no activity
- [x] Loading skeleton during fetch
- [x] Cache headers set for CDN efficiency

Closes #984