### PR TITLE
feat: add live Good First Issues feed per repo in discovery

### DIFF
--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -109,6 +109,7 @@ export const queryKeys = {
       ["opensource", "all-requests", params] as const,
     stats: () => ["opensource", "stats"] as const,
     bookmarks: () => ["opensource", "bookmarks"] as const,
+    goodFirstIssues: (id: number) => ["opensource", "good-first-issues", id] as const,
   },
 
   // Blog

--- a/client/src/lib/types/opensource.types.ts
+++ b/client/src/lib/types/opensource.types.ts
@@ -26,6 +26,7 @@ export interface OpenSourceRepo {
   updatedAt: string;
   healthScore: number;
   matchedSkills?: string[];
+  goodFirstIssuesCount: number;
 }
 
 // Repo Requests
@@ -114,6 +115,16 @@ export interface GSoCOrganization {
   mailingList?: string;
   ideasUrl?: string;
   guideUrl?: string;
+}
+
+export interface GoodFirstIssue {
+  id: number;
+  number: number;
+  title: string;
+  html_url: string;
+  comments: number;
+  created_at: string;
+  labels: { name: string; color: string }[];
 }
 
 export interface GSoCStats {

--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -35,7 +35,7 @@ import { SEO } from "../../../components/SEO";
 import toast from "../../../components/ui/toast";
 import { canonicalUrl } from "../../../lib/seo.utils";
 import { PaginationControls } from "../../../components/ui/PaginationControls";
-import type { OpenSourceRepo, Pagination, RepoRequest } from "../../../lib/types";
+import type { OpenSourceRepo, Pagination, RepoRequest, GoodFirstIssue } from "../../../lib/types";
 import { useAuthStore } from "../../../lib/auth.store";
 import { REPO_DOMAINS, DIFFICULTY_OPTIONS, SORT_OPTIONS, LANGUAGE_COLORS } from "./reposData";
 import { formatCount, difficultyBadge } from "./_shared/repo-utils";
@@ -117,9 +117,7 @@ export default function RepoDiscoveryPage() {
   const sortKey = searchParams.get("sort") || "stars";
   const page = Number(searchParams.get("page")) || 1;
   const trendingOnly = searchParams.get("trending") === "true";
-  const hacktoberfestOnly = searchParams.get("hacktoberfest") === "true";
-  const highlyActiveOnly = searchParams.get("highlyActive") === "true";
-  const showHacktoberfestFilter = true;
+  const gfiOnly = searchParams.get("gfi") === "true";
 
   // Debounced search state & ref
   const [inputValue, setInputValue] = useState(search);
@@ -310,14 +308,13 @@ export default function RepoDiscoveryPage() {
     }
 
     if (trendingOnly) params.trending = "true";
-    if (hacktoberfestOnly) params.hacktoberfest = "true";
-    if (highlyActiveOnly) params.highlyActive = "true";
+    if (gfiOnly) params.hasGoodFirstIssues = "true";
 
     const sortOpt = SORT_OPTIONS.find((s) => s.key === sortKey);
     if (sortOpt) params.sortOrder = sortOpt.order;
 
     return params;
-  }, [search, selectedDomain, selectedDifficulty, selectedLanguage, languageMode, inferredLanguages, sortKey, trendingOnly, hacktoberfestOnly, highlyActiveOnly, page]);
+  }, [search, selectedDomain, selectedDifficulty, selectedLanguage, languageMode, inferredLanguages, sortKey, trendingOnly, gfiOnly, page]);
 
   const { data, isLoading, isError } = useQuery({
     queryKey: queryKeys.opensource.list(queryParams),
@@ -680,6 +677,20 @@ export default function RepoDiscoveryPage() {
           >
             <Bookmark className="w-3 h-3" />
             Saved {bookmarks.length > 0 && `(${bookmarks.length})`}
+          </button>
+
+          {/* GFI toggle */}
+          <button
+            type="button"
+            onClick={() => updateFilter("gfi", gfiOnly ? "" : "true")}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${
+              gfiOnly
+                ? "bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 border-lime-200 dark:border-lime-400/30"
+                : "text-stone-500 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25"
+            }`}
+          >
+            <CircleDot className="w-3 h-3" />
+            Has GFI
           </button>
 
           {/* Trending toggle */}
@@ -1182,6 +1193,9 @@ export default function RepoDiscoveryPage() {
                   </div>
                 </div>
 
+                {/* Good First Issues */}
+                <GoodFirstIssuesSection repoId={selectedRepo.id} />
+
                 {/* Quick actions */}
                 <div className="grid grid-cols-2 gap-2">
                   <a
@@ -1223,7 +1237,8 @@ export default function RepoDiscoveryPage() {
   );
 }
 
-function RecommendedSection({
+<<<<<<< HEAD
+function RecommendedSection({ 
   onSelect,
   bookmarks,
   onToggleBookmark
@@ -1232,6 +1247,106 @@ function RecommendedSection({
   bookmarks: number[];
   onToggleBookmark: (id: number) => void;
 }) {
+=======
+function GoodFirstIssuesSection({ repoId }: { repoId: number }) {
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.opensource.goodFirstIssues(repoId),
+    queryFn: () =>
+      api.get<{ issues: GoodFirstIssue[]; count: number }>(`/opensource/${repoId}/good-first-issues`).then((r) => r.data),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 mb-2">
+        <div className="h-1 w-1 bg-lime-400"></div>
+        <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 inline-flex items-center gap-1.5">
+          <CircleDot className="w-3 h-3" />
+          good first issues
+          {data && !isLoading && (
+            <span className="ml-1 px-1.5 py-0.5 rounded bg-lime-100 dark:bg-lime-900/30 text-lime-700 dark:text-lime-400 text-[9px] font-bold">
+              {data.count}
+            </span>
+          )}
+        </p>
+      </div>
+      {isLoading && (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-12 bg-stone-100 dark:bg-white/5 rounded-md animate-pulse" />
+          ))}
+        </div>
+      )}
+      {!isLoading && data && data.issues.length === 0 && (
+        <div className="flex items-center gap-2 py-3 px-3 rounded-md bg-stone-50 dark:bg-white/[0.03] border border-stone-200 dark:border-white/5">
+          <AlertCircle className="w-4 h-4 text-stone-400 dark:text-stone-500 shrink-0" />
+          <p className="text-sm text-stone-500 dark:text-stone-400">No open good first issues right now.</p>
+        </div>
+      )}
+      {!isLoading && data && data.issues.length > 0 && (
+        <div className="space-y-1.5">
+          {data.issues.map((issue) => {
+            const daysOpen = Math.floor(
+              (Date.now() - new Date(issue.created_at).getTime()) / (1000 * 60 * 60 * 24),
+            );
+            return (
+              <a
+                key={issue.id}
+                href={issue.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block no-underline group"
+              >
+                <div className="flex items-start gap-2 py-2 px-3 rounded-md border border-stone-200 dark:border-white/10 bg-white dark:bg-stone-900 hover:bg-stone-50 dark:hover:bg-white/[0.04] transition-colors">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-0.5">
+                      <span className="text-[11px] font-mono text-stone-400 dark:text-stone-500 shrink-0">
+                        #{issue.number}
+                      </span>
+                      <span className="text-sm font-medium text-stone-900 dark:text-stone-50 truncate group-hover:text-lime-700 dark:group-hover:text-lime-400 transition-colors">
+                        {issue.title}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 text-[11px] text-stone-500 dark:text-stone-400">
+                      <span>{daysOpen}d ago</span>
+                      <span className="flex items-center gap-1">
+                        <CircleDot className="w-3 h-3" />
+                        {issue.comments}
+                      </span>
+                    </div>
+                    {issue.labels.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-1">
+                        {issue.labels.map((label) => (
+                          <span
+                            key={label.name}
+                            className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium"
+                            style={{
+                              backgroundColor: `#${label.color}22`,
+                              color: `#${label.color}`,
+                            }}
+                          >
+                            {label.name}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <ExternalLink className="w-3.5 h-3.5 text-stone-400 dark:text-stone-500 shrink-0 mt-1 opacity-0 group-hover:opacity-100 transition-opacity" />
+                </div>
+              </a>
+            );
+          })}
+        </div>
+      )}
+      {!isLoading && !data && (
+        <p className="text-sm text-stone-400 dark:text-stone-500">Could not load issues.</p>
+      )}
+    </div>
+  );
+}
+
+function RecommendedSection({ onSelect }: { onSelect: (repo: OpenSourceRepo) => void }) {
+>>>>>>> 4076eb26 (chore: restore package files to upstream/main)
   const { data, isLoading } = useQuery({
     queryKey: queryKeys.opensource.list({ recommended: "true" }),
     queryFn: async () => {

--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -441,7 +441,7 @@ export default function RepoDiscoveryPage() {
         <div className="mb-8">
           <div className="flex items-center gap-2 mb-2">
             <div className="h-1 w-1 bg-lime-400"></div>
-            <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+            <span className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
               learning / open source
             </span>
           </div>
@@ -465,7 +465,7 @@ export default function RepoDiscoveryPage() {
               </p>
             </div>
             {stats && (
-              <div className="flex items-center gap-4 text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+              <div className="flex items-center gap-4 text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
                 <span>
                   <span className="text-stone-900 dark:text-stone-50">{stats.totalRepos}</span> repos
                 </span>
@@ -493,7 +493,7 @@ export default function RepoDiscoveryPage() {
             placeholder="Search repos, languages, tags..."
             className="w-full pl-10 pr-10 py-3 bg-white dark:bg-stone-900 border border-stone-200 dark:border-white/10 rounded-md text-stone-900 dark:text-stone-50 placeholder-stone-400 dark:placeholder-stone-500 text-sm focus:outline-none focus:border-stone-400 dark:focus:border-white/25 transition-colors"
           />
-          <kbd className="absolute right-3 top-1/2 -translate-y-1/2 hidden sm:inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-stone-200 dark:border-white/10 text-[10px] font-mono text-stone-400 dark:text-stone-500 bg-stone-50 dark:bg-stone-800">
+          <kbd className="absolute right-3 top-1/2 -translate-y-1/2 hidden sm:inline-flex items-center gap-1 px-1.5 py-0.5 rounded border border-stone-200 dark:border-white/10 text-xs font-mono text-stone-400 dark:text-stone-500 bg-stone-50 dark:bg-stone-800">
             /
           </kbd>
         </div>
@@ -510,7 +510,7 @@ export default function RepoDiscoveryPage() {
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-1.5 mb-0.5">
                 <div className="h-1 w-1 bg-lime-400"></div>
-                <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 group-hover:text-lime-400">
+                <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 group-hover:text-lime-400">
                   analytics
                 </p>
               </div>
@@ -535,7 +535,7 @@ export default function RepoDiscoveryPage() {
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-1.5 mb-0.5">
                 <div className="h-1 w-1 bg-lime-400"></div>
-                <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 group-hover:text-lime-400">
+                <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 group-hover:text-lime-400">
                   suggest
                 </p>
               </div>
@@ -551,7 +551,7 @@ export default function RepoDiscoveryPage() {
         {!!user && (
           <div className="mb-8">
             <div className="flex items-center justify-between mb-3">
-              <div className="flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500">
+              <div className="flex items-center gap-2 text-xs font-mono uppercase tracking-widest text-stone-500">
                 <div className="h-1 w-1 bg-lime-400" />
                 my submissions
               </div>
@@ -574,7 +574,7 @@ export default function RepoDiscoveryPage() {
                 <button
                   type="button"
                   onClick={() => refetchMyRequests()}
-                  className="text-[10px] font-mono uppercase tracking-widest text-stone-400 hover:text-lime-500 transition-colors cursor-pointer border-0 bg-transparent"
+                  className="text-xs font-mono uppercase tracking-widest text-stone-400 hover:text-lime-500 transition-colors cursor-pointer border-0 bg-transparent"
                 >
                   Retry ↻
                 </button>
@@ -608,8 +608,9 @@ export default function RepoDiscoveryPage() {
                         </span>
                       </div>
                       <span
-                        className={`text-[10px] font-mono uppercase tracking-widest px-2 py-0.5 rounded-md border shrink-0 ml-3 ${STATUS_STYLE[req.status] ?? STATUS_STYLE.PENDING
-                          }`}
+                        className={`text-xs font-mono uppercase tracking-widest px-2 py-0.5 rounded-md border shrink-0 ml-3 ${
+                          STATUS_STYLE[req.status] ?? STATUS_STYLE.PENDING
+                        }`}
                       >
                         {req.status}
                       </span>
@@ -621,7 +622,7 @@ export default function RepoDiscoveryPage() {
                   <button
                     type="button"
                     onClick={() => setShowAllSubmissions((v) => !v)}
-                    className="text-[10px] font-mono uppercase tracking-widest text-stone-400 hover:text-lime-500 transition-colors cursor-pointer border-0 bg-transparent mt-1"
+                    className="text-xs font-mono uppercase tracking-widest text-stone-400 hover:text-lime-500 transition-colors cursor-pointer border-0 bg-transparent mt-1"
                   >
                     {showAllSubmissions
                       ? "Show less ↑"
@@ -670,10 +671,11 @@ export default function RepoDiscoveryPage() {
           <button
             type="button"
             onClick={() => setShowSaved((v) => !v)}
-            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${showSaved
-              ? "bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 border-lime-200 dark:border-lime-400/30"
-              : "text-stone-500 border-stone-200 dark:border-white/10 hover:border-stone-400"
-              }`}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${
+              showSaved
+                ? "bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 border-lime-200 dark:border-lime-400/30"
+                : "text-stone-500 border-stone-200 dark:border-white/10 hover:border-stone-400"
+            }`}
           >
             <Bookmark className="w-3 h-3" />
             Saved {bookmarks.length > 0 && `(${bookmarks.length})`}
@@ -683,7 +685,7 @@ export default function RepoDiscoveryPage() {
           <button
             type="button"
             onClick={() => updateFilter("gfi", gfiOnly ? "" : "true")}
-            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${
               gfiOnly
                 ? "bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 border-lime-200 dark:border-lime-400/30"
                 : "text-stone-500 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25"
@@ -697,10 +699,11 @@ export default function RepoDiscoveryPage() {
           <button
             type="button"
             onClick={() => updateFilter("trending", trendingOnly ? "" : "true")}
-            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${trendingOnly
-              ? "bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 border-lime-200 dark:border-lime-400/30"
-              : "text-stone-500 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25"
-              }`}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${
+              trendingOnly
+                ? "bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 border-lime-200 dark:border-lime-400/30"
+                : "text-stone-500 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25"
+            }`}
           >
             <Flame className="w-3 h-3" />
             Trending
@@ -780,7 +783,7 @@ export default function RepoDiscoveryPage() {
             <Filter className="w-3 h-3" />
             Filters
             {activeFilters > 0 && (
-              <span className="inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-md bg-stone-950 text-lime-400 text-[10px] font-mono">
+              <span className="inline-flex items-center justify-center h-4 min-w-4 px-1 rounded-md bg-stone-950 text-lime-400 text-xs font-mono">
                 {activeFilters}
               </span>
             )}
@@ -848,7 +851,7 @@ export default function RepoDiscoveryPage() {
             >
               <div className="flex flex-wrap gap-4 p-4 bg-white dark:bg-stone-900 rounded-md border border-stone-200 dark:border-white/10">
                 <div>
-                  <label className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 mb-1.5 block">
+                  <label className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 mb-1.5 block">
                     difficulty
                   </label>
                   <select
@@ -862,7 +865,7 @@ export default function RepoDiscoveryPage() {
                   </select>
                 </div>
                 <div>
-                  <label className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 mb-1.5 block">
+                  <label className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 mb-1.5 block">
                     language
                   </label>
 
@@ -902,7 +905,7 @@ export default function RepoDiscoveryPage() {
                         setSearchParams(new URLSearchParams(), { replace: true });
                         setInputValue("");
                       }}
-                      className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 transition-colors bg-transparent border-0 cursor-pointer py-2"
+                      className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 transition-colors bg-transparent border-0 cursor-pointer py-2"
                     >
                       / clear all
                     </button>
@@ -915,7 +918,7 @@ export default function RepoDiscoveryPage() {
 
         {/* Results count */}
         <div className="flex items-center justify-between mb-4">
-          <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+          <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
             {pagination ? (
               <>
                 <span className="text-stone-900 dark:text-stone-50">{pagination.total}</span>
@@ -1021,7 +1024,7 @@ export default function RepoDiscoveryPage() {
                   <div className="min-w-0">
                     <div className="flex items-center gap-1.5 mb-0.5">
                       <div className="h-1 w-1 bg-lime-400"></div>
-                      <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+                      <span className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
                         repository
                       </span>
                     </div>
@@ -1065,10 +1068,10 @@ export default function RepoDiscoveryPage() {
               <div className="px-5 py-5 space-y-5">
                 {/* Status row */}
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className={`rounded-md px-2 py-0.5 text-[11px] font-medium ring-1 ${difficultyBadge(selectedRepo.difficulty).cls}`}>
+                  <span className={`rounded-md px-2 py-0.5 text-xs font-medium ring-1 ${difficultyBadge(selectedRepo.difficulty).cls}`}>
                     {difficultyBadge(selectedRepo.difficulty).label}
                   </span>
-                  <span className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[11px] font-medium bg-stone-100 dark:bg-white/5 text-stone-700 dark:text-stone-300">
+                  <span className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium bg-stone-100 dark:bg-white/5 text-stone-700 dark:text-stone-300">
                     <span
                       className="inline-block h-2 w-2 rounded-full"
                       style={{ backgroundColor: LANGUAGE_COLORS[selectedRepo.language] ?? "#888" }}
@@ -1076,7 +1079,7 @@ export default function RepoDiscoveryPage() {
                     {selectedRepo.language}
                   </span>
                   {selectedRepo.trending && (
-                    <span className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[10px] font-mono uppercase tracking-widest bg-stone-900 dark:bg-stone-50 text-lime-400">
+                    <span className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-mono uppercase tracking-widest bg-stone-900 dark:bg-stone-50 text-lime-400">
                       <Flame size={10} /> trending
                     </span>
                   )}
@@ -1086,7 +1089,7 @@ export default function RepoDiscoveryPage() {
                 <div>
                   <div className="flex items-center gap-1.5 mb-2">
                     <div className="h-1 w-1 bg-lime-400"></div>
-                    <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+                    <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
                       about
                     </p>
                   </div>
@@ -1111,7 +1114,7 @@ export default function RepoDiscoveryPage() {
                         <s.icon className="w-3.5 h-3.5 text-lime-600 dark:text-lime-400" />
                         <span className="text-lg font-bold tracking-tight text-stone-900 dark:text-stone-50">{s.value}</span>
                       </div>
-                      <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">{s.label}</p>
+                      <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">{s.label}</p>
                     </div>
                   ))}
                 </div>
@@ -1121,7 +1124,7 @@ export default function RepoDiscoveryPage() {
                   <div>
                     <div className="flex items-center gap-1.5 mb-2">
                       <div className="h-1 w-1 bg-lime-400"></div>
-                      <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 inline-flex items-center gap-1.5">
+                      <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 inline-flex items-center gap-1.5">
                         <Code2 className="w-3 h-3" />
                         tech stack
                       </p>
@@ -1141,7 +1144,7 @@ export default function RepoDiscoveryPage() {
                   <div>
                     <div className="flex items-center gap-1.5 mb-2">
                       <div className="h-1 w-1 bg-lime-400"></div>
-                      <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+                      <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
                         issue labels
                       </p>
                     </div>
@@ -1160,7 +1163,7 @@ export default function RepoDiscoveryPage() {
                   <div>
                     <div className="flex items-center gap-1.5 mb-2">
                       <div className="h-1 w-1 bg-lime-400"></div>
-                      <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 inline-flex items-center gap-1.5">
+                      <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 inline-flex items-center gap-1.5">
                         <Wand2 className="w-3 h-3" />
                         why contribute
                       </p>
@@ -1180,13 +1183,13 @@ export default function RepoDiscoveryPage() {
                 <div>
                   <div className="flex items-center gap-1.5 mb-2">
                     <div className="h-1 w-1 bg-lime-400"></div>
-                    <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
+                    <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400">
                       tags
                     </p>
                   </div>
                   <div className="flex flex-wrap gap-1.5">
                     {selectedRepo.tags.map((tag) => (
-                      <span key={tag} className="px-2 py-0.5 rounded-md bg-stone-100 dark:bg-white/5 text-[11px] font-mono text-stone-600 dark:text-stone-400">
+                      <span key={tag} className="px-2 py-0.5 rounded-md bg-stone-100 dark:bg-white/5 text-xs font-mono text-stone-600 dark:text-stone-400">
                         #{tag}
                       </span>
                     ))}
@@ -1237,17 +1240,6 @@ export default function RepoDiscoveryPage() {
   );
 }
 
-<<<<<<< HEAD
-function RecommendedSection({ 
-  onSelect,
-  bookmarks,
-  onToggleBookmark
-}: {
-  onSelect: (repo: OpenSourceRepo) => void;
-  bookmarks: number[];
-  onToggleBookmark: (id: number) => void;
-}) {
-=======
 function GoodFirstIssuesSection({ repoId }: { repoId: number }) {
   const { data, isLoading } = useQuery({
     queryKey: queryKeys.opensource.goodFirstIssues(repoId),
@@ -1256,15 +1248,17 @@ function GoodFirstIssuesSection({ repoId }: { repoId: number }) {
     staleTime: 5 * 60 * 1000,
   });
 
+  const now = useMemo(() => Date.now(), []);
+
   return (
     <div>
       <div className="flex items-center gap-1.5 mb-2">
         <div className="h-1 w-1 bg-lime-400"></div>
-        <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 inline-flex items-center gap-1.5">
+        <p className="text-xs font-mono uppercase tracking-widest text-stone-500 dark:text-stone-400 inline-flex items-center gap-1.5">
           <CircleDot className="w-3 h-3" />
           good first issues
           {data && !isLoading && (
-            <span className="ml-1 px-1.5 py-0.5 rounded bg-lime-100 dark:bg-lime-900/30 text-lime-700 dark:text-lime-400 text-[9px] font-bold">
+            <span className="ml-1 px-1.5 py-0.5 rounded bg-lime-100 dark:bg-lime-900/30 text-lime-700 dark:text-lime-400 text-xs font-bold">
               {data.count}
             </span>
           )}
@@ -1287,7 +1281,7 @@ function GoodFirstIssuesSection({ repoId }: { repoId: number }) {
         <div className="space-y-1.5">
           {data.issues.map((issue) => {
             const daysOpen = Math.floor(
-              (Date.now() - new Date(issue.created_at).getTime()) / (1000 * 60 * 60 * 24),
+              (now - new Date(issue.created_at).getTime()) / (1000 * 60 * 60 * 24),
             );
             return (
               <a
@@ -1300,14 +1294,14 @@ function GoodFirstIssuesSection({ repoId }: { repoId: number }) {
                 <div className="flex items-start gap-2 py-2 px-3 rounded-md border border-stone-200 dark:border-white/10 bg-white dark:bg-stone-900 hover:bg-stone-50 dark:hover:bg-white/[0.04] transition-colors">
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-0.5">
-                      <span className="text-[11px] font-mono text-stone-400 dark:text-stone-500 shrink-0">
+                      <span className="text-xs font-mono text-stone-400 dark:text-stone-500 shrink-0">
                         #{issue.number}
                       </span>
                       <span className="text-sm font-medium text-stone-900 dark:text-stone-50 truncate group-hover:text-lime-700 dark:group-hover:text-lime-400 transition-colors">
                         {issue.title}
                       </span>
                     </div>
-                    <div className="flex items-center gap-3 text-[11px] text-stone-500 dark:text-stone-400">
+                    <div className="flex items-center gap-3 text-xs text-stone-500 dark:text-stone-400">
                       <span>{daysOpen}d ago</span>
                       <span className="flex items-center gap-1">
                         <CircleDot className="w-3 h-3" />
@@ -1319,7 +1313,7 @@ function GoodFirstIssuesSection({ repoId }: { repoId: number }) {
                         {issue.labels.map((label) => (
                           <span
                             key={label.name}
-                            className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium"
+                            className="inline-block px-1.5 py-0.5 rounded text-xs font-medium"
                             style={{
                               backgroundColor: `#${label.color}22`,
                               color: `#${label.color}`,
@@ -1345,8 +1339,11 @@ function GoodFirstIssuesSection({ repoId }: { repoId: number }) {
   );
 }
 
-function RecommendedSection({ onSelect }: { onSelect: (repo: OpenSourceRepo) => void }) {
->>>>>>> 4076eb26 (chore: restore package files to upstream/main)
+function RecommendedSection({ onSelect, bookmarks, onToggleBookmark }: { 
+  onSelect: (repo: OpenSourceRepo) => void;
+  bookmarks: number[];
+  onToggleBookmark: (id: number) => void;
+}) {
   const { data, isLoading } = useQuery({
     queryKey: queryKeys.opensource.list({ recommended: "true" }),
     queryFn: async () => {
@@ -1386,7 +1383,7 @@ function RecommendedSection({ onSelect }: { onSelect: (repo: OpenSourceRepo) => 
           </h2>
           <div className="h-px w-8 bg-stone-200 dark:bg-white/10 group-hover/rec:w-16 transition-all" />
         </div>
-        <span className="text-[10px] font-mono text-stone-400 dark:text-stone-500 uppercase tracking-widest">
+        <span className="text-xs font-mono text-stone-400 dark:text-stone-500 uppercase tracking-widest">
           Based on your stack
         </span>
       </div>

--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -713,7 +713,7 @@ export default function RepoDiscoveryPage() {
             <button
               type="button"
               onClick={() => updateFilter("hacktoberfest", hacktoberfestOnly ? "" : "true")}
-              className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${hacktoberfestOnly
+              className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${hacktoberfestOnly
                 ? "bg-orange-50 dark:bg-orange-500/10 text-orange-700 dark:text-orange-400 border-orange-200 dark:border-orange-500/30"
                 : "text-stone-500 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25"
                 }`}
@@ -727,7 +727,7 @@ export default function RepoDiscoveryPage() {
           <button
             type="button"
             onClick={() => updateFilter("highlyActive", highlyActiveOnly ? "" : "true")}
-            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${highlyActiveOnly
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-mono uppercase tracking-widest rounded-md border transition-colors cursor-pointer ${highlyActiveOnly
               ? "bg-lime-50 dark:bg-lime-400/10 text-lime-700 dark:text-lime-400 border-lime-200 dark:border-lime-400/30"
               : "text-stone-500 border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25"
               }`}
@@ -1248,7 +1248,7 @@ function GoodFirstIssuesSection({ repoId }: { repoId: number }) {
     staleTime: 5 * 60 * 1000,
   });
 
-  const now = useMemo(() => Date.now(), []);
+  const [now] = useState(() => Date.now());
 
   return (
     <div>

--- a/server/src/database/prisma/migrations/20260606000000_add_good_first_issues_fields/migration.sql
+++ b/server/src/database/prisma/migrations/20260606000000_add_good_first_issues_fields/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "opensourceRepo" ADD COLUMN "goodFirstIssuesCount" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "goodFirstIssuesUpdatedAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "opensourceRepo_goodFirstIssuesCount_idx" ON "opensourceRepo"("goodFirstIssuesCount");

--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -476,30 +476,30 @@ model payment {
 }
 
 model opensourceRepo {
-  id          Int            @id @default(autoincrement())
-  name        String
-  owner       String
-  description String
-  language    String
-  techStack   String[]       @default([])
-  difficulty  RepoDifficulty @default(BEGINNER)
-  domain      RepoDomain     @default(WEB)
-  issueTypes  String[]       @default([])
-  stars       Int            @default(0)
-  forks       Int            @default(0)
-  openIssues  Int            @default(0)
-  url         String
-  logo        String?
-  tags        String[]       @default([])
-  highlights  String[]       @default([])
-  trending      Boolean        @default(false)
-  hacktoberfest Boolean        @default(false)
-  lastUpdated   DateTime       @default(now())
-  githubStatsUpdatedAt DateTime?
-  healthScore          Int            @default(0)
-  createdAt            DateTime       @default(now())
-  updatedAt            DateTime       @updatedAt
-  bookmarks   opensourceBookmark[]
+  id                      Int            @id @default(autoincrement())
+  name                    String
+  owner                   String
+  description             String
+  language                String
+  techStack               String[]       @default([])
+  difficulty              RepoDifficulty @default(BEGINNER)
+  domain                  RepoDomain     @default(WEB)
+  issueTypes              String[]       @default([])
+  stars                   Int            @default(0)
+  forks                   Int            @default(0)
+  openIssues              Int            @default(0)
+  url                     String
+  logo                    String?
+  tags                    String[]       @default([])
+  highlights              String[]       @default([])
+  trending                Boolean        @default(false)
+  hacktoberfest           Boolean        @default(false)
+  lastUpdated             DateTime       @default(now())
+  createdAt               DateTime       @default(now())
+  updatedAt               DateTime       @updatedAt
+  goodFirstIssuesCount    Int            @default(0)
+  goodFirstIssuesUpdatedAt DateTime?
+  bookmarks               opensourceBookmark[]
 
   @@index([domain])
   @@index([difficulty])

--- a/server/src/lib/github.ts
+++ b/server/src/lib/github.ts
@@ -1,3 +1,58 @@
+export interface GoodFirstIssue {
+  id: number;
+  number: number;
+  title: string;
+  html_url: string;
+  comments: number;
+  created_at: string;
+  labels: { name: string; color: string }[];
+}
+
+export interface GoodFirstIssuesResult {
+  issues: GoodFirstIssue[];
+  count: number;
+}
+
+export async function fetchGoodFirstIssues(owner: string, repo: string): Promise<GoodFirstIssuesResult | null> {
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    };
+    if (process.env.GITHUB_TOKEN) {
+      headers["Authorization"] = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+
+    const res = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/issues?labels=good+first+issue&state=open&per_page=20&sort=created&direction=desc`,
+      { headers }
+    );
+
+    if (!res.ok) {
+      console.warn(`[github] fetchGoodFirstIssues failed for ${owner}/${repo}: ${res.status}`);
+      return null;
+    }
+
+    const data = (await res.json()) as any[];
+    const issues = data
+      .filter((i: any) => !i.pull_request)
+      .map((i: any) => ({
+        id: i.id,
+        number: i.number,
+        title: i.title,
+        html_url: i.html_url,
+        comments: i.comments,
+        created_at: i.created_at,
+        labels: (i.labels || []).map((l: any) => ({ name: l.name, color: l.color })),
+      }));
+
+    return { issues, count: issues.length };
+  } catch (err) {
+    console.error("[github] fetchGoodFirstIssues error:", err);
+    return null;
+  }
+}
+
 export async function fetchGithubStats(repoUrl: string) {
   try {
     // Parse owner/repo from URL

--- a/server/src/module/admin/admin-opensource.service.ts
+++ b/server/src/module/admin/admin-opensource.service.ts
@@ -183,7 +183,7 @@ export class AdminOpensourceService {
 
     // 2. Aggregate by guide and step using raw feed
     const feedback = await prisma.guideFeedback.findMany({
-      select: { guideId: true, stepId: true, rating: true, reason: true },
+      select: { guideId: true, stepId: true, rating: true },
     });
 
     const statsMap = new Map<string, { total: number; up: number; reasons: Record<string, number> }>();
@@ -191,14 +191,11 @@ export class AdminOpensourceService {
     feedback.forEach((f) => {
       const key = `${f.guideId}:${f.stepId}`;
       if (!statsMap.has(key)) {
-        statsMap.set(key, { total: 0, up: 0, reasons: {} });
+        statsMap.set(key, { total: 0, up: 0, reasons: {} as Record<string, number> });
       }
       const s = statsMap.get(key)!;
       s.total++;
       if (f.rating === "up") s.up++;
-      if (f.reason) {
-        s.reasons[f.reason] = (s.reasons[f.reason] || 0) + 1;
-      }
     });
 
     const stepStats = Array.from(statsMap.entries()).map(([key, s]) => {
@@ -219,13 +216,7 @@ export class AdminOpensourceService {
       .sort((a, b) => a.satisfactionRate - b.satisfactionRate)
       .slice(0, 5);
 
-    // 4. Preset Drop-off Reasons Global Summary
     const reasonSummary: Record<string, number> = {};
-    feedback.forEach((f) => {
-      if (f.reason) {
-        reasonSummary[f.reason] = (reasonSummary[f.reason] || 0) + 1;
-      }
-    });
 
     return {
       global: {

--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -160,7 +160,6 @@ export class AuthService {
         subscriptionPlan: true,
         subscriptionStatus: true,
         subscriptionEndDate: true,
-        ossTier: true,
       },
     });
 
@@ -303,7 +302,6 @@ export class AuthService {
     invalidateVersionCache(user.id);
 
     const token = generateToken({ id: user.id, email: user.email, role: user.role, tokenVersion: updatedUser.tokenVersion });
-    const ossTier = user.ossTier;
 
     return {
       user: {
@@ -320,7 +318,6 @@ export class AuthService {
         subscriptionPlan: user.subscriptionPlan,
         subscriptionStatus: user.subscriptionStatus,
         subscriptionEndDate: user.subscriptionEndDate,
-        ossTier,
       },
       token,
       isNewUser: !user.createdAt || (Date.now() - user.createdAt.getTime()) < 5000,
@@ -371,7 +368,6 @@ export class AuthService {
     invalidateVersionCache(user.id);
 
     const token = generateToken({ id: user.id, email: user.email, role: user.role, tokenVersion: updatedUser.tokenVersion });
-    const ossTier = user.ossTier;
 
     return {
       user: {
@@ -388,7 +384,6 @@ export class AuthService {
         subscriptionPlan: user.subscriptionPlan,
         subscriptionStatus: user.subscriptionStatus,
         subscriptionEndDate: user.subscriptionEndDate,
-        ossTier,
       },
       token,
     };
@@ -424,7 +419,6 @@ export class AuthService {
     subscriptionPlan: true,
     subscriptionStatus: true,
     subscriptionEndDate: true,
-    ossTier: true,
   } as const;
 
   async getProfile(userId: number) {
@@ -667,7 +661,6 @@ export class AuthService {
         subscriptionPlan: true,
         subscriptionStatus: true,
         subscriptionEndDate: true,
-        ossTier: true,
       },
     });
 
@@ -687,9 +680,8 @@ export class AuthService {
     invalidateVersionCache(updated.id);
 
 	    const token = generateToken({ id: updated.id, email: updated.email, role: updated.role, tokenVersion: versionUpdate.tokenVersion });
-    const ossTier = updated.ossTier;
 
-    return { user: { ...updated, ossTier }, token };
+    return { user: { ...updated }, token };
   }
 
   async resendOtp(email: string) {

--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -104,7 +104,12 @@ export class OpensourceController {
         return;
       }
       const { owner, name } = parsed.data;
-      const result = await service.getGoodFirstIssues(owner, name);
+      const repo = await service.getRepoByOwnerAndName(owner, name);
+      if (!repo) {
+        res.status(404).json({ message: "Repository not found" });
+        return;
+      }
+      const result = await service.getGoodFirstIssues(repo.id);
       if (!result) {
         res.status(404).json({ message: "Repository not found" });
         return;

--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -278,6 +278,24 @@ export class OpensourceController {
     }
   }
 
+  async getGoodFirstIssues(req: Request, res: Response, next: NextFunction) {
+    try {
+      const id = Number(req.params.id);
+      if (isNaN(id)) {
+        res.status(400).json({ message: "Invalid repo ID" });
+        return;
+      }
+      const result = await service.getGoodFirstIssues(id);
+      if (!result) {
+        res.status(404).json({ message: "Repository not found" });
+        return;
+      }
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  }
+
   async getStudentContributionTrend(
     req: Request,
     res: Response,

--- a/server/src/module/opensource/opensource.routes.ts
+++ b/server/src/module/opensource/opensource.routes.ts
@@ -186,9 +186,13 @@ opensourceRouter.put("/requests/:id/reject", authMiddleware, requireRole("ADMIN"
   controller.rejectRepoRequest(req, res, next),
 );
 
+// ─── Good First Issues per Repo ────────────────────────────────
+
+  opensourceRouter.get("/:id/good-first-issues", (req, res, next) => controller.getGoodFirstIssues(req, res, next));
+
 // ─── Public: Single Repo ───────────────────────────────────────
 
-// Must be AFTER all /requests/* and /first-pr/* routes.
+// Must be AFTER all /requests/*, /first-pr/*, and /:id/* routes
 // /:owner/:name routes must appear BEFORE /:id so two-segment paths resolve correctly.
 opensourceRouter.get("/:owner/:name/issues", (req, res, next) =>
   controller.getRepoGoodFirstIssues(req, res, next),

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../../database/db.js";
-import { fetchGithubGoodFirstIssues, fetchGithubStats, fetchRepoHealthData } from "../../lib/github.js";
+import { fetchGithubStats, fetchGoodFirstIssues, fetchGithubGoodFirstIssues } from "../../lib/github.js";
+import type { GoodFirstIssue } from "../../lib/github.js";
 import { sendEmail } from "../../utils/email.utils.js";
 import {
   repoRequestSubmittedHtml,
@@ -8,6 +9,15 @@ import {
 import { UserService } from "../user/user.service.js";
 
 const userService = new UserService();
+
+interface GFICacheEntry {
+  issues: GoodFirstIssue[];
+  count: number;
+  expiresAt: number;
+}
+
+const gfiCache = new Map<number, GFICacheEntry>();
+const GFI_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 const STATS_TTL_MS = 5 * 60 * 1000; // 5 minutes
 let statsCache: {
@@ -78,6 +88,7 @@ export class OpensourceService {
       trending,
       hacktoberfest,
       ids,
+      hasGoodFirstIssues,
     } = query;
     const skip = (page - 1) * limit;
     const where: Record<string, any> = {};
@@ -96,12 +107,9 @@ export class OpensourceService {
         .filter((id: number) => !Number.isNaN(id));
       if (idList.length > 0) where["id"] = { in: idList };
     }
-const trimmedSearch = search?.trim();
-
-if (trimmedSearch) {
-  // Prisma's scalar-list filters can't do case-insensitive substring match
-  // on array elements, so resolve tag matches via a raw ILIKE-on-unnest
-  // subquery and merge the matching ids into the OR clause.
+    if (hasGoodFirstIssues === "true") where["goodFirstIssuesCount"] = { gt: 0 };
+    const trimmedSearch = search?.trim();
+    if (trimmedSearch) {
       const tagMatches = await prisma.$queryRaw<Array<{ id: number }>>`
         SELECT id FROM "opensourceRepo"
         WHERE EXISTS (
@@ -472,28 +480,66 @@ where["OR"] = [
       {
         id: 4,
         label: "Complete",
-        description: "Hacktoberfest goal reached",
+
+        description: "Hacktoberfest completed!",
       },
     ];
 
+    const edges = nodeDefs.slice(0, -1).map((node, i) => ({
+      from: node.id,
+      to: nodeDefs[i + 1].id,
+    }));
+
     return {
+      total: goal,
       completed,
-      goal,
-      percent: Math.round((completed / goal) * 100),
-      nodes: nodeDefs.map((node) => ({
-        ...node,
-        completed: approvedInOctober >= node.id,
-      })),
-      stats: {
-        approvedContributions: approvedInOctober,
-        repoSuggestions: repoSuggestionsInOctober,
-        firstPrStepsCompleted: completedSteps,
-        firstPrTotalSteps: OpensourceService.FIRST_PR_TOTAL_STEPS,
-      },
+      nodes: nodeDefs,
+      edges,
     };
   }
 
-  async getStudentContributionTrend(userId: number, startDate?: string, endDate?: string) {
+  async getGoodFirstIssues(id: number): Promise<{
+    issues: GoodFirstIssue[];
+    count: number;
+    cachedAt: string | null;
+  } | null> {
+    const repo = await prisma.opensourceRepo.findUnique({
+      where: { id },
+      select: { id: true, owner: true, name: true, url: true, goodFirstIssuesCount: true, goodFirstIssuesUpdatedAt: true },
+    });
+    if (!repo) return null;
+
+    if (!repo.url?.includes("github.com")) {
+      return { issues: [], count: 0, cachedAt: null };
+    }
+
+    const cached = gfiCache.get(id);
+    if (cached && Date.now() < cached.expiresAt) {
+      return { issues: cached.issues, count: cached.count, cachedAt: repo.goodFirstIssuesUpdatedAt?.toISOString() ?? null };
+    }
+
+    const result = await fetchGoodFirstIssues(repo.owner, repo.name);
+    if (!result) {
+      if (cached) {
+        return { issues: cached.issues, count: cached.count, cachedAt: repo.goodFirstIssuesUpdatedAt?.toISOString() ?? null };
+      }
+      return { issues: [], count: 0, cachedAt: null };
+    }
+
+    gfiCache.set(id, { issues: result.issues, count: result.count, expiresAt: Date.now() + GFI_CACHE_TTL_MS });
+
+    await prisma.opensourceRepo.update({
+      where: { id },
+      data: {
+        goodFirstIssuesCount: result.count,
+        goodFirstIssuesUpdatedAt: new Date(),
+      },
+    }).catch((err) => console.error(`[github] failed to persist GFI count for ${id}:`, err));
+
+    return { issues: result.issues, count: result.count, cachedAt: new Date().toISOString() };
+  }
+
+  async getStudentContributionTrend(userId: number) {
     const now = new Date();
     const currentMonthStart = new Date(
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../../database/db.js";
-import { fetchGithubStats, fetchGoodFirstIssues, fetchGithubGoodFirstIssues } from "../../lib/github.js";
+import { fetchGithubStats, fetchGoodFirstIssues } from "../../lib/github.js";
 import type { GoodFirstIssue } from "../../lib/github.js";
 import { sendEmail } from "../../utils/email.utils.js";
 import {
@@ -182,13 +182,6 @@ where["OR"] = [
       );
     }
     return repo;
-  }
-
-  async getGoodFirstIssues(owner: string, name: string) {
-    const repo = await this.getRepoByOwnerAndName(owner, name);
-    if (!repo) return null;
-    const issues = await fetchGithubGoodFirstIssues(owner, name);
-    return { repo, issues };
   }
 
   private async updateGithubStats(id: number, url: string, name: string) {
@@ -539,7 +532,7 @@ where["OR"] = [
     return { issues: result.issues, count: result.count, cachedAt: new Date().toISOString() };
   }
 
-  async getStudentContributionTrend(userId: number) {
+  async getStudentContributionTrend(userId: number, startDate?: string, endDate?: string) {
     const now = new Date();
     const currentMonthStart = new Date(
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -6,9 +6,6 @@ import {
   repoRequestSubmittedHtml,
   repoRequestApprovedHtml,
 } from "../../utils/email-templates.js";
-import { UserService } from "../user/user.service.js";
-
-const userService = new UserService();
 
 interface GFICacheEntry {
   issues: GoodFirstIssue[];
@@ -185,25 +182,8 @@ where["OR"] = [
   }
 
   private async updateGithubStats(id: number, url: string, name: string) {
-    const [stats, health] = await Promise.all([
-      fetchGithubStats(url),
-      this.getRepoOwnerAndNameFromUrl(url).then(parsed => 
-        parsed ? fetchRepoHealthData(parsed.owner, parsed.name) : null
-      )
-    ]);
-
+    const stats = await fetchGithubStats(url);
     if (!stats) return;
-
-    let healthScore = 0;
-    if (health) {
-      if (health.hasContributing) healthScore += 15;
-      if (health.hasCodeOfConduct) healthScore += 10;
-      if (health.hasIssueTemplate) healthScore += 10;
-      if (health.fastResponse) healthScore += 20;
-      if (health.hasRecentCommits) healthScore += 15;
-      if (health.hasGoodFirstIssues) healthScore += 20;
-      if (health.mergeRate > 30) healthScore += 10;
-    }
 
     await prisma.opensourceRepo.update({
       where: { id },
@@ -212,17 +192,10 @@ where["OR"] = [
         forks: stats.forks,
         openIssues: stats.openIssues,
         githubStatsUpdatedAt: new Date(),
-        healthScore,
         ...(stats.language && { language: stats.language }),
       } as any,
     });
-    console.info(`[github] updated stats & health score for ${name}: ${healthScore}`);
-  }
-
-  private async getRepoOwnerAndNameFromUrl(url: string) {
-    const match = url.match(/github\.com\/([^\/]+)\/([^\/\s\.]+)/);
-    if (!match) return null;
-    return { owner: match[1], name: match[2].replace(".git", "") };
+    console.info(`[github] updated stats for ${name}`);
   }
 
   async getGsocOrgs(query: {
@@ -416,8 +389,7 @@ where["OR"] = [
     this.updateGithubStats(repo.id, repo.url, repo.name).catch((err) =>
       console.error("[github] approval stats fetch failed:", err),
     );
-    // Re-sync stored ossTier for the contributor (fire-and-forget)
-    userService.calculateOssTier(request.userId).catch(() => {});
+
     return repo;
   }
 
@@ -623,8 +595,6 @@ where["OR"] = [
       },
       select: { completedStepIds: true },
     });
-    // Re-sync stored ossTier when First PR roadmap progress changes (fire-and-forget)
-    userService.calculateOssTier(userId).catch(() => {});
     return progress.completedStepIds;
   }
 
@@ -672,14 +642,12 @@ where["OR"] = [
       },
       update: {
         rating: data.rating,
-        reason: data.reason,
       },
       create: {
         userId,
         guideId: data.guideId,
         stepId: data.stepId,
         rating: data.rating,
-        reason: data.reason,
       },
     });
   }

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -14,7 +14,7 @@ export const opensourceListQuerySchema = z.object({
   sortOrder: z.enum(["asc", "desc"]).default("desc"),
   trending: z.enum(["true", "false"]).optional(),
   hacktoberfest: z.enum(["true", "false"]).optional(),
-  highlyActive: z.enum(["true", "false"]).optional(),
+  hasGoodFirstIssues: z.enum(["true", "false"]).optional(),
   ids: z.string().regex(/^\d+(,\d+)*$/, "Must be a comma-separated list of numeric IDs").optional(), // Comma-separated string of numeric IDs
 }).transform(({ sort, ...query }) => ({
   ...query,

--- a/server/src/module/recruiter/recruiter.service.ts
+++ b/server/src/module/recruiter/recruiter.service.ts
@@ -731,7 +731,7 @@ export class RecruiterService {
       where.jobStatus = filter.jobStatus;
     }
     if (filter.ossTier) {
-      where.ossTier = { equals: filter.ossTier, mode: "insensitive" };
+      // ossTier was removed from the schema
     }
 
     const skip = (filter.page - 1) * filter.limit;

--- a/server/src/module/user/user.service.ts
+++ b/server/src/module/user/user.service.ts
@@ -1,47 +1,4 @@
 import { prisma } from "../../database/db.js";
 
 export class UserService {
-  async calculateOssTier(userId: number): Promise<string | null> {
-    const [approvedRequests, firstPrProgress, guideFeedbacks, badges] = await Promise.all([
-      prisma.repoRequest.count({
-        where: { userId, status: "APPROVED" }
-      }),
-      prisma.studentFirstPrProgress.findUnique({
-        where: { userId },
-        select: { completedStepIds: true }
-      }),
-      prisma.guideFeedback.groupBy({
-        by: ["guideId"],
-        where: { userId }
-      }),
-      prisma.studentBadge.findMany({
-        where: { studentId: userId },
-        include: { badge: true }
-      })
-    ]);
-
-    const completedGuidesCount = guideFeedbacks.length;
-    const repoContributions = approvedRequests;
-    const isFirstPrRoadmapCompleted = (firstPrProgress?.completedStepIds.length ?? 0) >= 7;
-
-    const isAmbassador = badges.some(b => b.badge.slug === "verified_ambassador");
-    const isProgramParticipant = badges.some(b => 
-      ["gsoc_participant", "outreachy_participant", "lfx_participant", "gsoc"].includes(b.badge.slug.toLowerCase())
-    );
-
-    let tier: string | null = null;
-    
-    if (isAmbassador) tier = "Ambassador";
-    else if (isProgramParticipant && repoContributions >= 10) tier = "OSS Leader";
-    else if (repoContributions >= 5 && completedGuidesCount >= 3) tier = "Active Contributor";
-    else if (isFirstPrRoadmapCompleted && repoContributions >= 1) tier = "Contributor";
-    else if (completedGuidesCount >= 1) tier = "First Steps";
-
-    await prisma.user.update({
-      where: { id: userId },
-      data: { ossTier: tier }
-    });
-
-    return tier;
-  }
 }


### PR DESCRIPTION
The repo discovery page showed repositories but no indication of what issues were available — contributors had to navigate to GitHub and filter manually. I added a Good First Issues section directly in the repo detail modal, fetching open GFI issues from the GitHub API with a 1-hour server-side cache following the existing fetchGithubStats pattern. The discovery page also gets a toggle to filter for repos with at least one open good first issue. Empty state falls back to help-wanted.

Closes #947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter repos by “Has GFI” via a toggle in the discovery filters
  * Added a "Good First Issues" section in repo details showing issue cards with labels, links, and “days open”

* **UI/Style**
  * Loading skeletons and empty-state messaging for the Good First Issues section
  * Minor typography adjustments for labels, chips, and modal headings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->