### PR TITLE
fix: add onError handler to useSaveJob hook (#1981)

### DIFF
--- a/client/src/hooks/useSaveJob.ts
+++ b/client/src/hooks/useSaveJob.ts
@@ -27,6 +27,9 @@ export function useSaveJob(opts?: UseSaveJobOptions) {
       });
       if (opts?.successToast) toast.success(opts.successToast);
     },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to save job");
+    },
   });
 
   return { toggleSave, isPending };


### PR DESCRIPTION
Fixes #1981

Adds an onError handler to the useMutation call that shows an error toast with the error message, preventing silent failures when the save/unsave API call fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error notifications when saving jobs fails, displaying specific error details to help users understand what went wrong.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->