### PR TITLE
fix: apply date filter to getDailyProblem to fix daily streak check

### DIFF
--- a/server/src/module/dsa/dsa.service.ts
+++ b/server/src/module/dsa/dsa.service.ts
@@ -1333,10 +1333,17 @@ Return ONLY a JSON array, no markdown fences:
     let solvedToday = false;
 
     if (userId) {
+      const todayStart = new Date(today + "T00:00:00.000Z");
+      const tomorrowStart = new Date(todayStart.getTime() + 86_400_000);
+
       const submission = await prisma.dsaSubmission.findFirst({
         where: {
           studentId: userId,
           problemId: selected.id,
+          createdAt: {
+            gte: todayStart,
+            lt: tomorrowStart,
+          },
         },
       });
 


### PR DESCRIPTION
## Description
This PR resolves Issue #2027 by fixing a bug in `getDailyProblem` where the `solvedToday` boolean was incorrectly returning `true` if a user had ever solved the problem in the past, rather than specifically solving it today.

## Changes Made
- Updated `server/src/module/dsa/dsa.service.ts`.
- Added a `createdAt` date range filter (`gte: todayStart, lt: tomorrowStart`) to the `prisma.dsaSubmission.findFirst` query.
- This ensures users correctly get credit for their daily streak only when they solve the problem on the current day.

Fixes #2027
