### PR TITLE
docs: add missing VITE_API_URL to client .env.example

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -2,5 +2,7 @@
 
 VITE_GOOGLE_CLIENT_ID=
 VITE_DODO_MODE=test_mode
+# API endpoint (for local dev outside Docker)
+VITE_API_URL=http://localhost:3000
 # LeetCode import feature flag — set to false to disable (default: enabled)
 VITE_LEETCODE_IMPORT_ENABLED=true


### PR DESCRIPTION
Fixes #1973

Added `VITE_API_URL=http://localhost:3000` to the client `.env.example` for local development outside Docker Compose.