### PR TITLE
perf(auth): deduplicate concurrent tokenVersion cache misses

### DIFF
--- a/server/src/middleware/auth.middleware.ts
+++ b/server/src/middleware/auth.middleware.ts
@@ -48,9 +48,10 @@ function setCachedVersion(userId: number, version: number): void {
   versionCache.set(userId, { version, expiresAt: Date.now() + TOKEN_VERSION_TTL_MS });
 }
 
-/** Invalidate cache for a user (call on login to force immediate propagation) */
+/** Invalidate cache for a user (call on login to force immediate propagation) and pending in-flight lookup. */
 export function invalidateVersionCache(userId: number): void {
   versionCache.delete(userId);
+  pendingVersionLookups.delete(userId);
 }
 
 /** Extract token from httpOnly cookie first, then Authorization header as fallback */
@@ -85,27 +86,31 @@ async function getTokenVersion(userId: number): Promise<number | null> {
     return user ? user.tokenVersion : null;
   }
 
-  try {
-    const dbQuery: Promise<TokenVersionLookupResult> = prisma.user.findUnique({
-      where: { id: userId },
-      select: { tokenVersion: true },
-    });
+  const dbQuery: Promise<TokenVersionLookupResult> = prisma.user.findUnique({
+    where: { id: userId },
+    select: { tokenVersion: true },
+  });
 
+  try {
     // Register the database query before awaiting it
     // so that concurrent requests can reuse it.
     pendingVersionLookups.set(userId, dbQuery);
 
     const user = await dbQuery;
 
-    if (user) {
+    //Only cache if the query is still active for this user.
+    if (user && pendingVersionLookups.get(userId) === dbQuery) {
       setCachedVersion(userId, user.tokenVersion);
       dbVersion = user.tokenVersion;
     }
   } 
   finally {
     // Remove the in-flight lookup regardless of success or failure.
-    pendingVersionLookups.delete(userId);
-  }
+    // Only remove the query if it is still active for this user.
+    if (pendingVersionLookups.get(userId) === dbQuery) {
+      pendingVersionLookups.delete(userId);
+    }
+  } 
 
   return dbVersion;
 }

--- a/server/src/middleware/auth.middleware.ts
+++ b/server/src/middleware/auth.middleware.ts
@@ -2,12 +2,19 @@ import type { Request, Response, NextFunction } from "express";
 import { verifyToken } from "../utils/jwt.utils.js";
 import { prisma } from "../database/db.js";
 
+type TokenVersionLookupResult = {
+  tokenVersion: number;
+} | null;
+
 // ── In-memory tokenVersion cache (5-minute TTL, 10 000-entry size cap) ──
 const TOKEN_VERSION_TTL_MS = 5 * 60 * 1000;
 const VERSION_CACHE_MAX_SIZE = 10_000;
 
 // insertion-ordered Map: oldest entries are at the front (Map preserves insertion order)
 const versionCache = new Map<number, { version: number; expiresAt: number }>();
+
+// Stores in-flight tokenVersion lookups by user ID.
+const pendingVersionLookups = new Map<number, Promise<TokenVersionLookupResult>>();
 
 // Background sweep: evict expired entries every 5 minutes so stale entries from
 // deleted or logged-out users do not accumulate for the process lifetime.
@@ -61,24 +68,56 @@ function extractToken(req: Request): string | null {
   return null;
 }
 
