### PR TITLE
fix: getDailyProblem now checks today's submissions only

### DIFF
--- a/server/src/module/dsa/dsa.service.ts
+++ b/server/src/module/dsa/dsa.service.ts
@@ -1333,10 +1333,16 @@ Return ONLY a JSON array, no markdown fences:
     let solvedToday = false;
 
     if (userId) {
+      const startOfDay = new Date();
+      startOfDay.setHours(0, 0, 0, 0);
+      const endOfDay = new Date();
+      endOfDay.setHours(23, 59, 59, 999);
+
       const submission = await prisma.dsaSubmission.findFirst({
         where: {
           studentId: userId,
           problemId: selected.id,
+          createdAt: { gte: startOfDay, lte: endOfDay },
         },
       });
 


### PR DESCRIPTION
The getDailyProblem service checked whether a user had any submission for the problem ever, not whether they solved it today. This meant users who solved a problem months ago would always see it marked as completed on the daily problem page, making the daily challenge useless for returning users. Added a date filter scoping the submission check to the current calendar day only.

Closes #2096