### PR TITLE
fix: replace deprecated keepPreviousData with placeholderData function

### DIFF
--- a/client/src/module/admin/blog/AdminBlogPage.tsx
+++ b/client/src/module/admin/blog/AdminBlogPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import { PaginationControls } from "../../../components/ui/PaginationControls";
-import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 import {
   FileText,
@@ -58,7 +58,7 @@ export default function AdminBlogPage() {
       const res = await api.get("/blog/admin/posts", { params });
       return res.data;
     },
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
   });
 
   const posts = data?.posts ?? [];

--- a/client/src/module/blog/BlogListPage.tsx
+++ b/client/src/module/blog/BlogListPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   BookOpen,
   ChevronLeft,
@@ -97,7 +97,7 @@ export default function BlogListPage() {
       return res.data;
     },
 
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
   });
 
   // Featured posts

--- a/client/src/module/recruiter/talent/TalentSearchPage.tsx
+++ b/client/src/module/recruiter/talent/TalentSearchPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Link, useSearchParams } from "react-router";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   Search as SearchIcon,
   SlidersHorizontal,
@@ -157,7 +157,7 @@ export default function TalentSearchPage() {
       const res = await api.get(`/recruiter/talent-search?${params}`);
       return res.data as TalentSearchResponse;
     },
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
     staleTime: 1000 * 60 * 5,
   });
 

--- a/client/src/module/scraped-jobs/ScrapedJobsPage.tsx
+++ b/client/src/module/scraped-jobs/ScrapedJobsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   Search,
   ChevronDown,
@@ -104,7 +104,7 @@ export default function ScrapedJobsPage() {
       const res = await api.get(`/scraped-jobs?${params}`);
       return res.data as { jobs: ScrapedJob[]; pagination: Pagination };
     },
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
     retry: 1,
   });
 

--- a/client/src/module/student/companies/CompanyDetailPage.tsx
+++ b/client/src/module/student/companies/CompanyDetailPage.tsx
@@ -1,6 +1,6 @@
 import { fadeUp, stagger } from "@/lib/motion-variants";
 import { useState } from "react";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useParams, Link, useLocation } from "react-router";
 import { queryKeys } from "../../../lib/query-keys";
 import { motion } from "framer-motion";
@@ -122,7 +122,7 @@ export default function CompanyDetailPage() {
     queryKey: [...queryKeys.companies.reviews(slug!), sortBy],
     queryFn: () => api.get(`/companies/${slug}/reviews?sort=${sortBy}`).then((r) => r.data),
     enabled: !!slug,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
     staleTime: 5 * 60 * 1000,
   });
 

--- a/client/src/module/student/companies/CompanyListPage.tsx
+++ b/client/src/module/student/companies/CompanyListPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { LoadingScreen } from "../../../components/LoadingScreen";
 import { PaginationControls } from "../../../components/ui/PaginationControls";
 import { Link, useSearchParams, useLocation } from "react-router";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   Search,
@@ -611,7 +611,7 @@ export default function CompanyListPage() {
     queryKey: queryKeys.companies.list(companyQueryParams),
     queryFn: () => api.get("/companies", { params: companyQueryParams }).then((r) => r.data),
     staleTime: 10 * 60 * 1000,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
   });
 
   const companies = companiesData?.companies ?? [];
@@ -650,7 +650,7 @@ export default function CompanyListPage() {
     queryFn: () => api.get("/yc/companies", { params: ycQueryParams }).then((r) => r.data),
     enabled: activeTab === "yc",
     staleTime: 60 * 60 * 1000,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
   });
 
   const ycCompanies = ycData?.companies ?? [];
@@ -677,7 +677,7 @@ export default function CompanyListPage() {
     queryFn: () => api.get("/professors", { params: profQueryParams }).then((r) => r.data),
     enabled: activeTab === "professors",
     staleTime: 60 * 60 * 1000,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
   });
 
   const professors = profData?.professors ?? [];

--- a/client/src/module/student/dsa/DsaCompaniesPage.tsx
+++ b/client/src/module/student/dsa/DsaCompaniesPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, memo } from "react";
-import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router";
 import {
   ArrowRight, Building2, CheckCircle2, Circle,
@@ -223,7 +223,7 @@ export default function DsaCompaniesPage() {
     queryKey: queryKeys.dsa.company(selectedCompany!, page),
     queryFn: () => api.get<DsaPaginatedProblems>(`/dsa/companies/${selectedCompany}?page=${page}&limit=50`).then((r) => r.data),
     enabled: !!selectedCompany,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
     staleTime: 15 * 24 * 60 * 60 * 1000,
   });
 

--- a/client/src/module/student/dsa/DsaListsPage.tsx
+++ b/client/src/module/student/dsa/DsaListsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { motion } from "framer-motion";
 import {
@@ -37,7 +37,7 @@ export default function DsaListsPage() {
     queryKey: queryKeys.dsa.list(selectedList!, page),
     queryFn: () => api.get<DsaPaginatedProblems>(`/dsa/lists/${selectedList}?page=${page}&limit=50`).then((r) => r.data),
     enabled: !!selectedList,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
     staleTime: 15 * 24 * 60 * 60 * 1000,
   });
 

