### PR TITLE
fix: treat Docker Compose postgres hostname as local for SSL detection (#2154)

### DIFF
--- a/server/src/database/db.ts
+++ b/server/src/database/db.ts
@@ -20,7 +20,8 @@ function resolveSsl():
     return false;
   }
   // Local Postgres installs typically do not support TLS.
-  if (/localhost|127\.0\.0\.1/.test(rawConnectionString)) {
+  // Docker Compose containers also use a non-TLS hostname (e.g. "postgres").
+  if (/localhost|127\.0\.0\.1|postgres/.test(rawConnectionString)) {
     return false;
   }
   return { rejectUnauthorized: false };


### PR DESCRIPTION
Fixes #2154

The resolveSsl() function only treats localhost and 127.0.0.1 as local database hosts. Docker Compose uses the service name 'postgres' as the hostname, which does not match the existing regex, causing TLS to be incorrectly enabled for a container that does not support it.

Add 'postgres' to the hostname regex so Docker Compose setups connect without SSL, matching the behavior of local Postgres installs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database connections to Docker Compose Postgres instances by automatically disabling TLS for local container hostnames, matching the existing behavior for localhost connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->