### PR TITLE
fix: add default type='button' to Button component (#1982)

### DIFF
--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -351,6 +351,7 @@ function Button({
   underline,
   asChild = false,
   placeholder = false,
+  type = "button",
   ...props
 }: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
@@ -361,6 +362,7 @@ function Button({
   return (
     <Comp
       data-slot="button"
+      type={type}
       className={cn(
         buttonVariants({
           variant,


### PR DESCRIPTION
Fixes #1982

- Added type='button' as default parameter in Button component destructuring
- Explicitly passes type={type} to the rendered element

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the button component to properly handle the `type` attribute by setting an explicit default value, ensuring consistent and predictable behavior across all button usages and form interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->