### PR TITLE
fix: use variable key instead of literal '1' in lazyWithRetry

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,7 +17,7 @@ function lazyWithRetry<T extends ComponentType<unknown>>(factory: () => Promise<
       factory().catch((err: unknown) => {
         const key = "chunk_reload";
         if (!sessionStorage.getItem(key)) {
-          sessionStorage.setItem("1", "1");
+          sessionStorage.setItem(key, "1");
           window.location.reload();
           return new Promise<never>(() => { }); // never resolves, page is reloading
         }


### PR DESCRIPTION
`sessionStorage.setItem` used string literal `'1'` instead of the declared `key` variable, causing the reload guard to never detect prior reload attempts (infinite reload loop).

Closes #2088