### PR TITLE
fix: remove silent .catch() in saveJob that swallowed all errors

### DIFF
--- a/server/src/module/student/student.service.ts
+++ b/server/src/module/student/student.service.ts
@@ -593,8 +593,6 @@ Rules:
       where: { userId: studentId },
       create: { userId: studentId, savedJobIds: [jobId] },
       update: { savedJobIds: { push: jobId } },
-    }).catch(() => {
-      // If push caused a duplicate (same id in array), silently succeed
     });
   }
 


### PR DESCRIPTION
The saveJob service called upsert with a .catch(() => {}) that silently discarded all errors. When the database write failed for any reason — connection error, constraint violation, timeout — the user received a success response while their saved job was never persisted. Removed the silent catch so errors propagate to the controller error handler and the user receives a proper error response.

Closes #2089