### PR TITLE
fix: wrap unsaveJob in transaction to prevent TOCTOU race

### DIFF
--- a/server/src/module/student/student.service.ts
+++ b/server/src/module/student/student.service.ts
@@ -599,16 +599,18 @@ Rules:
   }
 
   async unsaveJob(jobId: number, studentId: number) {
-    const pref = await prisma.userJobPreference.findUnique({
-      where: { userId: studentId },
-      select: { savedJobIds: true },
-    });
-    if (!pref) return;
+    await prisma.$transaction(async (tx) => {
+      const pref = await tx.userJobPreference.findUnique({
+        where: { userId: studentId },
+        select: { savedJobIds: true },
+      });
+      if (!pref) return;
 
-    const updated = pref.savedJobIds.filter((id) => id !== jobId);
-    await prisma.userJobPreference.update({
-      where: { userId: studentId },
-      data: { savedJobIds: updated },
+      const updated = pref.savedJobIds.filter((id) => id !== jobId);
+      await tx.userJobPreference.update({
+        where: { userId: studentId },
+        data: { savedJobIds: updated },
+      });
     });
   }
 


### PR DESCRIPTION
The unsaveJob service used a findUnique check followed by a separate update, creating a TOCTOU window where concurrent requests could read the same savedJobIds array and both write back filtered versions, causing one job to not be properly unsaved. Wrapped the read-filter-write in a Prisma transaction so the operation is atomic.

Closes #2093