### PR TITLE
refactor: extract analytics helper functions (groupByField, countByField, toPercentage)

### DIFF
--- a/server/src/lib/analytics.ts
+++ b/server/src/lib/analytics.ts
@@ -1,0 +1,29 @@
+export function groupByField<T extends Record<string, unknown>>(
+  items: T[],
+  field: keyof T,
+): Record<string, T[]> {
+  const map: Record<string, T[]> = {};
+  for (const item of items) {
+    const key = String(item[field]);
+    if (!map[key]) map[key] = [];
+    map[key].push(item);
+  }
+  return map;
+}
+
+export function countByField<T extends Record<string, unknown>>(
+  items: T[],
+  field: keyof T,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const item of items) {
+    const key = String(item[field]);
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
+
+export function toPercentage(count: number, total: number): number {
+  if (total <= 0) return 0;
+  return (count / total) * 100;
+}

--- a/server/src/module/analytics/analytics.service.ts
+++ b/server/src/module/analytics/analytics.service.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../../database/db.js";
 import { ContentType } from "@prisma/client";
+import { toPercentage } from "../../lib/analytics.js";
 
 export class AnalyticsService {
   async trackContentView(data: {
@@ -57,7 +58,7 @@ export class AnalyticsService {
         lessonId: s.contentId,
         avgTimeSpent: s._avg.timeSpentMs,
         totalViews: s._count._all,
-        completionRate: s._count._all > 0 ? (completedCount / s._count._all) * 100 : 0,
+        completionRate: toPercentage(completedCount, s._count._all),
       };
     });
   }
@@ -111,7 +112,7 @@ export class AnalyticsService {
       return {
         questionId: s.contentId,
         viewCount: s._count._all,
-        completionRate: s._count._all > 0 ? (completedCount / s._count._all) * 100 : 0,
+        completionRate: toPercentage(completedCount, s._count._all),
       };
     });
   }


### PR DESCRIPTION
## What
Extract duplicated analytics aggregation logic into shared helper

## Root cause
Analytics aggregation logic (groupByField, countByField, toPercentage) duplicated across multiple service files instead of shared helper

## Changes
- server/src/lib/analytics.ts — new helper with groupByField, countByField, toPercentage
- server/src/module/analytics/analytics.service.ts — replaced inline completionRate formula with toPercentage() call

## Verification
- [ ] Bug reproduced / feature confirmed missing
- [ ] Verified locally
- [ ] git diff shows only intended files
- [ ] eslint passes on changed files
- [ ] tsc --noEmit passes
- [ ] No console.logs remaining
- [ ] Screenshots attached if UI changed

## CI failures (if any)
N/A

## Before / After
N/A — refactor only, no behavior change

Closes #1855