### PR TITLE
feat: add scroll progress bar to show reading position

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { ProtectedRoute } from "./components/ProtectedRoute";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { LoadingScreen } from "./components/LoadingScreen";
 import BackToTopButton from "./components/common/BackToTopButton";
+import ScrollProgressBar from "./components/common/ScrollProgressBar";
 import ScrollToTop from "./components/common/ScrollToTop";
 const ContributorsPage = lazyWithRetry(() => import("./module/contributors/ContributorsPage"));
 
@@ -317,6 +318,7 @@ function AuthExpiredRedirect() {
 function App() {
   return (
     <>
+      <ScrollProgressBar />
       <ScrollToTop />
       <AuthExpiredRedirect />
       <Toaster />

--- a/client/src/components/common/ScrollProgressBar.tsx
+++ b/client/src/components/common/ScrollProgressBar.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+export default function ScrollProgressBar() {
+  const [scrollPercent, setScrollPercent] = useState(0);
+
+  useEffect(() => {
+    const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (prefersReduced) return;
+
+    const onScroll = () => {
+      const el = document.documentElement;
+      const percent = (el.scrollTop / (el.scrollHeight - el.clientHeight)) * 100;
+      setScrollPercent(Math.min(percent, 100));
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <div
+      className="fixed top-0 left-0 z-[9999] h-[3px] bg-lime-500 transition-none"
+      style={{ width: `${scrollPercent}%` }}
+    />
+  );
+}


### PR DESCRIPTION
## What
Add scroll progress bar to show reading position

## Root cause
No scroll progress indicator — users on long pages have no visual cue of reading position

## Changes
- client/src/components/common/ScrollProgressBar.tsx — new component tracking scroll percentage, fixed top bar with lime color, respects prefers-reduced-motion
- client/src/App.tsx — added ScrollProgressBar to root layout

## Verification
- [ ] Bug reproduced / feature confirmed missing
- [ ] Verified locally
- [ ] git diff shows only intended files
- [ ] eslint passes on changed files
- [ ] tsc --noEmit passes
- [ ] No console.logs remaining
- [ ] Screenshots attached if UI changed

## CI failures (if any)
N/A

## Before / After
N/A

Closes #1853