### PR TITLE
feat: DSA video explanations (NeetCode embed player + admin bulk import)

### DIFF
--- a/client/src/module/student/dsa/DsaProblemDetailPage.tsx
+++ b/client/src/module/student/dsa/DsaProblemDetailPage.tsx
@@ -25,6 +25,7 @@ import { DsaTestResults } from "./components/DsaTestResults";
 import { DsaSubmissionHistory } from "./components/DsaSubmissionHistory";
 import { DsaConsoleOutput } from "./components/DsaConsoleOutput";
 import { Button } from "@/components/ui/button";
+import { DsaVideoPanel } from "./components/DsaVideoPanel";
 
 const DIFF_STYLE: Record<string, string> = {
   Easy: "text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/60",
@@ -619,6 +620,13 @@ export default function DsaProblemDetailPage() {
                       </Link>
                     ))}
                   </div>
+                </div>
+              )}
+
+              {/* Video explanation */}
+              {problem.videoUrl && (
+                <div className="mt-6">
+                  <DsaVideoPanel videoUrl={problem.videoUrl} />
                 </div>
               )}
 

--- a/client/src/module/student/dsa/components/DsaVideoPanel.tsx
+++ b/client/src/module/student/dsa/components/DsaVideoPanel.tsx
@@ -1,0 +1,46 @@
+import { Youtube } from "lucide-react";
+
+function getYouTubeEmbedUrl(url: string): string | null {
+  try {
+    const u = new URL(url);
+    if (u.hostname === "youtu.be") return `https://www.youtube.com/embed${u.pathname}`;
+    if (u.hostname.includes("youtube.com")) {
+      if (u.pathname.startsWith("/embed")) return url;
+      const v = u.searchParams.get("v");
+      if (v) return `https://www.youtube.com/embed/${v}`;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+interface DsaVideoPanelProps {
+  videoUrl: string;
+}
+
+export function DsaVideoPanel({ videoUrl }: DsaVideoPanelProps) {
+  const embedUrl = getYouTubeEmbedUrl(videoUrl);
+  if (!embedUrl) return null;
+
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 mb-2">
+        <Youtube className="w-3 h-3 text-red-500" />
+        <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+          video explanation
+        </span>
+      </div>
+      <div className="relative w-full aspect-video rounded-md overflow-hidden bg-black/5 dark:bg-white/5 border border-stone-200 dark:border-white/10">
+        <iframe
+          src={embedUrl}
+          title="Video explanation"
+          className="absolute inset-0 w-full h-full"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          loading="lazy"
+        />
+      </div>
+    </div>
+  );
+}

--- a/server/src/database/seeds/seed.ts
+++ b/server/src/database/seeds/seed.ts
@@ -1441,12 +1441,39 @@ async function seedGsocOrgs() {
   log("GSoC Organizations", count);
 }
 
+// ─── 16. DSA Video URLs (curated NeetCode walkthroughs) ───────────────
+const DSA_VIDEOS: Record<string, string> = {
+  "two-sum": "https://youtu.be/KLlXCFG5TnA",
+  "best-time-to-buy-sell-stock": "https://youtu.be/1pkOgXD63yU",
+  "valid-parentheses": "https://youtu.be/WTzjTskDFMg",
+  "merge-two-sorted-lists": "https://youtu.be/XIdigk956u0",
+  "maximum-subarray": "https://youtu.be/5WZl3MMT0Eg",
+  "3sum": "https://youtu.be/jzZsG8n2R9A",
+  "binary-tree-level-order-traversal": "https://youtu.be/6ZnyEApgFYg",
+  "number-of-islands": "https://youtu.be/pV2kpPD66nE",
+  "longest-increasing-subsequence": "https://youtu.be/cjWnW0hdF1Y",
+  "trapping-rain-water": "https://youtu.be/ZI2z5pq0TqA",
+};
+
+async function seedDsaVideoUrls() {
+  let count = 0;
+  for (const [slug, videoUrl] of Object.entries(DSA_VIDEOS)) {
+    const existing = await prisma.dsaProblem.findUnique({ where: { slug } });
+    if (existing && !existing.videoUrl) {
+      await prisma.dsaProblem.update({ where: { slug }, data: { videoUrl } });
+      count++;
+    }
+  }
+  log("DSA Video URLs", count);
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────
 async function main() {
   console.log("\n🌱 Seeding InternHack database...\n");
 
   await seedUsers();
   await seedDsa();
+  await seedDsaVideoUrls();
   await seedAptitude();
   await seedCompanies();
   await seedBadges();

--- a/server/src/module/dsa/dsa-import.controller.ts
+++ b/server/src/module/dsa/dsa-import.controller.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import { DsaImportService } from "./dsa-import.service.js";
-import { leetcodeImportSchema, csvImportSchema, confirmImportSchema } from "./dsa-import.validation.js";
+import { leetcodeImportSchema, csvImportSchema, confirmImportSchema, bulkVideoImportSchema } from "./dsa-import.validation.js";
 
 // Feature flag — defaults ON; set LEETCODE_IMPORT_ENABLED=false to disable
 function isEnabled(): boolean {
@@ -114,6 +114,21 @@ export class DsaImportController {
       } else {
         next(err);
       }
+    }
+  }
+
+  // POST /api/dsa/import/bulk-videos
+  async bulkImportVideos(req: Request, res: Response, next: NextFunction) {
+    try {
+      const parsed = bulkVideoImportSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ message: parsed.error.issues[0]?.message ?? "Invalid input" });
+        return;
+      }
+      const result = await this.importService.bulkImportVideos(parsed.data.entries);
+      res.json(result);
+    } catch (err) {
+      next(err);
     }
   }
 

