### PR TITLE
refactor: consolidate duplicate PendingDelete/PendingAction union types across modules

### DIFF
--- a/client/src/lib/types/actions.types.ts
+++ b/client/src/lib/types/actions.types.ts
@@ -1,0 +1,15 @@
+export type PendingDelete = 
+  | { kind: "internal"; id: number }
+  | { kind: "external"; id: number }
+  | null;
+
+export type PendingAction<T = string> = {
+  id: T;
+  label?: string;
+} | null;
+
+export type ConfirmState = {
+  open: boolean;
+  message: string;
+  onConfirm: () => void;
+} | null;

--- a/client/src/module/student/applications/MyApplicationsPage.tsx
+++ b/client/src/module/student/applications/MyApplicationsPage.tsx
@@ -13,6 +13,7 @@ import { SEO } from "../../../components/SEO";
 import { ConfirmDialog } from "../../../components/ui/ConfirmDialog";
 import { ApplicationNotes } from "./ApplicationNotes";
 import toast from "@/components/ui/toast";
+import type { PendingDelete } from "@/lib/types/actions.types";
 
 function Kicker({ children }: { children: React.ReactNode }) {
   return (
@@ -249,16 +250,13 @@ function sortApplications(
   });
 }
 
-type PendingDelete =
-  | { kind: "internal"; id: number }
-  | { kind: "external"; id: number };
 
 export default function MyApplicationsPage() {
   const queryClient = useQueryClient();
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [page, setPage] = useState(1);
-  const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete>(null);
   const [sortOption, setSortOption] = useState<"newest" | "oldest" | "company" | "status">("newest");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("ALL");
 
@@ -319,7 +317,7 @@ export default function MyApplicationsPage() {
   const totalFiltered = filtered.length + filteredExternal.length;
 
   const deleteMutation = useMutation({
-    mutationFn: async (item: PendingDelete) => {
+    mutationFn: async (item: NonNullable<PendingDelete>) => {
       if (item.kind === "internal") {
         await api.delete(`/student/applications/${item.id}`);
       } else {


### PR DESCRIPTION
closes (#1907)

# Pull Request
refactor: consolidate duplicate PendingDelete/PendingAction union types across modules...this PR closes issue #1907 
## Description

Extracted the locally defined PendingDelete union type from MyApplicationsPage.tsx into a new centralized shared types file at client/src/lib/types/actions.types.ts. Also added PendingAction<T> and ConfirmState generic types for future use across the codebase.

## Related Issue
Fixes #1907 

## Type of Change
- [ ] Bug Fix  
- [x] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing

- Ran npx tsc --noEmit that means zero TypeScript errors introduced by this change
- Verified PendingDelete type is correctly imported from shared file
- Delete and withdraw functionality type signatures remain intact
- NonNullable<PendingDelete> used in mutationFn to maintain type safety

## Screenshots / Video

No UI changes in this PR

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal type definitions for improved code maintainability and type safety consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->