### PR TITLE
fix: use correct session storage key to prevent infinite reload loop

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,7 +17,7 @@ function lazyWithRetry<T extends ComponentType<unknown>>(factory: () => Promise<
       factory().catch((err: unknown) => {
         const key = "chunk_reload";
         if (!sessionStorage.getItem(key)) {
-          sessionStorage.setItem("1", "1");
+          sessionStorage.setItem(key, "1");
           window.location.reload();
           return new Promise<never>(() => { }); // never resolves, page is reloading
         }


### PR DESCRIPTION
## Description
This PR resolves Issue #2122 by fixing a bug in the frontend's `lazyWithRetry` wrapper that caused the application to get stuck in an infinite reload loop upon a chunk load failure.

## Changes Made
- Updated `client/src/App.tsx` where the fallback mechanism checks for the `chunk_reload` key.
- Fixed a typo where the code was incorrectly setting `sessionStorage.setItem("1", "1")` instead of setting the actual `key` variable.
- Now, the application properly records that a reload has been attempted, preventing it from infinitely reloading if the chunk is still unavailable on the second try.

Fixes #2122
