### PR TITLE
Fix/workflow json parsing

### DIFF
--- a/client/src/module/recruiter/talent/TalentSearchPage.tsx
+++ b/client/src/module/recruiter/talent/TalentSearchPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Link } from "react-router";
+import { Link, useSearchParams } from "react-router";
 import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import {
   Search as SearchIcon,
@@ -42,6 +42,57 @@ const defaultFilters: TalentFilters = {
   jobStatus: "",
 };
 
+const talentFilterKeys: (keyof TalentFilters)[] = [
+  "search",
+  "skills",
+  "verifiedSkills",
+  "college",
+  "graduationYearMin",
+  "graduationYearMax",
+  "minAtsScore",
+  "location",
+  "jobStatus",
+];
+
+function parsePositiveInt(value: string | null, fallback: number) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseAtsScore(value: string | null) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return defaultFilters.minAtsScore;
+  return Math.min(100, Math.max(0, parsed));
+}
+
+function getFiltersFromSearchParams(searchParams: URLSearchParams): TalentFilters {
+  return {
+    search: searchParams.get("search") ?? defaultFilters.search,
+    skills: searchParams.get("skills") ?? defaultFilters.skills,
+    verifiedSkills: searchParams.get("verifiedSkills") ?? defaultFilters.verifiedSkills,
+    college: searchParams.get("college") ?? defaultFilters.college,
+    graduationYearMin: searchParams.get("graduationYearMin") ?? defaultFilters.graduationYearMin,
+    graduationYearMax: searchParams.get("graduationYearMax") ?? defaultFilters.graduationYearMax,
+    minAtsScore: parseAtsScore(searchParams.get("minAtsScore")),
+    location: searchParams.get("location") ?? defaultFilters.location,
+    jobStatus: searchParams.get("jobStatus") ?? defaultFilters.jobStatus,
+  };
+}
+
+function buildTalentSearchParams(filters: TalentFilters, page = 1) {
+  const params = new URLSearchParams();
+  talentFilterKeys.forEach((key) => {
+    const value = filters[key];
+    if (key === "minAtsScore") {
+      if ((value as number) > 0) params.set(key, String(value));
+      return;
+    }
+    if (value) params.set(key, String(value));
+  });
+  if (page > 1) params.set("page", String(page));
+  return params;
+}
+
 const JOB_STATUS_OPTIONS = [
   { key: "", label: "All" },
   { key: "LOOKING", label: "Looking" },
@@ -61,9 +112,21 @@ const labelClass =
   "block text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-1.5";
 
 export default function TalentSearchPage() {
-  const [filters, setFilters] = useState<TalentFilters>(defaultFilters);
-  const [appliedFilters, setAppliedFilters] = useState<TalentFilters>(defaultFilters);
-  const [page, setPage] = useState(1);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchParamsKey = searchParams.toString();
+  const appliedFilters = useMemo(
+    () => getFiltersFromSearchParams(new URLSearchParams(searchParamsKey)),
+    [searchParamsKey],
+  );
+  const page = useMemo(
+    () => parsePositiveInt(new URLSearchParams(searchParamsKey).get("page"), 1),
+    [searchParamsKey],
+  );
+  const [draftFilters, setDraftFilters] = useState(() => ({
+    source: searchParamsKey,
+    values: appliedFilters,
+  }));
+  const filters = draftFilters.source === searchParamsKey ? draftFilters.values : appliedFilters;
   const [showFilters, setShowFilters] = useState(false);
 
   const { data: savedIdsData } = useQuery({
@@ -99,25 +162,30 @@ export default function TalentSearchPage() {
   });
 
   const applyFilters = useCallback(() => {
-    setAppliedFilters({ ...filters });
-    setPage(1);
-  }, [filters]);
+    const nextParams = buildTalentSearchParams(filters);
+    setDraftFilters({ source: nextParams.toString(), values: filters });
+    setSearchParams(nextParams);
+  }, [filters, setSearchParams]);
 
   const clearFilters = useCallback(() => {
-    setFilters(defaultFilters);
-    setAppliedFilters(defaultFilters);
-    setPage(1);
-  }, []);
+    const nextParams = new URLSearchParams();
+    setDraftFilters({ source: nextParams.toString(), values: defaultFilters });
+    setSearchParams(nextParams);
+  }, [setSearchParams]);
 
   const updateFilter = <K extends keyof TalentFilters>(key: K, value: TalentFilters[K]) => {
-    setFilters((prev) => ({ ...prev, [key]: value }));
+    setDraftFilters({ source: searchParamsKey, values: { ...filters, [key]: value } });
   };
 
   const setJobStatus = (status: string) => {
     const next = { ...filters, jobStatus: status };
-    setFilters(next);
-    setAppliedFilters(next);
-    setPage(1);
+    const nextParams = buildTalentSearchParams(next);
+    setDraftFilters({ source: nextParams.toString(), values: next });
+    setSearchParams(nextParams);
+  };
+
+  const setPage = (nextPage: number) => {
+    setSearchParams(buildTalentSearchParams(appliedFilters, nextPage));
   };
 
   const students = data?.students ?? [];

