### PR TITLE
Fix: Password confirmation validation not updating when password field is changes

### DIFF
--- a/client/src/module/auth/RegisterPage.tsx
+++ b/client/src/module/auth/RegisterPage.tsx
@@ -217,6 +217,16 @@ export default function RegisterPage() {
       } else {
         delete newErrors.password;
       }
+
+      // Re-validate confirmPassword against new password value
+      if (form.confirmPassword) {
+        const confirmPasswordError = validateConfirmPassword(value, form.confirmPassword);
+        if (confirmPasswordError) {
+          newErrors.confirmPassword = confirmPasswordError;
+        } else {
+          delete newErrors.confirmPassword;
+        }
+      }
     } else if (field === "confirmPassword") {
       const confirmPasswordError = validateConfirmPassword(form.password, value);
       if (confirmPasswordError) {


### PR DESCRIPTION
### Problem
When a user edits the password field after both password fields show valid, the confirmPassword field keeps showing a stale checkmark even when the passwords no longer match. The mismatch is only caught at form submission.

### Solution
Added real-time re-validation of confirmPassword when the password field changes. Now, when a user edits the passwords field, confirmPassword is immediately re-validated against the new value, providing instant visual feedback.

### Changes
- File: `RegisterPage.tsx`
- Modified: handleFieldChange function to re-validate confirmPassword when password changes.

### Testing
- Type matching passwords -> both show
- Edit password to a different value -> confirmPassword immediately shows
- Edit password back to match -> confirmPassword shows
- Form submission validation still works correctly 

### Impact 
- Fixes misleading UI feedback during registration
- Improves user experience with instant validation
- No breaking changes, pure validation logic

Closes #1833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved password confirmation validation to update in real-time as you modify your password, providing immediate feedback during registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->