### PR TITLE
fix: wrap unsaveJob in transaction to prevent TOCTOU race condition

### DIFF
--- a/server/src/module/student/student.service.ts
+++ b/server/src/module/student/student.service.ts
@@ -599,16 +599,18 @@ Rules:
   }
 
   async unsaveJob(jobId: number, studentId: number) {
-    const pref = await prisma.userJobPreference.findUnique({
-      where: { userId: studentId },
-      select: { savedJobIds: true },
-    });
-    if (!pref) return;
+    await prisma.$transaction(async (tx) => {
+      const pref = await tx.userJobPreference.findUnique({
+        where: { userId: studentId },
+        select: { savedJobIds: true },
+      });
+      if (!pref) return;
 
-    const updated = pref.savedJobIds.filter((id) => id !== jobId);
-    await prisma.userJobPreference.update({
-      where: { userId: studentId },
-      data: { savedJobIds: updated },
+      const updated = pref.savedJobIds.filter((id) => id !== jobId);
+      await tx.userJobPreference.update({
+        where: { userId: studentId },
+        data: { savedJobIds: updated },
+      });
     });
   }
 


### PR DESCRIPTION
## Description
This PR resolves Issue #2118 by fixing a Time-of-Check Time-of-Use (TOCTOU) race condition in the `unsaveJob` service method.

## Changes Made
- Wrapped the entire `unsaveJob` operation (reading `savedJobIds` and then writing the filtered array) inside a `prisma.$transaction`.
- This ensures the read and write operations are atomic, preventing a rare but critical bug where a concurrent `saveJob` call could have its newly saved job overwritten and lost.

Fixes #2118
