### PR TITLE
refactor: consolidate duplicate application status color mappings

### DIFF
--- a/client/src/module/student/applications/MyApplicationsPage.tsx
+++ b/client/src/module/student/applications/MyApplicationsPage.tsx
@@ -6,6 +6,7 @@ import { Briefcase, MapPin, Building2, ArrowUpRight, Clock, Search, ExternalLink
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import React, { useState, useMemo, useEffect, useCallback } from "react";
 import api from "../../../lib/axios";
+import { getStatusBorderColor } from "../../../lib/application-colors";
 import { queryKeys } from "../../../lib/query-keys";
 import type { Application, ExternalApplication } from "../../../lib/types";
 import { LoadingScreen } from "../../../components/LoadingScreen";
@@ -31,24 +32,6 @@ function CompanyMark({ label }: { label: string }) {
   );
 }
 
-function statusClass(status: string) {
-  switch (status) {
-    case "APPLIED":
-      return "text-stone-900 dark:text-stone-50 border-stone-300 dark:border-white/20";
-    case "IN_PROGRESS":
-      return "text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-900/60";
-    case "SHORTLISTED":
-      return "text-lime-700 dark:text-lime-400 border-lime-400";
-    case "HIRED":
-      return "text-lime-700 dark:text-lime-400 border-lime-400 bg-lime-50 dark:bg-lime-950/40";
-    case "REJECTED":
-      return "text-red-600 dark:text-red-400 border-red-300 dark:border-red-900/60";
-    case "WITHDRAWN":
-      return "text-stone-400 border-stone-200 dark:border-white/10";
-    default:
-      return "text-stone-500 border-stone-200 dark:border-white/10";
-  }
-}
 
 const ApplicationCard = React.memo(function ApplicationCard({
   app,
@@ -84,7 +67,7 @@ const ApplicationCard = React.memo(function ApplicationCard({
               </div>
             </div>
             <span
-              className={`inline-flex shrink-0 px-2 py-0.5 text-[10px] font-mono uppercase tracking-widest border rounded-md ${statusClass(app.status)}`}
+              className={`inline-flex shrink-0 px-2 py-0.5 text-[10px] font-mono uppercase tracking-widest border rounded-md ${getStatusBorderColor(app.status)}`}
             >
               {app.status.replace("_", " ")}
             </span>


### PR DESCRIPTION
## refactor: consolidate duplicate application status color mappings

Fixes #1893

### Problem
Two independent implementations of the application status → Tailwind color class mapping existed:
- `statusClass()` local function in `MyApplicationsPage.tsx` (lines 34–51)
- `getStatusBorderColor()` in `client/src/lib/application-colors.ts`

Both had identical logic and identical color values, creating a DRY violation and a risk of future inconsistency.

### Solution
- **Deleted** the local `statusClass` function from `MyApplicationsPage.tsx`
- **Imported** `getStatusBorderColor` from `client/src/lib/application-colors.ts`
- Updated the `ApplicationCard` status badge to call `getStatusBorderColor(app.status)`

All surfaces (student cards, recruiter tables, progress pages) now share a single canonical color mapping.

### Files changed
- `client/src/module/student/applications/MyApplicationsPage.tsx` — removed duplicate function, added shared import

### Testing
- No logic changes; purely a refactor. Existing status badge rendering is identical.
- TypeScript: no type errors (both functions accept `string` and return `string`).
- Visual output: unchanged — the deleted function's values were identical to `getStatusBorderColor`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code structure for the applications page by consolidating status styling logic into a shared helper function, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->