### PR TITLE
feat: enhance DSA company tracks with per-company progress and difficulty breakdown

### DIFF
--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -228,6 +228,7 @@ export const queryKeys = {
     bookmarks: () => ["dsa", "bookmarks"] as const,
     companies: () => ["dsa", "companies"] as const,
     company: (name: string, page?: number) => ["dsa", "company", name, page] as const,
+    companyTrackStats: (name: string) => ["dsa", "company", name, "track-stats"] as const,
     patterns: () => ["dsa", "patterns"] as const,
     pattern: (name: string, page?: number) => ["dsa", "pattern", name, page] as const,
     sheets: () => ["dsa", "sheets"] as const,

--- a/client/src/lib/types/learning.types.ts
+++ b/client/src/lib/types/learning.types.ts
@@ -99,11 +99,19 @@ export interface DsaSimilarProblem {
 export interface DsaCompany {
   name: string;
   count: number;
+  solved: number;
 }
 
 export interface DsaPattern {
   name: string;
   count: number;
+}
+
+export interface DsaCompanyTrackStats {
+  company: string;
+  total: number;
+  solved: number;
+  difficultyBreakdown: Record<string, { total: number; solved: number }>;
 }
 
 export interface DsaSheetStats {

--- a/client/src/module/student/dsa/DsaCompaniesPage.tsx
+++ b/client/src/module/student/dsa/DsaCompaniesPage.tsx
@@ -11,7 +11,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import toast from "@/components/ui/toast";
 import api from "../../../lib/axios";
 import { queryKeys } from "../../../lib/query-keys";
-import type { DsaCompany, DsaPaginatedProblems, DsaCompanyProblem } from "../../../lib/types";
+import type { DsaCompany, DsaPaginatedProblems, DsaCompanyProblem, DsaCompanyTrackStats } from "../../../lib/types";
 import { useAuthStore } from "../../../lib/auth.store";
 import { SEO } from "../../../components/SEO";
 import { canonicalUrl } from "../../../lib/seo.utils";
@@ -234,6 +234,13 @@ export default function DsaCompaniesPage() {
     staleTime: 15 * 24 * 60 * 60 * 1000,
   });
 
+  const { data: trackStats } = useQuery({
+    queryKey: queryKeys.dsa.companyTrackStats(selectedCompany!),
+    queryFn: () => api.get<DsaCompanyTrackStats>(`/dsa/companies/${selectedCompany}/track-stats`).then((r) => r.data),
+    enabled: !!selectedCompany,
+    staleTime: 15 * 24 * 60 * 60 * 1000,
+  });
+
   const toggleMutation = useMutation({
     mutationFn: (problemId: number) =>
       api.post<{ problemId: number; solved: boolean }>(`/dsa/problems/${problemId}/toggle`).then((r) => r.data),
@@ -257,6 +264,9 @@ export default function DsaCompaniesPage() {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.dsa.progress() });
+      if (selectedCompany) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.dsa.companyTrackStats(selectedCompany) });
+      }
     },
   });
 