--- a/server/src/module/leave/__tests__/leave.controller.test.ts
+++ b/server/src/module/leave/__tests__/leave.controller.test.ts
@@ -1,0 +1,73 @@
+import type { Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { LeaveController } from "../leave.controller.js";
+import type { LeaveService } from "../leave.service.js";
+
+function mockRes(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+describe("LeaveController self-service identity binding", () => {
+  it("creates leave requests for the authenticated user and ignores query employeeId", async () => {
+    const service = {
+      createRequest: vi.fn().mockResolvedValue({ id: 1 }),
+    } as unknown as LeaveService;
+    const controller = new LeaveController(service);
+    const req = {
+      user: { id: 42, email: "student@example.com", role: "STUDENT" },
+      query: { employeeId: "777" },
+      body: {
+        leaveType: "CASUAL",
+        startDate: "2026-06-08T00:00:00.000Z",
+        endDate: "2026-06-09T00:00:00.000Z",
+        totalDays: 2,
+        reason: "Family event",
+      },
+    } as unknown as Request;
+    const res = mockRes();
+
+    await controller.createRequest(req, res);
+
+    expect(service.createRequest).toHaveBeenCalledWith(42, req.body);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("lists only the authenticated user's leave requests and drops query employeeId", async () => {
+    const service = {
+      getMyRequests: vi.fn().mockResolvedValue({ requests: [], pagination: { page: 1, limit: 20, total: 0, totalPages: 0 } }),
+    } as unknown as LeaveService;
+    const controller = new LeaveController(service);
+    const req = {
+      user: { id: 42, email: "student@example.com", role: "STUDENT" },
+      query: { employeeId: "777", status: "PENDING" },
+    } as unknown as Request;
+    const res = mockRes();
+
+    await controller.getMyRequests(req, res);
+
+    expect(service.getMyRequests).toHaveBeenCalledWith(42, {
+      page: 1,
+      limit: 20,
+      status: "PENDING",
+    });
+  });
+
+  it("reads leave balance for the authenticated user and ignores query employeeId", async () => {
+    const service = {
+      getBalance: vi.fn().mockResolvedValue([]),
+    } as unknown as LeaveService;
+    const controller = new LeaveController(service);
+    const req = {
+      user: { id: 42, email: "student@example.com", role: "STUDENT" },
+      query: { employeeId: "777", year: "2026" },
+    } as unknown as Request;
+    const res = mockRes();
+
+    await controller.getBalance(req, res);
+
+    expect(service.getBalance).toHaveBeenCalledWith(42, 2026);
+  });
+});

--- a/server/src/module/leave/leave.controller.ts
+++ b/server/src/module/leave/leave.controller.ts
@@ -34,7 +34,7 @@ export class LeaveController {
       if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
       const employeeId = req.user.id;
-      const query = leaveQuerySchema.parse(req.query);
+      const { employeeId: _ignoredEmployeeId, ...query } = leaveQuerySchema.parse(req.query);
       const data = await this.leaveService.getMyRequests(employeeId, query);
       return res.json(data);
     } catch (error) {

--- a/server/src/module/leave/leave.controller.ts
+++ b/server/src/module/leave/leave.controller.ts
@@ -16,7 +16,7 @@ export class LeaveController {
       const result = createLeaveRequestSchema.safeParse(req.body);
       if (!result.success) return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
 
-      const employeeId = Number(req.query["employeeId"] ?? req.user.id);
+      const employeeId = req.user.id;
       const request = await this.leaveService.createRequest(employeeId, result.data);
       return res.status(201).json({ message: "Leave request submitted", request });
     } catch (error) {
@@ -31,9 +31,9 @@ export class LeaveController {
 
   async getMyRequests(req: Request, res: Response) {
     try {
-      const employeeId = Number(req.query["employeeId"]);
-      if (isNaN(employeeId)) return res.status(400).json({ message: "employeeId query param required" });
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
+      const employeeId = req.user.id;
       const query = leaveQuerySchema.parse(req.query);
       const data = await this.leaveService.getMyRequests(employeeId, query);
       return res.json(data);
@@ -112,9 +112,9 @@ export class LeaveController {
 
   async getBalance(req: Request, res: Response) {
     try {
-      const employeeId = Number(req.query["employeeId"]);
-      if (isNaN(employeeId)) return res.status(400).json({ message: "employeeId required" });
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
+      const employeeId = req.user.id;
       const year = req.query["year"] ? Number(req.query["year"]) : undefined;
       const balances = await this.leaveService.getBalance(employeeId, year);
       return res.json({ balances });

--- a/server/src/module/payroll/__tests__/payroll.controller.test.ts
+++ b/server/src/module/payroll/__tests__/payroll.controller.test.ts
@@ -1,0 +1,30 @@
+import type { Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { PayrollController } from "../payroll.controller.js";
+import type { PayrollService } from "../payroll.service.js";
+
+function mockRes(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+describe("PayrollController self-service identity binding", () => {
+  it("lists payslips for the authenticated user and ignores query employeeId", async () => {
+    const service = {
+      getMyPayslips: vi.fn().mockResolvedValue([]),
+    } as unknown as PayrollService;
+    const controller = new PayrollController(service);
+    const req = {
+      user: { id: 42, email: "student@example.com", role: "STUDENT" },
+      query: { employeeId: "777" },
+    } as unknown as Request;
+    const res = mockRes();
+
+    await controller.getMyPayslips(req, res);
+
+    expect(service.getMyPayslips).toHaveBeenCalledWith(42);
+    expect(res.json).toHaveBeenCalledWith({ payslips: [] });
+  });
+});

--- a/server/src/module/payroll/payroll.controller.ts
+++ b/server/src/module/payroll/payroll.controller.ts
@@ -63,9 +63,9 @@ export class PayrollController {
 
   async getMyPayslips(req: Request, res: Response) {
     try {
-      const employeeId = Number(req.query["employeeId"]);
-      if (isNaN(employeeId)) return res.status(400).json({ message: "employeeId required" });
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
+      const employeeId = req.user.id;
       const payslips = await this.payrollService.getMyPayslips(employeeId);
       return res.json({ payslips });
     } catch (error) {

--- a/server/src/module/workflow/__tests__/workflow.service.test.ts
+++ b/server/src/module/workflow/__tests__/workflow.service.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prisma } from "../../../database/db.js";
+import { WorkflowService } from "../workflow.service.js";
+
+vi.mock("../../../database/db.js", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    workflowDefinition: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    workflowInstance: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      count: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+const WORKFLOW_STEPS = [
+  { name: "Manager approval", type: "APPROVAL" },
+  { name: "HR approval", type: "APPROVAL" },
+];
+
+function activeInstance(steps: unknown = WORKFLOW_STEPS, stepHistory: unknown = []) {
+  return {
+    id: 1,
+    definitionId: 10,
+    entityType: "leave",
+    entityId: 99,
+    currentStep: 0,
+    status: "ACTIVE",
+    stepHistory,
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+    definition: {
+      id: 10,
+      name: "Leave approval",
+      description: null,
+      triggerEvent: "LEAVE_REQUESTED",
+      steps,
+      isActive: true,
+      createdAt: new Date("2026-06-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+    },
+  };
+}
+
+describe("WorkflowService Json handling", () => {
+  let service: WorkflowService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new WorkflowService();
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 42 } as any);
+    vi.mocked(prisma.workflowInstance.update).mockImplementation(({ data }: any) => Promise.resolve(data) as any);
+  });
+
+  it("advances workflows using Prisma Json arrays without reparsing them as strings", async () => {
+    vi.mocked(prisma.workflowInstance.findUnique).mockResolvedValue(activeInstance() as any);
+
+    const result = await service.advanceStep(1, "APPROVE", "Looks good", 42);
+
+    expect(result).toMatchObject({
+      currentStep: 1,
+      status: "ACTIVE",
+    });
+    expect(prisma.workflowInstance.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: expect.objectContaining({
+        currentStep: 1,
+        status: "ACTIVE",
+        stepHistory: [
+          expect.objectContaining({
+            step: 0,
+            action: "APPROVE",
+            note: "Looks good",
+            performedBy: 42,
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("still advances legacy rows that stored Json fields as stringified arrays", async () => {
+    vi.mocked(prisma.workflowInstance.findUnique).mockResolvedValue(
+      activeInstance(JSON.stringify(WORKFLOW_STEPS), JSON.stringify([])) as any,
+    );
+
+    await service.advanceStep(1, "APPROVE");
+
+    expect(prisma.workflowInstance.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: expect.objectContaining({
+        currentStep: 1,
+        status: "ACTIVE",
+        stepHistory: [
+          expect.objectContaining({
+            step: 0,
+            action: "APPROVE",
+          }),
+        ],
+      }),
+    });
+  });
+});

--- a/server/src/module/workflow/workflow.service.ts
+++ b/server/src/module/workflow/workflow.service.ts
@@ -16,6 +16,18 @@ interface StepHistoryEntry {
   performedAt: string;
 }
 
+function readJsonArray(value: Prisma.JsonValue, fieldName: string): unknown[] {
+  const parsed = typeof value === "string" ? JSON.parse(value) : value;
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Invalid workflow data: ${fieldName} must be an array`);
+  }
+  return parsed;
+}
+
+function toInputJson(value: unknown): Prisma.InputJsonValue {
+  return value as Prisma.InputJsonValue;
+}
+
 export class WorkflowService {
   // ── Definitions ──
 
@@ -25,7 +37,7 @@ export class WorkflowService {
         name: data.name,
         description: data.description ?? null,
         triggerEvent: data.triggerEvent,
-        steps: JSON.stringify(data.steps),
+        steps: toInputJson(data.steps),
         isActive: data.isActive,
       },
     });
@@ -46,7 +58,7 @@ export class WorkflowService {
     if (!definition) throw new Error("Workflow definition not found");
 
     const updateData: Record<string, unknown> = { ...data };
-    if (data.steps) updateData.steps = JSON.stringify(data.steps);
+    if (data.steps !== undefined) updateData.steps = toInputJson(data.steps);
 
     return prisma.workflowDefinition.update({ where: { id }, data: updateData });
   }
@@ -75,7 +87,7 @@ export class WorkflowService {
         entityId,
         currentStep: 0,
         status: "ACTIVE",
-        stepHistory: JSON.stringify([]),
+        stepHistory: [],
       },
       include: { definition: { select: { name: true, steps: true } } },
     });
@@ -132,8 +144,8 @@ export class WorkflowService {
     let steps: unknown[];
     let history: StepHistoryEntry[];
     try {
-      steps = JSON.parse(instance.definition.steps as string) as unknown[];
-      history = JSON.parse(instance.stepHistory as string) as StepHistoryEntry[];
+      steps = readJsonArray(instance.definition.steps, "definition steps");
+      history = readJsonArray(instance.stepHistory, "step history") as StepHistoryEntry[];
     } catch {
       throw new Error("Invalid workflow data: failed to parse definition steps or history");
     }
@@ -154,7 +166,7 @@ export class WorkflowService {
       data: {
         currentStep: isComplete ? instance.currentStep : nextStep,
         status: action === "REJECT" ? "CANCELLED" : isComplete ? "COMPLETED" : "ACTIVE",
-        stepHistory: JSON.stringify(history),
+        stepHistory: toInputJson(history),
       },
     });
   }


### PR DESCRIPTION
# Pull Request

## Description
Now Workflow parses Prisma Json fields with JSON.parse() correctly

## Related Issue
Fixes #1952 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
- Ran `npm run typecheck` in `server/` to verify there are no new TypeScript errors.
- Ran `npx vitest run src/module/workflow/__tests__/workflow.service.test.ts` in `server/` to verify workflow Json handling.
- Ran full server test suite with `npm test` in `server/`.

Manual coverage:
- Added regression tests confirming workflow advancement works when Prisma returns `steps` and `stepHistory` as native Json arrays.
- Added compatibility coverage for legacy rows where Json fields were stored as stringified arrays.

## Screenshots / Video

_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Talent search filters are now URL-based, enabling shareable search links and improved navigation.

* **Bug Fixes**
  * Leave and payroll endpoints now correctly authenticate users and use their identity for data access, preventing unauthorized cross-user data access.

* **Tests**
  * Added comprehensive test coverage for leave, payroll, and workflow functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->