### PR TITLE
refactor: extract clear filter logic into useClearFilters hook

### DIFF
--- a/client/src/hooks/useClearFilters.ts
+++ b/client/src/hooks/useClearFilters.ts
@@ -1,0 +1,17 @@
+import { useCallback, useRef, useEffect } from "react";
+import { useSearchParams } from "react-router";
+
+export function useClearFilters(filterResets: Array<() => void>) {
+  const [, setSearchParams] = useSearchParams();
+
+  // Use a ref to store the latest filterResets to avoid dependency changes and lint issues
+  const resetsRef = useRef(filterResets);
+  useEffect(() => {
+    resetsRef.current = filterResets;
+  }, [filterResets]);
+
+  return useCallback(() => {
+    resetsRef.current.forEach((reset) => reset());
+    setSearchParams(new URLSearchParams(), { replace: true });
+  }, [setSearchParams]);
+}

--- a/client/src/module/student/applications/MyApplicationsPage.tsx
+++ b/client/src/module/student/applications/MyApplicationsPage.tsx
@@ -1,6 +1,7 @@
 import DailyInterviewTipWidget from "./DailyInterviewTipWidget";
 import { BadgeProgressWidget } from "../opensource/components/BadgeProgressWidget";
 import { Link } from "react-router";
+import { useClearFilters } from "../../../hooks/useClearFilters";
 import { motion } from "framer-motion";
 import { Briefcase, MapPin, Building2, ArrowUpRight, Clock, Search, ExternalLink, X, Trash2 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -263,6 +264,12 @@ export default function MyApplicationsPage() {
   const [sortOption, setSortOption] = useState<"newest" | "oldest" | "company" | "status">("newest");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("ALL");
 
+  const clearFilters = useClearFilters([
+    () => setSearch(""),
+    () => setStatusFilter("ALL"),
+    () => setPage(1),
+  ]);
+
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search), 200);
     return () => clearTimeout(t);
@@ -300,7 +307,7 @@ export default function MyApplicationsPage() {
   }, [applications, debouncedSearch, sortOption, statusFilter]);
 
   const filteredExternal = useMemo(() => {
-    let base = !debouncedSearch.trim()
+    const base = !debouncedSearch.trim()
       ? externalApplications
       : externalApplications.filter(
         (a) =>
@@ -314,7 +321,7 @@ export default function MyApplicationsPage() {
       if (sortOption === "company") return (a.adminJob.company ?? "").localeCompare(b.adminJob.company ?? "");
       return 0;
     });
-  }, [externalApplications, debouncedSearch, sortOption, statusFilter]);
+  }, [externalApplications, debouncedSearch, sortOption]);
 
   const totalAll = applications.length + externalApplications.length;
   const totalFiltered = filtered.length + filteredExternal.length;
@@ -510,10 +517,7 @@ export default function MyApplicationsPage() {
       {isFiltered && (
         <div className="mb-6">
           <button
-            onClick={() => {
-              setSearch("");
-              setStatusFilter("ALL");
-            }}
+            onClick={clearFilters}
             className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-mono uppercase tracking-widest text-stone-500 hover:text-red-500 transition-colors border-0 bg-transparent cursor-pointer"
           >
             <X className="w-3 h-3" /> clear all filters
@@ -548,10 +552,7 @@ export default function MyApplicationsPage() {
             action={
               <button
                 type="button"
-                onClick={() => {
-                  setSearch("");
-                  setStatusFilter("ALL");
-                }}
+                onClick={clearFilters}
                 className="inline-flex items-center gap-2 px-4 py-2.5 rounded-md text-xs font-bold bg-stone-900 dark:bg-stone-50 text-stone-50 dark:text-stone-900 hover:bg-stone-800 dark:hover:bg-stone-200 transition-colors border-0 cursor-pointer mt-2"
               >
                 Clear all filters

--- a/client/src/module/student/companies/AddCompanyPage.tsx
+++ b/client/src/module/student/companies/AddCompanyPage.tsx
@@ -7,7 +7,6 @@ import {
   Loader2,
   MapPin,
   Plus,
-  Users,
   X,
 } from "lucide-react";
 import toast from "@/components/ui/toast";

--- a/client/src/module/student/jobs/JobBrowsePage.tsx
+++ b/client/src/module/student/jobs/JobBrowsePage.tsx
@@ -27,6 +27,7 @@ import api from "../../../lib/axios";
 import { queryKeys } from "../../../lib/query-keys";
 import { CARD_BASE } from "../../../lib/card-styles";
 import { useSaveJob } from "../../../hooks/useSaveJob";
+import { useClearFilters } from "../../../hooks/useClearFilters";
 import type {
   ExternalJob,
   Job,
@@ -301,19 +302,18 @@ export default function JobBrowsePage() {
     setScrPage(1);
   };
 
-  const clearAll = () => {
-    setSearch("");
-    setLocationFilter("");
-    setDebouncedSearch("");
-    setDebouncedLocation("");
-    setSelectedTags([]);
-    setSalaryMin("");
-    setSalaryMax("");
-    setSearchParams({});
-    setPage(1);
-    setExtPage(1);
-    setScrPage(1);
-  };
+  const clearAll = useClearFilters([
+    () => setSearch(""),
+    () => setLocationFilter(""),
+    () => setDebouncedSearch(""),
+    () => setDebouncedLocation(""),
+    () => setSelectedTags([]),
+    () => setSalaryMin(""),
+    () => setSalaryMax(""),
+    () => setPage(1),
+    () => setExtPage(1),
+    () => setScrPage(1),
+  ]);
 
   const hasFilters = search || locationFilter || selectedTags.length > 0 || salaryMin || salaryMax;
   const selectSuggestion = (location: string) => {

--- a/client/src/module/student/signals/SignalsPage.tsx
+++ b/client/src/module/student/signals/SignalsPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { useQuery } from "@tanstack/react-query";
+import { useClearFilters } from "../../../hooks/useClearFilters";
 import { motion } from "framer-motion";
 import {
   Search,
@@ -128,12 +129,12 @@ export default function SignalsPage() {
     setPage(1);
   };
 
-  const clearFilters = () => {
-    setSearch("");
-    setSearchInput("");
-    setSource("");
-    setPage(1);
-  };
+  const clearFilters = useClearFilters([
+    () => setSearch(""),
+    () => setSearchInput(""),
+    () => setSource(""),
+    () => setPage(1),
+  ]);
 
   const changeKind = (next: SignalKind) => {
     setKind(next);


### PR DESCRIPTION
# Pull Request

## Description

Extracted the duplicated filter clearing logic from multiple student pages into a reusable `useClearFilters` hook. This reduces code duplication and centralizes the behavior for resetting filters, clearing URL search parameters, and resetting pagination.

## Related Issue

Fixes #1905 

## Type of Change

* [ ] Bug Fix
* [ ] Feature
* [x] Enhancement
* [ ] Documentation

## Testing

* Verified the project compiles without introducing new TypeScript errors.
* Tested the filter reset functionality manually on:

  * Job Browse Page
  * My Applications Page
  * Signals Page
* Confirmed that clicking "Clear Filters" resets filter states to their defaults.
* Confirmed that URL search parameters are cleared correctly.
* Confirmed that pagination resets to page 1 after clearing filters.

## Screenshots / Video

*No UI changes in this PR*

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [ ] Docs updated (if needed)
* [x] Screenshot or video attached for every UI change (N/A – no UI changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated filter-clearing logic across application pages through improved code organization.

* **Chores**
  * Removed unused icon import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->