### PR TITLE
chore: remove commented-out hackathon router dead code

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -54,7 +54,6 @@ import { complianceRouter } from "./module/compliance/compliance.routes.js";
 import { workflowRouter } from "./module/workflow/workflow.routes.js";
 import { hrAnalyticsRouter } from "./module/hr-analytics/hr-analytics.routes.js";
 import { contactRouter } from "./module/contact/contact.routes.js";
-// import { hackathonRouter } from "./module/hackathon/hackathon.routes.js";
 import { sitemapRouter } from "./module/sitemap/sitemap.routes.js";
 import { jobFeedRouter } from "./module/job-feed/job-feed.routes.js";
 import { jobAgentRouter } from "./module/job-agent/job-agent.routes.js";
@@ -297,7 +296,6 @@ app.use("/api/coach", coachRouter);
 
 // Contact form (public, no auth)
 app.use("/api/contact", contactRouter);
-// app.use("/api/hackathons", hackathonRouter);
 // Public external jobs endpoints (no auth)
 const publicAdminController = new AdminController(new AdminService());
 // Public ingest endpoint, external websites POST jobs here with API key


### PR DESCRIPTION
Fixes #1963

Removed two lines of commented-out dead code from `server/src/index.ts`: the unused hackathon router import and route registration.