### PR TITLE
fix: rethrow unexpected errors in saveJob upsert

### DIFF
--- a/server/src/module/student/student.service.ts
+++ b/server/src/module/student/student.service.ts
@@ -593,8 +593,12 @@ Rules:
       where: { userId: studentId },
       create: { userId: studentId, savedJobIds: [jobId] },
       update: { savedJobIds: { push: jobId } },
-    }).catch(() => {
-      // If push caused a duplicate (same id in array), silently succeed
+    }).catch((err: any) => {
+      // If push caused a duplicate (e.g. unique constraint), silently succeed
+      if (err.code === "P2002") {
+        return;
+      }
+      throw err;
     });
   }
 


### PR DESCRIPTION
## Description
This PR resolves Issue #2121 by fixing a bug in the `saveJob` service where a `catch` block was silently swallowing all errors.

## Changes Made
- Updated the `.catch()` block on the `userJobPreference.upsert` operation.
- Added an error code check so that it *only* swallows Prisma's `P2002` error (which happens if a duplicate ID is somehow pushed to the array).
- All other errors (such as database connection drops or timeouts) are now correctly re-thrown, ensuring that the API returns a proper 500 error instead of a false success message.

Fixes #2121