@@ -593,6 +603,19 @@ export default function DsaCompaniesPage() {
                               <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 tabular-nums mt-1 block">
                                 {company.count} problems
                               </span>
+                              {user && (
+                                <div className="mt-2 flex items-center gap-2">
+                                  <div className="flex-1 h-1 bg-stone-200 dark:bg-stone-700 rounded-full overflow-hidden">
+                                    <div
+                                      className="h-full bg-lime-500 rounded-full transition-all duration-500"
+                                      style={{ width: `${Math.round((company.solved / company.count) * 100)}%` }}
+                                    />
+                                  </div>
+                                  <span className="text-[10px] font-mono tabular-nums text-stone-500 dark:text-stone-400">
+                                    {company.solved}/{company.count}
+                                  </span>
+                                </div>
+                              )}
                             </div>
 
                             <ArrowRight className="w-4 h-4 text-stone-400 dark:text-stone-500 group-hover:text-lime-600 dark:group-hover:text-lime-400 group-hover:translate-x-0.5 transition-all shrink-0" />
@@ -636,10 +659,28 @@ export default function DsaCompaniesPage() {
                     <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-stone-900 dark:text-stone-50 capitalize mb-1.5 wrap-break-word">
                       {selectedCompany}
                     </h1>
-                    {!problemsLoading && (
-                      <p className="text-sm text-stone-600 dark:text-stone-400">
-                        <span className="tabular-nums">{problemData?.total ?? 0}</span> problems from recent interviews.
-                      </p>
+                    {trackStats && (
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-3 text-sm">
+                          <span className="tabular-nums text-stone-900 dark:text-stone-50 font-bold">{trackStats.solved}</span>
+                          <span className="text-stone-500 dark:text-stone-400">/</span>
+                          <span className="tabular-nums text-stone-600 dark:text-stone-400">{trackStats.total}</span>
+                          <span className="text-stone-400 dark:text-stone-500">solved</span>
+                        </div>
+                        <div className="flex gap-3 text-xs">
+                          {Object.entries(trackStats.difficultyBreakdown).map(([diff, data]) => {
+                            const color =
+                              diff === "Easy" ? "text-emerald-600 dark:text-emerald-400" :
+                              diff === "Medium" ? "text-amber-600 dark:text-amber-400" :
+                              "text-red-600 dark:text-red-400";
+                            return (
+                              <span key={diff} className={`${color} tabular-nums`}>
+                                {diff}: {data.solved}/{data.total}
+                              </span>
+                            );
+                          })}
+                        </div>
+                      </div>
                     )}
                   </div>
                 </div>

--- a/server/src/module/dsa/dsa.controller.ts
+++ b/server/src/module/dsa/dsa.controller.ts
@@ -136,9 +136,10 @@ export class DsaController {
     }
   }
 
-  async getCompanies(_req: Request, res: Response, next: NextFunction) {
+  async getCompanies(req: Request, res: Response, next: NextFunction) {
     try {
-      const companies = await this.dsaService.getCompanies();
+      const userId = req.user?.id;
+      const companies = await this.dsaService.getCompanies(userId);
       res.json(companies);
     } catch (err) {
       next(err);
@@ -152,6 +153,17 @@ export class DsaController {
       const { page, limit } = parsePagination(req, { defaultLimit: 50 });
       const result = await this.dsaService.getCompanyProblems(company, studentId, page, limit);
       res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async getCompanyTrackStats(req: Request, res: Response, next: NextFunction) {
+    try {
+      const company = req.params.company as string;
+      const userId = req.user?.id;
+      const stats = await this.dsaService.getCompanyTrackStats(company, userId);
+      res.json(stats);
     } catch (err) {
       next(err);
     }

--- a/server/src/module/dsa/dsa.routes.ts
+++ b/server/src/module/dsa/dsa.routes.ts
@@ -43,6 +43,7 @@ dsaRouter.get("/sheets", optionalAuthMiddleware, (req, res, next) => dsaControll
 dsaRouter.get("/lists", optionalAuthMiddleware, (req, res, next) => dsaController.getLists(req, res, next));
 dsaRouter.get("/lists/:name", optionalAuthMiddleware, (req, res, next) => dsaController.getListProblems(req, res, next));
 dsaRouter.get("/companies", optionalAuthMiddleware, (req, res, next) => dsaController.getCompanies(req, res, next));
+dsaRouter.get("/companies/:company/track-stats", optionalAuthMiddleware, (req, res, next) => dsaController.getCompanyTrackStats(req, res, next));
 dsaRouter.get("/companies/:company", optionalAuthMiddleware, (req, res, next) => dsaController.getCompanyProblems(req, res, next));
 dsaRouter.get("/patterns", optionalAuthMiddleware, (req, res, next) => dsaController.getPatterns(req, res, next));
 dsaRouter.get("/patterns/:pattern", optionalAuthMiddleware, (req, res, next) => dsaController.getPatternProblems(req, res, next));

--- a/server/src/module/dsa/dsa.service.ts
+++ b/server/src/module/dsa/dsa.service.ts
@@ -344,28 +344,43 @@ export class DsaService {
     });
   }
 
-  async getCompanies() {
-    if (companiesCache && companiesCache.expiresAt > Date.now()) {
+  async getCompanies(studentId?: number) {
+    if (companiesCache && companiesCache.expiresAt > Date.now() && !studentId) {
       return companiesCache.data;
     }
 
     const problems = await prisma.dsaProblem.findMany({
       where: { companies: { isEmpty: false } },
-      select: { companies: true },
+      select: { id: true, companies: true },
     });
 
     const countMap = new Map<string, number>();
+    const problemIdsByCompany = new Map<string, number[]>();
     for (const p of problems) {
       for (const c of p.companies) {
         countMap.set(c, (countMap.get(c) || 0) + 1);
+        if (!problemIdsByCompany.has(c)) problemIdsByCompany.set(c, []);
+        problemIdsByCompany.get(c)!.push(p.id);
+      }
+    }
+
+    let solvedByCompany = new Map<string, number>();
+    if (studentId) {
+      const solved = await prisma.studentDsaProgress.findMany({
+        where: { studentId, solved: true },
+        select: { problemId: true },
+      });
+      const solvedIds = new Set(solved.map((s) => s.problemId));
+      for (const [company, pIds] of problemIdsByCompany) {
+        solvedByCompany.set(company, pIds.filter((id) => solvedIds.has(id)).length);
       }
     }
 
     const result = Array.from(countMap.entries())
-      .map(([name, count]) => ({ name, count }))
+      .map(([name, count]) => ({ name, count, solved: solvedByCompany.get(name) ?? 0 }))
       .sort((a, b) => b.count - a.count);
 
-    companiesCache = { data: result, expiresAt: Date.now() + AGG_CACHE_TTL };
+    if (!studentId) companiesCache = { data: result, expiresAt: Date.now() + AGG_CACHE_TTL };
     return result;
   }
 
@@ -430,6 +445,47 @@ export class DsaService {
       total,
       totalPages: Math.ceil(total / limit),
       page,
+    };
+  }
+
+  async getCompanyTrackStats(company: string, studentId?: number) {
+    const problems = await prisma.dsaProblem.findMany({
+      where: { companies: { has: company } },
+      select: { id: true, difficulty: true },
+    });
+
+    const diffCount = { Easy: 0, Medium: 0, Hard: 0 };
+    for (const p of problems) {
+      const d = p.difficulty as keyof typeof diffCount;
+      if (d in diffCount) diffCount[d]++;
+    }
+
+    let solvedIds = new Set<number>();
+    if (studentId) {
+      const solved = await prisma.studentDsaProgress.findMany({
+        where: { studentId, solved: true, problemId: { in: problems.map((p) => p.id) } },
+        select: { problemId: true },
+      });
+      solvedIds = new Set(solved.map((s) => s.problemId));
+    }
+
+    const diffSolved = { Easy: 0, Medium: 0, Hard: 0 };
+    for (const p of problems) {
+      if (solvedIds.has(p.id)) {
+        const d = p.difficulty as keyof typeof diffCount;
+        if (d in diffSolved) diffSolved[d]++;
+      }
+    }
+
+    return {
+      company,
+      total: problems.length,
+      solved: solvedIds.size,
+      difficultyBreakdown: {
+        Easy: { total: diffCount.Easy, solved: diffSolved.Easy },
+        Medium: { total: diffCount.Medium, solved: diffSolved.Medium },
+        Hard: { total: diffCount.Hard, solved: diffSolved.Hard },
+      },
     };
   }
 


### PR DESCRIPTION
- **Issue:** #1042 DSA company-specific tracks
- Returns per-company solved counts in \GET /api/dsa/companies\ for authenticated users
- New \GET /api/dsa/companies/:company/track-stats\ endpoint with difficulty (Easy/Medium/Hard) breakdown
- Company cards now show progress bar and solved/total on the listing page
- Company detail header shows track stats with per-difficulty solved/total
- Track stats auto-invalidate on problem toggle