### PR TITLE
feat: add in-browser code playground for JS lesson pages

### DIFF
--- a/client/src/components/LessonCodeRunner.tsx
+++ b/client/src/components/LessonCodeRunner.tsx
@@ -1,0 +1,84 @@
+import { useState, useCallback } from "react";
+import { Play, ChevronDown, ChevronRight } from "lucide-react";
+import { run } from "../module/student/javascript/lib/js-engine";
+import type { RunResult } from "../module/student/javascript/lib/js-engine";
+
+interface LessonCodeRunnerProps {
+  initialCode?: string;
+  language?: string;
+}
+
+export default function LessonCodeRunner({ initialCode = "", language = "javascript" }: LessonCodeRunnerProps) {
+  const [code, setCode] = useState(initialCode);
+  const [result, setResult] = useState<RunResult | null>(null);
+  const [outputOpen, setOutputOpen] = useState(false);
+
+  const handleRun = useCallback(() => {
+    const r = run(code);
+    setResult(r);
+    setOutputOpen(true);
+  }, [code]);
+
+  if (language !== "javascript") {
+    return (
+      <div className="rounded-md border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900 p-4">
+        <p className="text-xs text-stone-500 dark:text-stone-400">
+          Browser execution supports JavaScript only. Copy this code to run it locally.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900 overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2.5 bg-stone-50 dark:bg-stone-950/40 border-b border-stone-200 dark:border-stone-700">
+        <span className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+          run this code
+        </span>
+        <button
+          type="button"
+          onClick={handleRun}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold text-stone-50 bg-stone-900 dark:bg-stone-50 dark:text-stone-900 hover:bg-stone-800 dark:hover:bg-stone-200 transition-colors cursor-pointer"
+        >
+          <Play className="w-3 h-3" />
+          Run
+        </button>
+      </div>
+
+      <textarea
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        className="w-full p-4 text-sm font-mono text-stone-700 dark:text-stone-300 bg-white dark:bg-stone-900 border-0 resize-y min-h-[100px] focus:outline-none"
+        spellCheck={false}
+      />
+
+      {result && (
+        <div className="border-t border-stone-200 dark:border-stone-700">
+          <button
+            type="button"
+            onClick={() => setOutputOpen((o) => !o)}
+            className="flex items-center gap-2 w-full px-4 py-2.5 bg-stone-50 dark:bg-stone-950/40 hover:bg-stone-100 dark:hover:bg-stone-800/60 transition-colors cursor-pointer text-left"
+          >
+            {outputOpen ? <ChevronDown className="w-3 h-3 text-stone-500" /> : <ChevronRight className="w-3 h-3 text-stone-500" />}
+            <span className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">output</span>
+            <span className={`ml-auto text-xs font-mono ${result.status === "success" ? "text-lime-600 dark:text-lime-400" : "text-red-600 dark:text-red-400"}`}>
+              {result.status === "success" ? "success" : "error"}
+            </span>
+          </button>
+          {outputOpen && (
+            <div className="p-4 bg-stone-950 max-h-48 overflow-y-auto">
+              {result.stderr && (
+                <pre className="text-sm text-red-400 whitespace-pre-wrap font-mono mb-2">{result.stderr}</pre>
+              )}
+              {result.stdout ? (
+                <pre className="text-sm text-stone-100 whitespace-pre-wrap font-mono">{result.stdout}</pre>
+              ) : (
+                !result.stderr && <span className="text-sm text-stone-500 italic">No output</span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/module/student/javascript/JsLessonDetailPage.tsx
+++ b/client/src/module/student/javascript/JsLessonDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   Code2,
 } from "lucide-react";
 import { CodeBlock } from "../../../components/ui/CodeBlock";
+import LessonCodeRunner from "../../../components/LessonCodeRunner";
 import { sections, lessons } from "./data";
 import type { JsProgress, PracticeExercise } from "./data/types";
 import { jsEngine } from "./lib/js-engine";
@@ -448,7 +449,10 @@ export default function JsLessonDetailPage() {
             </div>
             <div className="space-y-3">
               {content.codeExamples.map((example, i) => (
-                <CodeBlock key={`${lesson.id}-${example.title || i}`} example={example} language="javascript" />
+                <div key={`${lesson.id}-${example.title || i}`} className="space-y-3">
+                  <CodeBlock example={example} language="javascript" />
+                  <LessonCodeRunner initialCode={example.code} language="javascript" />
+                </div>
               ))}
             </div>
           </motion.div>

--- a/client/src/module/student/javascript/lib/js-engine.ts
+++ b/client/src/module/student/javascript/lib/js-engine.ts
@@ -97,3 +97,39 @@ ${code}
 }
 
 export const jsEngine = new JsEngine();
+
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+  status: "success" | "error";
+}
+
+export function run(code: string): RunResult {
+  const logs: string[] = [];
+  const errs: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  const originalInfo = console.info;
+
+  console.log = (...args) => logs.push(args.map(String).join(" "));
+  console.error = (...args) => errs.push(args.map(String).join(" "));
+  console.warn = (...args) => logs.push(args.map(String).join(" "));
+  console.info = (...args) => logs.push(args.map(String).join(" "));
+
+  try {
+    // eslint-disable-next-line no-new-func
+    new Function(code)();
+    console.log = originalLog;
+    console.error = originalError;
+    console.warn = originalWarn;
+    console.info = originalInfo;
+    return { stdout: logs.join("\n"), stderr: errs.join("\n"), status: "success" };
+  } catch (err) {
+    console.log = originalLog;
+    console.error = originalError;
+    console.warn = originalWarn;
+    console.info = originalInfo;
+    return { stdout: logs.join("\n"), stderr: String(err), status: "error" };
+  }
+}


### PR DESCRIPTION
The JavaScript lesson pages show code blocks as static text with no way to run them. I extended the existing jsEngine in js-engine.ts to expose a run() function and built a LessonCodeRunner component that calls it directly in the browser — no backend or external API needed. The Run button appears below each code block in JavaScript lessons. Non-JS lessons show a message explaining browser execution supports JS only.

Closes #1053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive JavaScript code runner integrated into lessons, enabling users to execute code examples directly and view real-time output with execution status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->