### PR TITLE
fix: invalidate user session on account deletion (closes #1750)

### DIFF
--- a/server/src/module/admin/admin-platform.service.ts
+++ b/server/src/module/admin/admin-platform.service.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../../database/db.js";
+import { invalidateVersionCache } from "../../middleware/auth.middleware.js";
 import { Prisma } from "@prisma/client";
 import type { UserRole, JobStatus } from "@prisma/client";
 
@@ -233,6 +234,9 @@ export class AdminPlatformService {
         throw new Error("Cannot delete the last SUPER_ADMIN");
     }
 
+    // Invalidate all active sessions before deleting the user
+    await prisma.user.update({ where: { id: userId }, data: { tokenVersion: { increment: 1 } } });
+    invalidateVersionCache(userId);
     await prisma.user.delete({ where: { id: userId } });
   }
 


### PR DESCRIPTION
## Summary
Fixes the security bug where JWT sessions remain valid after account deletion.

## Root Cause
In `admin-platform.service.ts`, `prisma.user.delete()` was called directly without invalidating the user's active sessions. The `tokenVersion` field and middleware check already existed but were never triggered on deletion.

## Fix
In `deleteUser()`, before calling `prisma.user.delete()`:
1. Increment `tokenVersion` in the DB — this makes all existing JWTs invalid immediately
2. Call `invalidateVersionCache(userId)` — clears the in-memory cache so the next request hits the DB and gets rejected

## Files Changed
- `server/src/module/admin/admin-platform.service.ts`
  - Added import for `invalidateVersionCache`
  - Added `tokenVersion` increment before user deletion
  - Added cache invalidation before user deletion

Closes #1750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session invalidation when admin users are deleted to ensure active sessions are properly terminated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->