### PR TITLE
feat: DSA approaches tab with curated solution explanations

### DIFF
--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -238,6 +238,7 @@ export const queryKeys = {
     streak: () => ["dsa", "streak"] as const,
     activity: (year: number) => ["dsa", "activity", year] as const,
     similar: (id: number) => ["dsa", "similar", id] as const,
+    approaches: (slug: string) => ["dsa", "approaches", slug] as const,
   },
 
   // Roadmaps

--- a/client/src/lib/types/learning.types.ts
+++ b/client/src/lib/types/learning.types.ts
@@ -88,6 +88,12 @@ export interface DsaProgress {
   };
 }
 
+export interface DsaApproachEntry {
+  title: string;
+  complexity: string;
+  content: string;
+}
+
 export interface DsaSimilarProblem {
   id: number;
   title: string;

--- a/client/src/module/student/dsa/DsaProblemDetailPage.tsx
+++ b/client/src/module/student/dsa/DsaProblemDetailPage.tsx
@@ -25,6 +25,7 @@ import { DsaTestResults } from "./components/DsaTestResults";
 import { DsaSubmissionHistory } from "./components/DsaSubmissionHistory";
 import { DsaConsoleOutput } from "./components/DsaConsoleOutput";
 import { Button } from "@/components/ui/button";
+import { DsaApproachesPanel } from "./components/DsaApproachesPanel";
 
 const DIFF_STYLE: Record<string, string> = {
   Easy: "text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/60",
@@ -539,6 +540,9 @@ export default function DsaProblemDetailPage() {
                   </div>
                 </div>
               )}
+
+              {/* Approaches */}
+              <DsaApproachesPanel slug={problem.slug} />
 
               {/* AI Hints */}
               {user && (

--- a/client/src/module/student/dsa/components/DsaApproachesPanel.tsx
+++ b/client/src/module/student/dsa/components/DsaApproachesPanel.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { motion, AnimatePresence } from "framer-motion";
+import { ChevronDown, Lightbulb, Code2 } from "lucide-react";
+import api from "../../../../lib/axios";
+import { queryKeys } from "../../../../lib/query-keys";
+import type { DsaApproachEntry } from "../../../../lib/types";
+
+interface DsaApproachesPanelProps {
+  slug: string;
+}
+
+export function DsaApproachesPanel({ slug }: DsaApproachesPanelProps) {
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const { data: approaches = [] } = useQuery({
+    queryKey: queryKeys.dsa.approaches(slug),
+    queryFn: () =>
+      api.get<DsaApproachEntry[]>(`/dsa/problems/${slug}/approaches`).then((r) => r.data),
+    staleTime: 24 * 60 * 60 * 1000,
+  });
+
+  if (approaches.length === 0) return null;
+
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 mb-2">
+        <Code2 className="w-3 h-3 text-violet-500" />
+        <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+          {approaches.length} {approaches.length === 1 ? "approach" : "approaches"}
+        </span>
+      </div>
+      <div className="bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md divide-y divide-stone-100 dark:divide-white/5 overflow-hidden">
+        {approaches.map((approach, i) => (
+          <div key={i}>
+            <button
+              onClick={() => setExpanded(expanded === i ? null : i)}
+              className="w-full flex items-center justify-between gap-3 px-4 py-3 text-left hover:bg-stone-50 dark:hover:bg-stone-800/40 transition-colors"
+            >
+              <span className="inline-flex items-center gap-3 min-w-0">
+                <span className="text-[10px] font-mono font-bold tabular-nums text-violet-600 dark:text-violet-400 shrink-0">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <span className="truncate">
+                  <span className="text-[11px] font-mono uppercase tracking-widest text-stone-600 dark:text-stone-400">
+                    {approach.title}
+                  </span>
+                  <span className="ml-2 text-[10px] font-mono text-stone-400 dark:text-stone-500">
+                    {approach.complexity}
+                  </span>
+                </span>
+              </span>
+              <ChevronDown
+                className={`w-3.5 h-3.5 text-stone-400 shrink-0 transition-transform duration-200 ${
+                  expanded === i ? "rotate-180" : ""
+                }`}
+              />
+            </button>
+            <AnimatePresence>
+              {expanded === i && (
+                <motion.div
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.2 }}
+                  className="overflow-hidden"
+                >
+                  <div className="px-4 pb-4 pl-11 text-sm text-stone-700 dark:text-stone-300 leading-relaxed whitespace-pre-line">
+                    {approach.content}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/server/src/module/dsa/dsa-approaches.data.ts
+++ b/server/src/module/dsa/dsa-approaches.data.ts
@@ -1,0 +1,119 @@
+export interface ApproachEntry {
+  title: string;
+  complexity: string;
+  content: string;
+}
+
+const APPROACHES: Record<string, ApproachEntry[]> = {
+  "two-sum": [
+    {
+      title: "Brute Force — O(n²)",
+      complexity: "Time: O(n²) | Space: O(1)",
+      content:
+        "Check every pair using two nested loops. For each element at index i, look through all elements after it (j = i + 1) and check if nums[i] + nums[j] == target. Return the indices when found.",
+    },
+    {
+      title: "Hash Map — O(n)",
+      complexity: "Time: O(n) | Space: O(n)",
+      content:
+        "Iterate through the array once. For each element, compute the complement (target - nums[i]). If the complement exists in the hash map, return the current index and the complement's index. Otherwise, store the current element and its index in the map.",
+    },
+  ],
+  "best-time-to-buy-sell-stock": [
+    {
+      title: "Brute Force — O(n²)",
+      complexity: "Time: O(n²) | Space: O(1)",
+      content: "For each day as a potential buy day, iterate through all future days to find the maximum profit. Track the global maximum.",
+    },
+    {
+      title: "One Pass — O(n)",
+      complexity: "Time: O(n) | Space: O(1)",
+      content: "Maintain the minimum price seen so far and the maximum profit achievable. Iterate once: update minPrice if current price is lower, otherwise update maxProfit if selling today yields more profit.",
+    },
+  ],
+  "valid-parentheses": [
+    {
+      title: "Stack — O(n)",
+      complexity: "Time: O(n) | Space: O(n)",
+      content: "Use a stack. Push opening brackets onto the stack. When a closing bracket is encountered, check if the stack top matches the corresponding opening bracket. If it matches, pop; otherwise return false. At the end, the stack must be empty.",
+    },
+  ],
+  "merge-two-sorted-lists": [
+    {
+      title: "Iterative — O(n + m)",
+      complexity: "Time: O(n + m) | Space: O(1)",
+      content: "Use a dummy head node. Compare the heads of both lists and append the smaller node to the result. Advance the pointer of the list whose node was taken. When one list is exhausted, append the remainder of the other list.",
+    },
+    {
+      title: "Recursive — O(n + m)",
+      complexity: "Time: O(n + m) | Space: O(n + m)",
+      content: "Base case: if either list is null, return the other. Compare the head values: the smaller head becomes the result node, and its next pointer is set recursively using the next node of that list and the other list. Return the smaller head.",
+    },
+  ],
+  "maximum-subarray": [
+    {
+      title: "Kadane's Algorithm — O(n)",
+      complexity: "Time: O(n) | Space: O(1)",
+      content: "Iterate through the array. Maintain current_sum (max ending here) and max_sum (global max). At each element, set current_sum = max(num, current_sum + num). Update max_sum = max(max_sum, current_sum). Return max_sum.",
+    },
+    {
+      title: "Divide & Conquer — O(n log n)",
+      complexity: "Time: O(n log n) | Space: O(log n)",
+      content: "Split the array in half. Recursively find the max subarray sum for the left half, right half, and the crossing subarray that spans the midpoint. Return the maximum of the three. The crossing subarray is found by expanding outward from the midpoint.",
+    },
+  ],
+  "3sum": [
+    {
+      title: "Two Pointers — O(n²)",
+      complexity: "Time: O(n²) | Space: O(1) ignoring output",
+      content: "Sort the array. Fix one element at index i. Use two pointers (left = i + 1, right = n - 1) to find pairs that sum to -nums[i]. Skip duplicates at each level. If sum < 0 move left forward; if sum > 0 move right backward.",
+    },
+  ],
+  "binary-tree-level-order-traversal": [
+    {
+      title: "BFS — O(n)",
+      complexity: "Time: O(n) | Space: O(n)",
+      content: "Use a queue initialized with the root. While the queue is not empty, record the current level size. Pop that many nodes, add their values to the current level list, and enqueue their children. Append each level to the result.",
+    },
+  ],
+  "number-of-islands": [
+    {
+      title: "DFS — O(m × n)",
+      complexity: "Time: O(m × n) | Space: O(m × n)",
+      content: "Iterate through every cell. When '1' is found, increment the island count and run DFS to mark all adjacent '1's as visited (by changing them to '0' or using a visited set). DFS recurses in four directions.",
+    },
+    {
+      title: "BFS — O(m × n)",
+      complexity: "Time: O(m × n) | Space: O(min(m, n))",
+      content: "Same outer loop as DFS, but use a queue instead of recursion. When '1' is found, BFS from that cell to mark the entire island. BFS uses less stack space than DFS on large grids.",
+    },
+  ],
+  "longest-increasing-subsequence": [
+    {
+      title: "DP — O(n²)",
+      complexity: "Time: O(n²) | Space: O(n)",
+      content: "Let dp[i] = length of LIS ending at index i. Initialize dp[i] = 1 for all i. For each i, check all j < i: if nums[j] < nums[i], update dp[i] = max(dp[i], dp[j] + 1). Answer is max(dp).",
+    },
+    {
+      title: "Patience Sorting — O(n log n)",
+      complexity: "Time: O(n log n) | Space: O(n)",
+      content: "Maintain an array tails where tails[i] is the smallest possible tail value for an increasing subsequence of length i+1. For each num, binary search in tails for the first element >= num and replace it. The length of tails is the LIS length.",
+    },
+  ],
+  "trapping-rain-water": [
+    {
+      title: "Two Pointers — O(n)",
+      complexity: "Time: O(n) | Space: O(1)",
+      content: "Use left and right pointers. Track maxLeft and maxRight. At each step, process the side with the smaller max. If current height is less than the corresponding max, add the difference to the water count. Otherwise, update the max. Move the pointer inward.",
+    },
+    {
+      title: "Prefix Max — O(n)",
+      complexity: "Time: O(n) | Space: O(n)",
+      content: "Precompute leftMax[i] (max height to the left of i) and rightMax[i] (max height to the right of i). Water at position i = min(leftMax[i], rightMax[i]) - height[i]. Sum over all i.",
+    },
+  ],
+};
+
+export function getApproaches(slug: string): ApproachEntry[] {
+  return APPROACHES[slug] ?? [];
+}

--- a/server/src/module/dsa/dsa.controller.ts
+++ b/server/src/module/dsa/dsa.controller.ts
@@ -378,4 +378,19 @@ export class DsaController {
       next(err);
     }
   }
+
+  async getApproaches(req: Request, res: Response, next: NextFunction) {
+    try {
+      const slug = req.params.slug as string;
+      if (!slug) { res.status(400).json({ message: "Problem slug is required" }); return; }
+      const approaches = await this.dsaService.getApproaches(slug);
+      res.json(approaches);
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("Problem not found")) {
+        res.status(404).json({ message: err.message });
+        return;
+      }
+      next(err);
+    }
+  }
 }

--- a/server/src/module/dsa/dsa.routes.ts
+++ b/server/src/module/dsa/dsa.routes.ts
@@ -47,5 +47,6 @@ dsaRouter.get("/companies/:company", optionalAuthMiddleware, (req, res, next) =>
 dsaRouter.get("/patterns", optionalAuthMiddleware, (req, res, next) => dsaController.getPatterns(req, res, next));
 dsaRouter.get("/patterns/:pattern", optionalAuthMiddleware, (req, res, next) => dsaController.getPatternProblems(req, res, next));
 dsaRouter.get("/problems/:id/similar", optionalAuthMiddleware, (req, res, next) => dsaController.getSimilarProblems(req, res, next));
+dsaRouter.get("/problems/:slug/approaches", optionalAuthMiddleware, (req, res, next) => dsaController.getApproaches(req, res, next));
 dsaRouter.get("/problems/:slug", optionalAuthMiddleware, (req, res, next) => dsaController.getProblemBySlug(req, res, next));
 dsaRouter.get("/topics/:slug", optionalAuthMiddleware, (req, res, next) => dsaController.getTopicBySlug(req, res, next));

--- a/server/src/module/dsa/dsa.service.ts
+++ b/server/src/module/dsa/dsa.service.ts
@@ -4,6 +4,7 @@ import { executeCode, LANGUAGE_IDS } from "../../utils/judge0.utils.js";
 import { getProviderForService } from "../../lib/ai-provider-registry.js";
 import { logAIRequest } from "../../lib/ai-request-logger.js";
 import { codeReviewResponseSchema, type CodeReviewResponse } from "./dsa.validation.js";
+import { getApproaches } from "./dsa-approaches.data.js";
 
 interface TestCaseResult {
   input: string;
@@ -1162,6 +1163,10 @@ Return ONLY a JSON array, no markdown fences:
     });
 
     return similar.slice(0, limit);
+  }
+
+  async getApproaches(slug: string) {
+    return getApproaches(slug);
   }
 
   // ── AI Code Review ──


### PR DESCRIPTION
## Summary

Adds an **approaches tab** on the DSA problem detail page showing curated solution explanations with time/space complexity, placed between hints and AI hints.

## Changes

### Server
- \dsa-approaches.data.ts\ (new): Static curated approaches for all 10 seeded problems (Two Sum, Buy/Sell Stock, Valid Parentheses, etc.) with multiple approaches per problem (brute force, optimal, divide & conquer, etc.)
- \GET /api/dsa/problems/:slug/approaches\ — returns approach entries with title, complexity string, and detailed content
- No Prisma migration needed — Phase 1 is purely static data

### Client
- **DsaApproachesPanel.tsx** (new): Accordion-style component matching the hints UI pattern, showing approach title + complexity on collapsed row, full explanation when expanded
- Integrated into DsaProblemDetailPage between hints and AI hints
- New type \DsaApproachEntry\ and \pproaches\ query key

### Seed data coverage
Two Sum (2 approaches), Best Time (2), Valid Parentheses (1), Merge Two Sorted Lists (2), Maximum Subarray (2 — Kadane's + D&C), 3Sum (1), BT Level Order (1), Number of Islands (2), LIS (2 — DP + Patience Sorting), Trapping Rain Water (2 — Two Pointers + Prefix Max)

Closes #1062