### PR TITLE
fix: replace removed z.iso.datetime() with z.string().datetime() for Zod 4

### DIFF
--- a/server/src/module/job/job.validation.ts
+++ b/server/src/module/job/job.validation.ts
@@ -47,7 +47,7 @@ export const createJobSchema = z.object({
   company: z.string(),
   status: z.enum(["DRAFT", "PUBLISHED", "CLOSED", "ARCHIVED"]).default("DRAFT"),
   customFields: z.array(customFieldDefinitionSchema).default([]),
-  deadline: z.iso.datetime().optional(),
+  deadline: z.string().datetime().optional(),
   tags: z.array(z.string()).default([]),
 });
 


### PR DESCRIPTION
`z.iso.datetime()` was removed in Zod 4 and causes a runtime crash. Replaced with `z.string().datetime()`.

Closes #2087