### PR TITLE
refactor(ui): extract shared SELECT_CLASS constant and apply to Inter…

### DIFF
--- a/client/src/lib/form-styles.ts
+++ b/client/src/lib/form-styles.ts
@@ -1,0 +1,2 @@
+export const SELECT_CLASS =
+  'text-sm bg-white dark:bg-stone-950 border border-stone-200 dark:border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-lime-400 cursor-pointer';

--- a/client/src/module/student/interview-prep/InterviewSectionPage.tsx
+++ b/client/src/module/student/interview-prep/InterviewSectionPage.tsx
@@ -246,7 +246,7 @@ export default function InterviewSectionPage() {
               <select
                 value={selectedCompany}
                 onChange={(e) => setSelectedCompany(e.target.value)}
-                className="${SELECT_CLASS}"
+                className={SELECT_CLASS}
               >
                 <option value="All">All Companies</option>
                 {availableCompanies.map((company) => (
@@ -264,7 +264,7 @@ export default function InterviewSectionPage() {
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value)}
-              className="${SELECT_CLASS}"
+              className={SELECT_CLASS}
             >
               <option value="frequency">Most Frequent</option>
               <option value="order">Curated Order</option>

--- a/client/src/module/student/interview-prep/InterviewSectionPage.tsx
+++ b/client/src/module/student/interview-prep/InterviewSectionPage.tsx
@@ -1,3 +1,4 @@
+import { SELECT_CLASS } from "@/lib/form-styles";
 import { useMemo, useState } from "react";
 import { useParams, Link, Navigate } from "react-router";
 import { motion } from "framer-motion";
@@ -245,7 +246,7 @@ export default function InterviewSectionPage() {
               <select
                 value={selectedCompany}
                 onChange={(e) => setSelectedCompany(e.target.value)}
-                className="text-sm bg-white dark:bg-stone-950 border border-stone-200 dark:border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-lime-400 cursor-pointer"
+                className="${SELECT_CLASS}"
               >
                 <option value="All">All Companies</option>
                 {availableCompanies.map((company) => (
@@ -263,7 +264,7 @@ export default function InterviewSectionPage() {
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value)}
-              className="text-sm bg-white dark:bg-stone-950 border border-stone-200 dark:border-white/10 rounded-md px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-lime-400 cursor-pointer"
+              className="${SELECT_CLASS}"
             >
               <option value="frequency">Most Frequent</option>
               <option value="order">Curated Order</option>


### PR DESCRIPTION
Closes #1908

## Changes
- Created `client/src/lib/form-styles.ts` exporting `SELECT_CLASS` constant
- Replaced hardcoded select className string in `InterviewSectionPage.tsx` at lines 245–248 and 263–267 with `SELECT_CLASS` import
- Investigated JobBrowsePage.tsx, SignalsPage.tsx, and MyApplicationsPage.tsx — these files use different className variants with different padding, font sizes, and focus styles, so they were intentionally not modified to avoid unintended visual regressions

## Notes
The SELECT_CLASS constant is now available in `client/src/lib/form-styles.ts` for future use as other pages are standardized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated styling for dropdown controls to ensure consistent appearance and behavior across the interview prep page—improved spacing, focus rings, cursor affordance and dark-mode support for company and sort selectors, resulting in a more polished, accessible UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->