### PR TITLE
Refactor/unify difficulty color maps

### DIFF
--- a/client/src/lib/difficulty-styles.ts
+++ b/client/src/lib/difficulty-styles.ts
@@ -1,0 +1,8 @@
+export const DIFFICULTY_STYLE: Record<string, string> = {
+  Beginner: "text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/60",
+  Intermediate: "text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-900/60",
+  Advanced: "text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/60",
+  Easy: "text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/60",
+  Medium: "text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-900/60",
+  Hard: "text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/60",
+};

--- a/client/src/module/student/applications/MyApplicationsPage.tsx
+++ b/client/src/module/student/applications/MyApplicationsPage.tsx
@@ -234,6 +234,13 @@ const STATUS_ORDER: Record<string, number> = {
   REJECTED: 4,
   WITHDRAWN: 5,
 };
+const EXTERNAL_STATUS = "APPLIED";
+const EXTERNAL_VISIBLE_FILTERS = ["ALL", "APPLIED", "IN_PROGRESS"] as const;
+type ExternalVisibleFilter = (typeof EXTERNAL_VISIBLE_FILTERS)[number];
+
+function isExternalVisibleFilter(filter: string): filter is ExternalVisibleFilter {
+  return (EXTERNAL_VISIBLE_FILTERS as readonly string[]).includes(filter);
+}
 
 function sortApplications(
   apps: Application[],
@@ -259,6 +266,7 @@ export default function MyApplicationsPage() {
   const [page, setPage] = useState(1);
   const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null);
   const [sortOption, setSortOption] = useState<"newest" | "oldest" | "company" | "status">("newest");
+  const [activeFilter, setActiveFilter] = useState("ALL");
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search), 200);
@@ -268,7 +276,7 @@ export default function MyApplicationsPage() {
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setPage(1);
-  }, [debouncedSearch]);
+  }, [debouncedSearch, activeFilter]);
 
   const { data, isLoading } = useQuery({
     queryKey: queryKeys.applications.mine(),
@@ -288,9 +296,10 @@ export default function MyApplicationsPage() {
         (a) => a.job?.title?.toLowerCase().includes(debouncedSearch.toLowerCase()) || a.job?.company?.toLowerCase().includes(debouncedSearch.toLowerCase())
       );
     return sortApplications(base, sortOption);
-  }, [applications, debouncedSearch, sortOption]);
+ }, [applications, debouncedSearch, sortOption, activeFilter]);
 
  const filteredExternal = useMemo(() => {
+  if (!isExternalVisibleFilter(activeFilter)) return [];
   const base = !debouncedSearch.trim()
     ? externalApplications
     : externalApplications.filter(
@@ -304,7 +313,7 @@ export default function MyApplicationsPage() {
     if (sortOption === "company") return (a.adminJob.company ?? "").localeCompare(b.adminJob.company ?? "");
     return 0;
   });
-}, [externalApplications, debouncedSearch, sortOption]);
+}, [externalApplications, debouncedSearch, sortOption, activeFilter]);
 
   const totalAll = applications.length + externalApplications.length;
   const totalFiltered = filtered.length + filteredExternal.length;

--- a/client/src/module/student/dsa/DsaProblemDetailPage.tsx
+++ b/client/src/module/student/dsa/DsaProblemDetailPage.tsx
@@ -22,12 +22,7 @@ import { DsaTestResults } from "./components/DsaTestResults";
 import { DsaSubmissionHistory } from "./components/DsaSubmissionHistory";
 import { DsaConsoleOutput } from "./components/DsaConsoleOutput";
 import { Button } from "@/components/ui/button";
