### PR TITLE
fix: replace HTML entity &quot; with quotes in JSX

### DIFF
--- a/client/src/module/student/roadmap/AiRoadmapWizardPage.tsx
+++ b/client/src/module/student/roadmap/AiRoadmapWizardPage.tsx
@@ -382,7 +382,7 @@ const res = await api.post<{
           toast.warning(
             <div className="flex flex-col gap-2 p-1 text-left">
               <p className="font-bold">Similar roadmap exists</p>
-              <p className="text-[10px] opacity-70">We found &quot;{duplicate.title}&quot; which seems similar to your goal.</p>
+              <p className="text-[10px] opacity-70">We found "{duplicate.title}" which seems similar to your goal.</p>
               <div className="flex items-center gap-3 mt-1">
                 <Link to={`/learn/roadmaps/${duplicate.slug}`} className="text-xs font-bold text-stone-950 dark:text-stone-50 hover:underline">
                   View existing


### PR DESCRIPTION
React escapes text content, so `&quot;` renders as the literal string instead of quotation marks.

Closes #2067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting of duplicate roadmap titles displayed in notification messages for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->