+// Returns user's tokenVersion from cache or a shared in-flight DB query.
+async function getTokenVersion(userId: number): Promise<number | null> {
+
+  let dbVersion = getCachedVersion(userId);
+
+  if (dbVersion !== null) {
+    return dbVersion;
+  }
+
+  const pendingLookup = pendingVersionLookups.get(userId);
+
+  // Reuse an existing in-flight lookup.
+  if (pendingLookup !== undefined) {
+    const user = await pendingLookup;
+    return user ? user.tokenVersion : null;
+  }
+
+  try {
+    const dbQuery: Promise<TokenVersionLookupResult> = prisma.user.findUnique({
+      where: { id: userId },
+      select: { tokenVersion: true },
+    });
+
+    // Register the database query before awaiting it
+    // so that concurrent requests can reuse it.
+    pendingVersionLookups.set(userId, dbQuery);
+
+    const user = await dbQuery;
+
+    if (user) {
+      setCachedVersion(userId, user.tokenVersion);
+      dbVersion = user.tokenVersion;
+    }
+  } 
+  finally {
+    // Remove the in-flight lookup regardless of success or failure.
+    pendingVersionLookups.delete(userId);
+  }
+
+  return dbVersion;
+}
+
 export async function optionalAuthMiddleware(req: Request, _res: Response, next: NextFunction): Promise<void> {
   const token = extractToken(req);
   if (token) {
     try {
       const decoded = verifyToken(token);
 
-      // Verify tokenVersion (cached), silently discard revoked tokens
-      let dbVersion = getCachedVersion(decoded.id);
-      if (dbVersion === null) {
-        const user = await prisma.user.findUnique({
-          where: { id: decoded.id },
-          select: { tokenVersion: true },
-        });
-        if (user) {
-          dbVersion = user.tokenVersion;
-          setCachedVersion(decoded.id, dbVersion);
-        }
-      }
+      // Verify tokenVersion, silently discard revoked tokens
+      const dbVersion = await getTokenVersion(decoded.id);
 
       if (dbVersion !== null && decoded.tokenVersion === dbVersion) {
         req.user = { id: decoded.id, email: decoded.email, role: decoded.role };
@@ -106,22 +145,12 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
     return;
   }
 
-  // Single-device enforcement: check tokenVersion (cached, 2-min TTL)
-  let dbVersion = getCachedVersion(decoded.id);
+  // Single-device enforcement: resolve current tokenVersion.
+  const dbVersion = await getTokenVersion(decoded.id);
 
   if (dbVersion === null) {
-    const user = await prisma.user.findUnique({
-      where: { id: decoded.id },
-      select: { tokenVersion: true },
-    });
-
-    if (!user) {
-      res.status(401).json({ message: "Session expired. Please log in again." });
-      return;
-    }
-
-    dbVersion = user.tokenVersion;
-    setCachedVersion(decoded.id, dbVersion);
+    res.status(401).json({ message: "Session expired. Please log in again." });
+    return;
   }
 
   if (decoded.tokenVersion !== dbVersion) {


### PR DESCRIPTION
# Pull Request

## Description
- This PR improves the authentication middleware by preventing duplicate database lookups during concurrent tokenVersion cache misses.
- Previously, when a `tokenVersion` cache entry expired, multiple concurrent requests for the same user could execute identical `prisma.user.findUnique()` queries before the cache was repopulated. This could result in unnecessary database load during high-concurrency scenarios.
- To handle this, an in-flight lookup workflow was is introduced. When a cache miss occurs:
  - The first request initiates the database lookup and registers the Promise.
  - Subsequent requests for the same user reuse the existing Promise instead of creating additional database queries.
  - The in-flight entry is removed once the lookup completes or fails.
- The change preserves existing authentication and authorization behavior.

## Related Issue
- Fixes #1914 

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Benefits / Use case
- Prevents cache stampede (thundering herd) scenarios for `tokenVersion` lookups.
- Improves cache effectiveness under concurrent traffic.
- Reduces unnecessary database load.

## Testing
- [x] Verified TypeScript compilation passes (`npm run typecheck`).
- [x] Verified lint checks pass (`npm run lint`).
- [x] Confirmed existing authentication flow remains unchanged.

## Screenshots / Video

> **REQUIRED for any UI change.** PRs that modify visible UI (layout, components, styles, pages) will be rejected without this.

_No UI changes in this PR_ 

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)

## Additional details
- Closes #1914 
- Labels: GSSoC'2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced redundant backend work for session validation to improve responsiveness under concurrent requests.

* **Bug Fixes**
  * Sessions with revoked or mismatched token versions now reliably expire; users will be prompted to log in again when their session is no longer valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->