### PR TITLE
fix: lazyWithRetry uses literal '1' instead of key variable

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,7 +17,7 @@ function lazyWithRetry<T extends ComponentType<unknown>>(factory: () => Promise<
       factory().catch((err: unknown) => {
         const key = "chunk_reload";
         if (!sessionStorage.getItem(key)) {
-          sessionStorage.setItem("1", "1");
+          sessionStorage.setItem(key, "1");
           window.location.reload();
           return new Promise<never>(() => { }); // never resolves, page is reloading
         }


### PR DESCRIPTION
The lazyWithRetry utility used the string literal '1' as the sessionStorage key instead of the key variable, which meant every lazy-loaded chunk shared the same retry flag. Once any one chunk triggered a reload, all other chunks would see the flag already set and refuse to retry, causing an infinite reload loop for subsequent chunk failures. Replaced the literal with the key variable so each chunk tracks its own retry state independently.

Closes #2088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for dynamic import chunk loading to prevent unnecessary repeated reload attempts when chunks fail to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->