-
-const DIFF_STYLE: Record<string, string> = {
-  Easy: "text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/60",
-  Medium: "text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-900/60",
-  Hard: "text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/60",
-};
+import { DIFFICULTY_STYLE } from "../../../lib/difficulty-styles";
 
 const DEFAULT_CODE: Record<DsaLanguage, string> = {
   python: `import sys
@@ -288,7 +283,7 @@ export default function DsaProblemDetailPage() {
         {/* ── Top bar ── */}
         <div className="flex flex-wrap items-center gap-3 px-4 py-3 border-b border-stone-200 dark:border-white/10 shrink-0">
           <div className="flex items-center gap-3 min-w-0 flex-1">
-            <MetaChip className={DIFF_STYLE[problem.difficulty]}>{problem.difficulty}</MetaChip>
+            <MetaChip className={DIFFICULTY_STYLE[problem.difficulty]}>{problem.difficulty}</MetaChip>
             <div className="min-w-0">
               <div className="inline-flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-stone-500">
                 <span className="h-1 w-1 bg-lime-400" />
@@ -590,7 +585,7 @@ export default function DsaProblemDetailPage() {
                           {sq.title}
                         </span>
                         <div className="flex items-center gap-2 shrink-0">
-                          <MetaChip className={DIFF_STYLE[sq.difficulty]}>{sq.difficulty}</MetaChip>
+                          <MetaChip className={DIFFICULTY_STYLE[sq.difficulty]}>{sq.difficulty}</MetaChip>
                           <ArrowUpRight className="w-3.5 h-3.5 text-stone-400 group-hover:text-lime-500 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 transition-all" />
                         </div>
                       </Link>
@@ -862,7 +857,7 @@ export default function DsaProblemDetailPage() {
                     className="group block border border-stone-200 dark:border-white/10 rounded-md p-3.5 hover:border-stone-400 dark:hover:border-white/30 transition-colors no-underline bg-stone-50 dark:bg-stone-950"
                   >
                     <div className="flex items-center gap-2 mb-2">
-                      <span className={`inline-flex items-center px-2 py-0.5 text-xs font-mono uppercase tracking-wider border rounded-md ${DIFF_STYLE[sp.difficulty] || "text-stone-600 dark:text-stone-400 border-stone-200 dark:border-white/10"}`}>
+                      <span className={`inline-flex items-center px-2 py-0.5 text-xs font-mono uppercase tracking-wider border rounded-md ${DIFFICULTY_STYLE[sp.difficulty] || "text-stone-600 dark:text-stone-400 border-stone-200 dark:border-white/10"}`}>
                         {sp.difficulty}
                       </span>
                     </div>

--- a/client/src/module/student/interview-prep/InterviewQuestionPage.tsx
+++ b/client/src/module/student/interview-prep/InterviewQuestionPage.tsx
@@ -18,7 +18,7 @@ import { canonicalUrl } from "../../../lib/seo.utils";
 import { useAuthStore } from "../../../lib/auth.store";
 import { reportMilestone } from "../../../lib/milestone.utils";
 import api from "../../../lib/axios";
-
+import { DIFFICULTY_STYLE } from "../../../lib/difficulty-styles";
 async function getServerProgress() {
   const { data } = await api.get("/interview-progress");
   return data;
@@ -32,11 +32,7 @@ async function updateServerProgress(
   return data;
 }
 
-const DIFF_STYLE: Record<string, string> = {
-  Beginner:     "text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/60",
-  Intermediate: "text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-900/60",
-  Advanced:     "text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/60",
-};
+
 
 const TYPE_STYLE: Record<string, string> = {
   Theory:      "text-blue-700 dark:text-blue-400 border-blue-300 dark:border-blue-900/60",
@@ -267,7 +263,7 @@ export default function InterviewQuestionPage() {
           </h1>
 
           <div className="flex items-center gap-1.5 flex-wrap mt-4">
-            <MetaChip className={DIFF_STYLE[question.difficulty]}>{question.difficulty}</MetaChip>
+            <MetaChip className={DIFFICULTY_STYLE[question.difficulty]}>{question.difficulty}</MetaChip>
             <MetaChip className={TYPE_STYLE[question.type]}>{question.type}</MetaChip>
             {completed && (
               <MetaChip className="text-lime-600 dark:text-lime-400 border-lime-300 dark:border-lime-900/60">

--- a/client/src/module/student/interview-prep/InterviewSectionPage.tsx
+++ b/client/src/module/student/interview-prep/InterviewSectionPage.tsx
@@ -7,12 +7,8 @@ import { SEO } from "../../../components/SEO";
 import { canonicalUrl } from "../../../lib/seo.utils";
 import { useAuthStore } from "../../../lib/auth.store";
 import api from "../../../lib/axios";
+import { DIFFICULTY_STYLE } from "../../../lib/difficulty-styles";
 
-const DIFF_STYLE: Record<string, string> = {
-  Beginner:     "text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/60",
-  Intermediate: "text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-900/60",
-  Advanced:     "text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/60",
-};
 
 const FILTER_STYLE: Record<string, string> = {
   Beginner: "text-green-700 dark:text-green-400 border-green-200 dark:border-green-900/60 bg-green-50 dark:bg-green-900/20",
@@ -276,7 +272,7 @@ export default function InterviewSectionPage() {
                     </div>
 
                     <span className="hidden sm:inline-flex shrink-0">
-                      <MetaChip className={DIFF_STYLE[question.difficulty]}>
+                      <MetaChip className={DIFFICULTY_STYLE[question.difficulty]}>
                         {question.difficulty}
                       </MetaChip>
                     </span>

--- a/client/src/module/student/opensource/FirstPRRoadmapPage.tsx
+++ b/client/src/module/student/opensource/FirstPRRoadmapPage.tsx
@@ -132,7 +132,7 @@ export default function FirstPRRoadmapPage() {
                 >
                   Discover repos to contribute to
                 </Link>
-                <button
+                <Button
                   onClick={() => {
                     if (window.confirm("Reset all steps?")) {
                       setCompleted(new Set());
@@ -142,7 +142,7 @@ export default function FirstPRRoadmapPage() {
                   className="text-sm text-lime-700 dark:text-lime-400 border border-lime-400 px-3 py-0.5 rounded-lg font-medium"
                 >
                   Start over
-                </button>
+                </Button>
               </div>
             </div>
           </motion.div>

--- a/client/src/module/student/opensource/FirstPRRoadmapPage.tsx
+++ b/client/src/module/student/opensource/FirstPRRoadmapPage.tsx
@@ -123,8 +123,27 @@ export default function FirstPRRoadmapPage() {
           >
             <Trophy className="w-8 h-8 text-green-500 shrink-0" />
             <div>
-              <p className="text-base font-bold text-green-900 dark:text-green-300">You're an open source contributor!</p>
-              <p className="text-sm text-green-700 dark:text-green-400 mt-0.5">You've completed all {totalSteps} steps. Time to find your next issue!</p>
+              <p className="text-base font-bold text-green-900 dark:text-green-300">You shipped your first PR!</p>
+              <p className="text-sm text-green-700 dark:text-green-400 mt-0.5">10 / 10 steps complete. Your open source journey has begun.</p>
+            <div className="flex gap-4 mt-3 flex-wrap items-center">
+                <Link
+                  to="/student/opensource"
+                  className="text-sm text-lime-700 dark:text-lime-400 underline font-medium"
+                >
+                  Discover repos to contribute to
+                </Link>
+                <button
+                  onClick={() => {
+                    if (window.confirm("Reset all steps?")) {
+                      setCompleted(new Set());
+                      try { localStorage.removeItem(STORAGE_KEY); } catch { /**/ }
+                    }
+                  }}
+                  className="text-sm text-lime-700 dark:text-lime-400 border border-lime-400 px-3 py-0.5 rounded-lg font-medium"
+                >
+                  Start over
+                </button>
+              </div>
             </div>
           </motion.div>
         )}

--- a/client/src/module/student/opensource/OpenSourceAnalyticsPage.tsx
+++ b/client/src/module/student/opensource/OpenSourceAnalyticsPage.tsx
@@ -387,6 +387,29 @@ export default function OpenSourceAnalyticsPage() {
     );
   }
 
+  // Empty state: student has zero contributions
+  if (!trendIsLoading && !trendIsError && contributionTotal === 0) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center px-4 text-center">
+        <div className="bg-indigo-50 rounded-full p-6 mb-5">
+          <BarChart3 className="w-12 h-12 text-indigo-400" />
+        </div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-3">
+          No contributions tracked yet
+        </h2>
+        <p className="text-gray-500 max-w-md mb-8">
+          Submit a repo suggestion and get it approved to start tracking
+          your open source journey.
+        </p>
+        <Link
+          to="/student/opensource"
+          className="bg-indigo-600 text-white px-6 py-3 rounded-xl font-medium hover:bg-indigo-700 transition-colors"
+        >
+          Discover Repositories →
+        </Link>
+      </div>
+    );
+  }
   return (
     <div className="min-h-screen bg-gray-50 pb-16">
       {/* Header */}


### PR DESCRIPTION
# Pull Request

## Description
Created a shared `DIFFICULTY_STYLE` map in `client/src/lib/difficulty-styles.ts`
and removed the duplicate local `DIFF_STYLE` definitions from:
- InterviewSectionPage.tsx
- InterviewQuestionPage.tsx
- DsaProblemDetailPage.tsx

All three now import and use the shared `DIFFICULTY_STYLE` constant, removing
duplicate color/style logic for difficulty badges across interview-prep and
DSA modules.

## Related Issue
Fixes #1911

## Type of Change
- [ ] Bug Fix
- [x] Feature
- [ ] Enhancement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added external application visibility filtering to My Applications page
  * Enabled "Start over" option on first PR roadmap with updated completion messaging and repository discovery link
  * Added empty-state screen for Open Source Analytics when no contributions are tracked

<!-- end of auto-generated comment: release notes by coderabbit.ai -->