--- a/client/src/module/student/dsa/DsaPatternsPage.tsx
+++ b/client/src/module/student/dsa/DsaPatternsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { motion } from "framer-motion";
 import {
@@ -35,7 +35,7 @@ export default function DsaPatternsPage() {
     queryKey: queryKeys.dsa.pattern(selectedPattern!, page),
     queryFn: () => api.get<DsaPaginatedProblems>(`/dsa/patterns/${selectedPattern}?page=${page}&limit=50`).then((r) => r.data),
     enabled: !!selectedPattern,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
     staleTime: 15 * 24 * 60 * 60 * 1000,
   });
 

--- a/client/src/module/student/dsa/DsaTopicDetailPage.tsx
+++ b/client/src/module/student/dsa/DsaTopicDetailPage.tsx
@@ -5,7 +5,6 @@ import {
   useQuery,
   useMutation,
   useQueryClient,
-  keepPreviousData,
 } from "@tanstack/react-query";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -79,7 +78,7 @@ export default function DsaTopicDetailPage() {
         .then((r) => r.data);
     },
     enabled: !!slug,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
     staleTime: 15 * 24 * 60 * 60 * 1000,
   });
 

--- a/client/src/module/student/dsa/DsaTopicsPage.tsx
+++ b/client/src/module/student/dsa/DsaTopicsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { motion } from "framer-motion";
 import {
@@ -225,7 +225,7 @@ const clearFilters = () => {
       const params = qs.toString() ? `?${qs.toString()}` : "";
       return api.get<DsaTopicsResponse>(`/dsa/topics${params}`).then((r) => r.data);
     },
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
     staleTime: 15 * 24 * 60 * 60 * 1000,
   });
   const topics = topicsData?.topics;

--- a/client/src/module/student/jobs/GovInternshipsPage.tsx
+++ b/client/src/module/student/jobs/GovInternshipsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router";
 import { motion } from "framer-motion";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   Search,
   X,
@@ -127,7 +127,7 @@ export default function GovInternshipsPage() {
     queryKey: queryKeys.internships.stats(),
     queryFn: () => api.get("/internships/stats").then((r) => r.data),
     staleTime: 5 * 60 * 1000,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
   });
 
   const queryParams: Record<string, string | number> = { page, limit: 24 };

--- a/client/src/module/student/jobs/JobBrowsePage.tsx
+++ b/client/src/module/student/jobs/JobBrowsePage.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useDebounce } from "../../../hooks/useDebounce";
 import { Link, useLocation, useSearchParams } from "react-router";
 import { motion, AnimatePresence } from "framer-motion";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   Search,
   MapPin,
@@ -195,7 +195,7 @@ export default function JobBrowsePage() {
       return res.data as { jobs: Job[]; pagination: Pagination };
     },
     staleTime: 60_000,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
   });
 
   const { data: extData } = useQuery({
@@ -223,7 +223,7 @@ export default function JobBrowsePage() {
       };
     },
     staleTime: 60_000,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
   });
 
   const { data: scrData } = useQuery({
@@ -246,7 +246,7 @@ export default function JobBrowsePage() {
       return res.data as { jobs: ScrapedJob[]; pagination: Pagination };
     },
     staleTime: 60_000,
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
   });
 
   const { data: savedIds } = useQuery({

--- a/client/src/module/student/learn/dsa-foundations/PracticeTab.tsx
+++ b/client/src/module/student/learn/dsa-foundations/PracticeTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, Bookmark, CheckCircle2, Circle, ExternalLink } from "lucide-react";
 import api from "../../../../lib/axios";
 import { queryKeys } from "../../../../lib/query-keys";
@@ -37,7 +37,7 @@ export function PracticeTab({ topicSlug, limit = 50 }: PracticeTabProps) {
       if (diffParam) params.set("difficulty", diffParam);
       return api.get<DsaTopicDetail>(`/dsa/topics/${topicSlug}?${params}`).then((r) => r.data);
     },
-    placeholderData: keepPreviousData,
+    placeholderData: (previousData) => previousData,
     staleTime: 5 * 60 * 1000,
     retry: false,
   });


### PR DESCRIPTION
## Description
This PR resolves Issue #2025 by refactoring the `@tanstack/react-query` usage to be compatible with upcoming v5.60+ upgrades. The deprecated `keepPreviousData` option has been fully removed from the codebase and replaced with the recommended `(previousData) => previousData` syntax.

## Changes Made
- Removed `keepPreviousData` imports across 14 files (including DSA pages, Job browse pages, and Company lists).
- Replaced `placeholderData: keepPreviousData` with `placeholderData: (previousData) => previousData` in all query hooks to prevent application breaks on future minor dependency upgrades.

Fixes #2025
