### PR TITLE
fix: prevent dodoPaymentId overwrite in webhook handlers to fix retries

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -105,7 +105,6 @@ export class PaymentService {
           await prisma.payment.updateMany({
             where: { dodoPaymentId: payment.checkout_session_id },
             data: {
-              dodoPaymentId: payment.payment_id,
               amount: payment.total_amount,
               currency: payment.currency,
               status: "SUCCESS",
@@ -121,7 +120,6 @@ export class PaymentService {
           await prisma.payment.updateMany({
             where: { dodoPaymentId: payment.checkout_session_id },
             data: {
-              dodoPaymentId: payment.payment_id,
               status: "FAILED",
             },
           });


### PR DESCRIPTION
## Description
This PR resolves an idempotency bug in the `payment.service.ts` webhook handlers (`payment.succeeded` and `payment.failed`).

## Changes Made
- Removed the `dodoPaymentId: payment.payment_id` overwrite logic from both webhook handlers.
- Previously, overwriting the checkout session ID meant that if the webhook handler partially succeeded but timed out (causing Dodo to retry the webhook), the retry would fail because the lookup key was changed. 
- Now, the checkout session ID correctly remains the lookup key for the payment record, restoring idempotency.

Fixes #2119
