### PR TITLE
fix: change ATS scan limit from daily to monthly window

### DIFF
--- a/server/src/config/usage-limits.ts
+++ b/server/src/config/usage-limits.ts
@@ -30,5 +30,6 @@ export function getPlanTier(
 }
 
 export const MONTHLY_LIMITS: Partial<Record<UsageAction, Record<PlanTier, number>>> = {
+  ATS_SCORE: { FREE: 3, PREMIUM: 20 },
   ROADMAP_GENERATION: { FREE: 5, PREMIUM: 50 },
 };

--- a/server/src/module/ats/ats.routes.ts
+++ b/server/src/module/ats/ats.routes.ts
@@ -29,7 +29,7 @@ atsRouter.use(authMiddleware, requireRole("STUDENT"));
 
 atsRouter.get("/usage", (req, res, next) => atsController.getUsageStats(req, res, next));
 atsRouter.get("/history", (req, res, next) => atsController.getScoreHistory(req, res, next));
-atsRouter.post("/score", usageLimit("ATS_SCORE"), (req, res, next) => atsController.scoreResume(req, res, next));
+atsRouter.post("/score", usageLimit("ATS_SCORE", "monthly"), (req, res, next) => atsController.scoreResume(req, res, next));
 atsRouter.post("/apply-suggestions", usageLimit("GENERATE_RESUME"), (req, res, next) => atsController.applySuggestions(req, res, next));
 atsRouter.post("/cover-letter", usageLimit("COVER_LETTER"), (req, res, next) => coverLetterController.generate(req, res, next));
 atsRouter.get("/cover-letter/history", (req, res, next) => coverLetterController.getHistory(req, res, next));

--- a/server/src/module/recommendation/recommendation.routes.ts
+++ b/server/src/module/recommendation/recommendation.routes.ts
@@ -8,4 +8,4 @@ export const recommendationRouter = Router();
 
 recommendationRouter.use(authMiddleware, requireRole("STUDENT"));
 
-recommendationRouter.get("/", usageLimit("ATS_SCORE"), getRecommendationsHandler);
+recommendationRouter.get("/", usageLimit("ATS_SCORE", "monthly"), getRecommendationsHandler);


### PR DESCRIPTION
## What
Change ATS score scan limit from daily to monthly window

## Root cause
usageLimit middleware checked daily count for ATS_SCORE, causing free users to hit limit after 2 scans in a day

## Changes
- server/src/config/usage-limits.ts — added ATS_SCORE to MONTHLY_LIMITS with FREE: 3, PREMIUM: 20
- server/src/module/ats/ats.routes.ts — changed usageLimit(ATS_SCORE) to usageLimit(ATS_SCORE, monthly)
- server/src/module/recommendation/recommendation.routes.ts — changed usageLimit(ATS_SCORE) to usageLimit(ATS_SCORE, monthly)

## Verification
- [ ] Bug reproduced / feature confirmed missing
- [ ] Verified locally
- [ ] git diff shows only intended files
- [ ] eslint passes on changed files
- [ ] tsc --noEmit passes
- [ ] No console.logs remaining
- [ ] Screenshots attached if UI changed

## CI failures (if any)
N/A

## Before / After
N/A — backend only, no UI change

Closes #1815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established monthly usage limits for ATS Score feature (3 uses for Free plan, 20 uses for Premium plan).
  * Updated rate limiting configuration to enforce monthly-based usage quotas across scoring endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->