### PR TITLE
refactor: replace raw <button> with reusable Button component in ErrorBoundary

### DIFF
--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button } from "./ui/button";
 
 interface Props {
   children: ReactNode;
@@ -30,12 +31,9 @@ export class ErrorBoundary extends Component<Props, State> {
           <div className="text-center p-8">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">Something went wrong</h1>
             <p className="text-gray-600 dark:text-gray-400 mb-6">{this.state.error?.message || "An unexpected error occurred"}</p>
-            <button
-              onClick={() => { this.setState({ hasError: false, error: null }); window.location.href = "/"; }}
-              className="px-6 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
-            >
+            <Button variant="primary" onClick={() => { this.setState({ hasError: false, error: null }); window.location.href = "/"; }}>
               Go Home
-            </button>
+            </Button>
           </div>
         </div>
       );


### PR DESCRIPTION
Fixes #1969

Replaced the raw `<button>` element with inline Tailwind classes with the project's CVA-based `Button` component, following the convention in AGENTS.md.