### PR TITLE
fix: wrap subscription lifecycle handlers in transactions

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -241,9 +241,11 @@ export class PaymentService {
     });
     if (!payment) return;
 
-    await prisma.user.update({
-      where: { id: payment.userId },
-      data: { subscriptionStatus: "CANCELLED" },
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: payment.userId },
+        data: { subscriptionStatus: "CANCELLED" },
+      });
     });
     await invalidateUserTierCache(payment.userId);
   }
@@ -255,12 +257,14 @@ export class PaymentService {
     });
     if (!payment) return;
 
-    await prisma.user.update({
-      where: { id: payment.userId },
-      data: {
-        subscriptionStatus: "EXPIRED",
-        subscriptionPlan: "FREE",
-      },
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: payment.userId },
+        data: {
+          subscriptionStatus: "EXPIRED",
+          subscriptionPlan: "FREE",
+        },
+      });
     });
     await invalidateUserTierCache(payment.userId);
   }
@@ -272,9 +276,11 @@ export class PaymentService {
     });
     if (!payment) return;
 
-    await prisma.user.update({
-      where: { id: payment.userId },
-      data: { subscriptionStatus: "EXPIRED" },
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: payment.userId },
+        data: { subscriptionStatus: "EXPIRED" },
+      });
     });
     await invalidateUserTierCache(payment.userId);
   }
@@ -286,12 +292,14 @@ export class PaymentService {
     });
     if (!payment) return;
 
-    await prisma.user.update({
-      where: { id: payment.userId },
-      data: {
-        subscriptionStatus: "ACTIVE",
-        subscriptionEndDate: new Date(sub.next_billing_date),
-      },
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: payment.userId },
+        data: {
+          subscriptionStatus: "ACTIVE",
+          subscriptionEndDate: new Date(sub.next_billing_date),
+        },
+      });
     });
     await invalidateUserTierCache(payment.userId);
   }


### PR DESCRIPTION
Subscription lifecycle handlers (cancel, expire, hold, renew) performed multiple database writes sequentially outside any transaction. If the process crashed or the database errored between writes, the subscription and user records could end up in inconsistent states — for example subscription cancelled but user plan not downgraded, or usage log missing. Wrapped all writes in each handler in a Prisma transaction so they either all succeed or all roll back together.

Closes #2092