### PR TITLE
fix: make webhook handlers idempotent by not overwriting dodoPaymentId

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -105,7 +105,6 @@ export class PaymentService {
           await prisma.payment.updateMany({
             where: { dodoPaymentId: payment.checkout_session_id },
             data: {
-              dodoPaymentId: payment.payment_id,
               amount: payment.total_amount,
               currency: payment.currency,
               status: "SUCCESS",
@@ -121,7 +120,6 @@ export class PaymentService {
           await prisma.payment.updateMany({
             where: { dodoPaymentId: payment.checkout_session_id },
             data: {
-              dodoPaymentId: payment.payment_id,
               status: "FAILED",
             },
           });


### PR DESCRIPTION
Webhook handlers updated dodoPaymentId unconditionally on every call. When a webhook was retried after a transient failure, the payment ID could be overwritten with a different value from a subsequent event, breaking payment audit trails and retry idempotency. Changed the succeeded and failed handlers to no longer overwrite dodoPaymentId, so the checkout_session_id is retained as the stable identifier and the lookup always works on retry.

Closes #2091