### PR TITLE
fix: replace z.iso.datetime() with z.string().datetime() for Zod 4

### DIFF
--- a/server/src/module/job/job.validation.ts
+++ b/server/src/module/job/job.validation.ts
@@ -47,7 +47,7 @@ export const createJobSchema = z.object({
   company: z.string(),
   status: z.enum(["DRAFT", "PUBLISHED", "CLOSED", "ARCHIVED"]).default("DRAFT"),
   customFields: z.array(customFieldDefinitionSchema).default([]),
-  deadline: z.iso.datetime().optional(),
+  deadline: z.string().datetime().optional(),
   tags: z.array(z.string()).default([]),
 });
 


### PR DESCRIPTION
z.iso.datetime() was removed in Zod 4 and calling it at runtime throws a TypeError. Any validation schema using it would crash the endpoint silently. Replaced all occurrences with z.string().datetime() which is the correct Zod 4 API and behaves identically for ISO 8601 datetime validation.

Closes #2087

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deadline field validation for job creation to properly handle datetime string inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->