### PR TITLE
fix: update deprecated z.iso.datetime to z.string.datetime for Zod 4 …

### DIFF
--- a/server/src/module/job/job.validation.ts
+++ b/server/src/module/job/job.validation.ts
@@ -47,7 +47,7 @@ export const createJobSchema = z.object({
   company: z.string(),
   status: z.enum(["DRAFT", "PUBLISHED", "CLOSED", "ARCHIVED"]).default("DRAFT"),
   customFields: z.array(customFieldDefinitionSchema).default([]),
-  deadline: z.iso.datetime().optional(),
+  deadline: z.string().datetime().optional(),
   tags: z.array(z.string()).default([]),
 });
 


### PR DESCRIPTION
## Description
This PR resolves Issue #2123 by fixing a deprecated method call in the backend's validation schema that would cause a runtime crash on Zod 4.

## Changes Made
- Updated `server/src/module/job/job.validation.ts`.
- Replaced the deprecated `z.iso.datetime()` with the forward-compatible `z.string().datetime()` method inside the `createJobSchema`.
- This ensures the API validation pipeline remains stable and future-proof against upcoming dependency bumps.

Fixes #2123
