### PR TITLE
fix: move DSA import token deletion inside transaction

### DIFF
--- a/server/src/module/dsa/dsa-import.service.ts
+++ b/server/src/module/dsa/dsa-import.service.ts
@@ -432,8 +432,6 @@ export class DsaImportService {
         code: "TOKEN_EXPIRED",
       });
 
-    pendingImports.delete(token);
-
     if (pending.rows.length === 0) {
       return { imported: 0, skipped: 0, importedAt: new Date().toISOString() };
     }
@@ -458,6 +456,8 @@ export class DsaImportService {
           imported: created.count,
         },
       });
+
+      pendingImports.delete(token);
 
       return created;
     });


### PR DESCRIPTION
The DSA import confirm handler deleted the import token before running the actual import transaction. If the import failed after token deletion — due to a database error, constraint violation, or network issue — the token was permanently gone and the user had no way to retry. The import data was lost. Moved the token deletion to the last step inside the import transaction so it only commits if all question imports succeed, making the operation fully atomic and retryable on failure.

Closes #2095