### PR TITLE
refactor : extract CARD_BASE styling constant to resolve DRY violation

### DIFF
--- a/client/src/lib/card-styles.ts
+++ b/client/src/lib/card-styles.ts
@@ -1,0 +1,2 @@
+export const CARD_BASE =
+  "group relative flex flex-col bg-white dark:bg-stone-900 p-5 rounded-md border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30 transition-colors h-full no-underline";

--- a/client/src/module/student/jobs/GovInternshipsPage.tsx
+++ b/client/src/module/student/jobs/GovInternshipsPage.tsx
@@ -20,6 +20,8 @@ import { canonicalUrl } from "../../../lib/seo.utils";
 import api from "../../../lib/axios";
 import { queryKeys } from "../../../lib/query-keys";
 import type { Pagination } from "../../../lib/types";
+import { CARD_BASE } from "../../../lib/card-styles";
+
 
 interface Internship {
   id: number;
@@ -49,8 +51,6 @@ function Kicker({ children }: { children: React.ReactNode }) {
 }
 
 function InternshipCard({ internship }: { internship: Internship }) {
-  const cardClassName = "group relative flex flex-col bg-white dark:bg-stone-900 p-5 rounded-md border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30 transition-colors h-full no-underline";
-
   const cardContent = (
     <>
       <div className="flex items-start justify-between gap-3 mb-3">
@@ -98,13 +98,13 @@ function InternshipCard({ internship }: { internship: Internship }) {
 
   if (internship.applyUrl) {
     return (
-      <a href={internship.applyUrl} target="_blank" rel="noopener noreferrer" className={cardClassName}>
+      <a href={internship.applyUrl} target="_blank" rel="noopener noreferrer" className={CARD_BASE}>
         {cardContent}
       </a>
     );
   }
 
-  return <div className={cardClassName}>{cardContent}</div>;
+  return <div className={CARD_BASE}>{cardContent}</div>;
 }
 
 export default function GovInternshipsPage() {

--- a/client/src/module/student/jobs/JobBrowsePage.tsx
+++ b/client/src/module/student/jobs/JobBrowsePage.tsx
@@ -24,6 +24,7 @@ import { MetaChip } from "../../../components/ui/MetaChip";
 import { canonicalUrl } from "../../../lib/seo.utils";
 import api from "../../../lib/axios";
 import { queryKeys } from "../../../lib/query-keys";
+import { CARD_BASE } from "../../../lib/card-styles";
 import { useSaveJob } from "../../../hooks/useSaveJob";
 import type {
   ExternalJob,
@@ -47,9 +48,6 @@ const FILTER_TAGS = [
 
 const SALARY_HAS_CURRENCY = /[₹$€£¥]|\b(USD|EUR|GBP|INR|JPY|CAD|AUD)\b/i;
 
-const cardBase =
-  "group relative flex flex-col bg-white dark:bg-stone-900 p-5 rounded-md border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30 transition-colors h-full no-underline";
-
 function CompanyMark({ label }: { label: string }) {
   return (
     <div className="w-10 h-10 rounded-md bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-white/10 flex items-center justify-center shrink-0 text-stone-900 dark:text-stone-50 text-sm font-bold">
@@ -64,7 +62,7 @@ const ExternalJobCard = React.memo(function ExternalJobCard({ job }: { job: Exte
   const salaryHasCurrency = job.salary ? SALARY_HAS_CURRENCY.test(job.salary) : false;
   const SalaryIcon = salaryHasCurrency ? Wallet : IndianRupee;
   return (
-    <Link to={job.slug ? `/jobs/ext/${job.slug}` : "#"} className={cardBase}>
+    <Link to={job.slug ? `/jobs/ext/${job.slug}` : "#"} className={CARD_BASE}>
       <span className="absolute top-4 right-4 text-[10px] font-mono uppercase tracking-widest text-stone-500 inline-flex items-center gap-1.5">
         <span className="h-1 w-1 bg-lime-400" />
         external
@@ -110,7 +108,7 @@ const ScrapedJobCard = React.memo(function ScrapedJobCard({ job }: { job: Scrape
   const salaryHasCurrency = job.salary ? SALARY_HAS_CURRENCY.test(job.salary) : false;
   const SalaryIcon = salaryHasCurrency ? Wallet : IndianRupee;
   return (
-    <a href={job.applicationUrl} target="_blank" rel="noopener noreferrer" className={cardBase}>
+    <a href={job.applicationUrl} target="_blank" rel="noopener noreferrer" className={CARD_BASE}>
       <span className="absolute top-4 right-4 text-[10px] font-mono uppercase tracking-widest text-stone-500 inline-flex items-center gap-1.5">
         <span className="h-1 w-1 bg-lime-400" />
         {job.source}

--- a/client/src/module/student/jobs/SavedJobsPage.tsx
+++ b/client/src/module/student/jobs/SavedJobsPage.tsx
@@ -8,9 +8,8 @@ import { MetaChip } from "../../../components/ui/MetaChip";
 import { queryKeys } from "../../../lib/query-keys";
 import type { Job } from "../../../lib/types";
 import { useSaveJob } from "../../../hooks/useSaveJob";
+import { CARD_BASE } from "../../../lib/card-styles";
 
-const cardBase =
-  "group relative flex flex-col bg-white dark:bg-stone-900 p-5 rounded-md border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30 transition-colors h-full no-underline";
 
 export default function SavedJobsPage() {
   const { data, isLoading } = useQuery({
@@ -104,7 +103,7 @@ export default function SavedJobsPage() {
               transition={{ delay: i * 0.03 }}
               className="relative"
             >
-              <Link to={`/student/jobs/${job.id}`} className={cardBase}>
+              <Link to={`/student/jobs/${job.id}`} className={CARD_BASE}>
                 <div className="flex items-start gap-3 mb-3">
                   <div className="w-10 h-10 rounded-md bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-white/10 flex items-center justify-center shrink-0 text-stone-900 dark:text-stone-50 text-sm font-bold">
                     {job.company?.charAt(0)?.toUpperCase() || "?"}

--- a/client/src/module/student/jobs/component/jobcard.tsx
+++ b/client/src/module/student/jobs/component/jobcard.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import { Link } from "react-router";
 import { ArrowUpRight } from "lucide-react";
-
-const cardBase =
-  "group relative flex flex-col bg-white dark:bg-stone-900 p-5 rounded-md border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/30 transition-colors h-full no-underline";
+import { CARD_BASE } from "../../../../lib/card-styles";
 
 function CompanyMark({ label }: { label: string }) {
   return (
@@ -107,14 +105,14 @@ const JobCard = React.memo(function JobCard({
 
   if (href) {
     return (
-      <a href={href} target="_blank" rel="noopener noreferrer" className={cardBase}>
+      <a href={href} target="_blank" rel="noopener noreferrer" className={CARD_BASE}>
         {inner}
       </a>
     );
   }
 
   return (
-    <Link to={to ?? "#"} className={cardBase}>
+    <Link to={to ?? "#"} className={CARD_BASE}>
       {inner}
     </Link>
   );


### PR DESCRIPTION
# Pull Request

## Description
Resolved a DRY violation by extracting the duplicate long Tailwind CSS class string for job and internship cards to a shared constant `CARD_BASE` in `client/src/lib/card-styles.ts`. Replaced all inline duplications in the affected pages and components to use this constant.

## Changes Made
- `client/src/lib/card-styles.ts`: Created file and exported the new shared `CARD_BASE` constant.
-   Imported `CARD_BASE` and refactored 
`client/src/module/student/jobs/component/jobcard.tsx`,
`client/src/module/student/jobs/JobBrowsePage.tsx`,
`client/src/module/student/jobs/SavedJobsPage.tsx`,
`client/src/module/student/jobs/GovInternshipsPage.tsx`
 to use the shared style.

## Related Issue
Fixes #1892 

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
- Verified that all modified files compile successfully without typescript errors by running `npm run typecheck` in the `client` directory.
- Confirmed that card layout and style values remain identical to their original configuration.

## Screenshots / Video

_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)
