### PR TITLE
fix: add missing aria-label to RepoCard bookmark button

### DIFF
--- a/client/src/module/student/opensource/RepoCard.tsx
+++ b/client/src/module/student/opensource/RepoCard.tsx
@@ -87,6 +87,7 @@ export const RepoCard = React.memo(React.forwardRef<HTMLDivElement, RepoCardProp
             <div className="flex items-center gap-2 shrink-0 relative z-10">
               <button
                 type="button"
+                aria-label={bookmarked ? `Remove bookmark for ${repo.name}` : `Bookmark ${repo.name}`}
                 onClick={(e) => {
                   e.stopPropagation();
                   e.preventDefault();


### PR DESCRIPTION
## Summary
Adds an `aria-label` to the bookmark toggle button in `RepoCard.tsx` so screen readers can announce its purpose. The label dynamically reflects the current state ("Bookmark {name}" vs "Remove bookmark for {name}").

## Changes
- `client/src/module/student/opensource/RepoCard.tsx`: Added `aria-label` prop to bookmark button

## Related
Closes #2022

Part of GSSoC 2026 contributions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility of the bookmark button with dynamic labels that clearly indicate whether the repository is already bookmarked, enhancing the experience for screen reader users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->