### PR TITLE
refactor: centralize TanStack Query keys for external jobs (#1899)

### DIFF
--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -164,6 +164,12 @@ export const queryKeys = {
       ["scraped-jobs", "list", params] as const,
     detail: (id: string | number) => ["scraped-jobs", "detail", id] as const,
   },
+  
+  externalJobs: {
+    detail: (slug: string) => ["external-job", slug] as const,
+    similar: (id: string | number) => ["external-job-similar", id] as const,
+    status: (id: string | number) => ["external-job-status", id] as const,
+  },
 
   // Professors
   professors: {

--- a/client/src/module/student/jobs/ExternalJobDetailPage.tsx
+++ b/client/src/module/student/jobs/ExternalJobDetailPage.tsx
@@ -44,7 +44,7 @@ export default function ExternalJobDetailPage() {
   const [applied, setApplied] = useState(false);
 
   const { data: job, isLoading, error } = useQuery({
-    queryKey: ["external-job", slug],
+    queryKey: queryKeys.externalJobs.detail(slug!),
     queryFn: async () => {
       const res = await api.get(`/external-jobs/${slug}`);
       return res.data.job as ExternalJob;
@@ -55,7 +55,7 @@ export default function ExternalJobDetailPage() {
   });
 
   const { data: similarJobs = [] } = useQuery({
-    queryKey: ["external-job-similar", job?.id],
+    queryKey: queryKeys.externalJobs.similar(job?.id as number),
     queryFn: async () => {
       const res = await api.get(`/external-jobs`, { params: { limit: 20 } });
       const all = (res.data.jobs || []) as ExternalJob[];
@@ -76,7 +76,7 @@ export default function ExternalJobDetailPage() {
   });
 
   useQuery({
-    queryKey: ["external-job-status", job?.id],
+    queryKey: queryKeys.externalJobs.status(job?.id as number),
     queryFn: async () => {
       const res = await api.get(`/student/external-jobs/${job!.id}/status`);
       if (res.data.applied) setApplied(true);


### PR DESCRIPTION
# Pull Request

## Description
Centralizes TanStack Query keys to eliminate DRY violations and prevent cache invalidation failures caused by inconsistent string literal keys across components. 

Specifically:
- Added `externalJobs` to the centralized `queryKeys` object in `client/src/lib/query-keys.ts` (`detail`, `similar`, `status`).
- Replaced the inline string query keys in `client/src/module/student/jobs/ExternalJobDetailPage.tsx` with calls to the centralized `queryKeys` functions.
*(Note: `JobBrowsePage`, `SavedJobsPage`, `MyApplicationsPage`, and `SignalsPage` were verified and confirmed to already use the centralized `queryKeys` imported from `client/src/lib/query-keys.ts` from previous refactoring).*

## Related Issue
Fixes #1899

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
- Verified `ExternalJobDetailPage.tsx` successfully queries details, similar jobs, and application status using the centralized keys.
- Ran `tsc --noEmit` to ensure TypeScript strict mode passes with 0 errors.

## Screenshots / Video

_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [ ] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized query key management for external job data queries to improve internal consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->