--- a/server/src/module/dsa/dsa-import.service.ts
+++ b/server/src/module/dsa/dsa-import.service.ts
@@ -408,6 +408,29 @@ export class DsaImportService {
     });
     return { lastImport: last ?? null };
   }
+
+  // ── Admin: Bulk-import video URLs ─────────────────────────────────────────
+  async bulkImportVideos(
+    entries: Array<{ slug: string; videoUrl: string }>,
+  ): Promise<{ updated: number; failed: { slug: string; reason: string }[] }> {
+    const failed: { slug: string; reason: string }[] = [];
+    let updated = 0;
+
+    for (const entry of entries) {
+      const problem = await prisma.dsaProblem.findUnique({ where: { slug: entry.slug }, select: { id: true } });
+      if (!problem) {
+        failed.push({ slug: entry.slug, reason: "Problem not found" });
+        continue;
+      }
+      await prisma.dsaProblem.update({
+        where: { id: problem.id },
+        data: { videoUrl: entry.videoUrl },
+      });
+      updated++;
+    }
+
+    return { updated, failed };
+  }
 }
 
 // ── Utility: simple CSV line parser (handles quoted fields) ───────────────

--- a/server/src/module/dsa/dsa-import.validation.ts
+++ b/server/src/module/dsa/dsa-import.validation.ts
@@ -15,3 +15,18 @@ export const csvImportSchema = z.object({
 export const confirmImportSchema = z.object({
   token: z.string().uuid("Invalid import token"),
 });
+
+export const bulkVideoImportSchema = z.object({
+  entries: z
+    .array(
+      z.object({
+        slug: z.string().min(1, "Slug is required"),
+        videoUrl: z.string().url("Must be a valid URL").refine(
+          (url) => url.includes("youtube.com") || url.includes("youtu.be"),
+          "Must be a YouTube URL",
+        ),
+      }),
+    )
+    .min(1, "At least one entry required")
+    .max(500, "Max 500 entries per request"),
+});

--- a/server/src/module/dsa/dsa.routes.ts
+++ b/server/src/module/dsa/dsa.routes.ts
@@ -20,6 +20,7 @@ dsaRouter.post("/import/leetcode", authMiddleware, requireRole("STUDENT"), (req,
 dsaRouter.post("/import/csv", authMiddleware, requireRole("STUDENT"), (req, res, next) => dsaImportController.previewCsv(req, res, next));
 dsaRouter.post("/import/confirm", authMiddleware, requireRole("STUDENT"), (req, res, next) => dsaImportController.confirm(req, res, next));
 dsaRouter.get("/import/status", authMiddleware, requireRole("STUDENT"), (req, res, next) => dsaImportController.status(req, res, next));
+dsaRouter.post("/import/bulk-videos", authMiddleware, requireRole("ADMIN"), (req, res, next) => dsaImportController.bulkImportVideos(req, res, next));
 
 dsaRouter.post("/problems/:problemId/toggle", authMiddleware, requireRole("STUDENT"), (req, res, next) => dsaController.toggleProblem(req, res, next));
 dsaRouter.put("/problems/:problemId/notes", authMiddleware, requireRole("STUDENT"), (req, res, next) => dsaController.updateNotes(req, res, next));


### PR DESCRIPTION
## Summary

Adds embedded YouTube video explanations to the DSA problem detail page, curated from NeetCode's free public walkthroughs.

## Changes

### Client
- **DsaVideoPanel.tsx** (new): Extracts YouTube video ID from \ideoUrl\ (supports \youtube.com/watch\, \youtu.be\, \youtube.com/embed\) and renders an embedded iframe player
- **DsaProblemDetailPage.tsx**: Integrates the video panel between hints and external links section, only when \ideoUrl\ is populated

### Server
- **Seed data**: 10 curated NeetCode video URLs for the 10 seeded problems via \seedDsaVideoUrls()\ — idempotent (skips if already set)
- **Admin bulk import**: \POST /api/dsa/import/bulk-videos\ with Zod validation accepts \{ entries: [{ slug, videoUrl }] }\ for row-level import of video URLs

### Schema
No migration needed — the \ideoUrl\ field already exists on \dsaProblem\.

## Notes
- Phase 1: Curated public YouTube videos (NeetCode), zero production cost
- Phase 2 (future): Generate AI video explanations using Gemini, behind premium gate