### PR TITLE
fix: replace deprecated bg-gradient-to-r with bg-linear-to-r in RoadmapCompletionModal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules/
 CLAUDE.md
 agents.md
 REPO_MAP.md
+
+# Windows reserved filenames
+nul

--- a/client/src/module/student/roadmap/RoadmapCompletionModal.tsx
+++ b/client/src/module/student/roadmap/RoadmapCompletionModal.tsx
@@ -197,7 +197,7 @@ export default function RoadmapCompletionModal({
           </div>
 
           {/* Top gradient accent */}
-          <div className="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-transparent via-lime-400/60 to-transparent" />
+          <div className="absolute top-0 inset-x-0 h-px bg-linear-to-r from-transparent via-lime-400/60 to-transparent" />
 
           {/* Close button */}
           <button
@@ -259,7 +259,7 @@ export default function RoadmapCompletionModal({
               initial={{ scaleX: 0 }}
               animate={{ scaleX: 1 }}
               transition={{ delay: 0.4, duration: 0.5 }}
-              className="my-6 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent"
+              className="my-6 h-px bg-linear-to-r from-transparent via-white/10 to-transparent"
             />
 
             {/* Share buttons */}


### PR DESCRIPTION
## Summary
Replaces the deprecated `bg-gradient-to-r` TailwindCSS v3 class with the v4-standard `bg-linear-to-r` in two locations within RoadmapCompletionModal.tsx.

## Changes
- `client/src/module/student/roadmap/RoadmapCompletionModal.tsx`: `bg-gradient-to-r` ? `bg-linear-to-r` (lines 200, 262)
- Added `nul` to `.gitignore` for Windows compatibility

## Related
Closes #2020

Part of GSSoC 2026 contributions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated gradient styling in the roadmap completion modal for enhanced visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->