### PR TITLE
fix(accessibility): add aria-live announcements for application status updates

### DIFF
--- a/client/src/module/recruiter/applications/ApplicationsList.tsx
+++ b/client/src/module/recruiter/applications/ApplicationsList.tsx
@@ -32,6 +32,17 @@ export default function ApplicationsList() {
   const [updatingId, setUpdatingId] = useState<number | null>(null);
   const [advancingIds, setAdvancingIds] = useState<Set<number>>(() => new Set());
   const [pendingAdvanceApp, setPendingAdvanceApp] = useState<Application | null>(null);
+  // Message announced to screen readers via the visually-hidden live region.
+  // We store an incrementing key alongside the text so that repeating the same
+  // outcome (e.g. retrying a failed update) still re-triggers an announcement —
+  // a live region does not re-announce when its text content is unchanged.
+  const [announcement, setAnnouncement] = useState<{ key: number; text: string }>(
+    { key: 0, text: "" },
+  );
+
+  const announce = (text: string) => {
+    setAnnouncement((prev) => ({ key: prev.key + 1, text }));
+  };
 
   // Reset to page 1 when search or filter changes
   useEffect(() => {

--- a/client/src/module/recruiter/applications/ApplicationsList.tsx
+++ b/client/src/module/recruiter/applications/ApplicationsList.tsx
@@ -74,8 +74,10 @@ export default function ApplicationsList() {
       await api.patch(`/recruiter/applications/${appId}/status`, { status });
       queryClient.invalidateQueries({ queryKey: ["applications"] });
       toast.success("Status updated");
+      announce(`Status updated to ${STATUS_LABELS[status] ?? status}.`);
     } catch {
       toast.error("Failed to update status");
+      announce("Failed to update status. Please try again.");
     } finally {
       setUpdatingId(null);
     }
@@ -88,9 +90,11 @@ export default function ApplicationsList() {
       await api.patch(`/recruiter/applications/${appId}/advance`);
       queryClient.invalidateQueries({ queryKey: ["applications"] });
       toast.success("Application advanced");
+      announce("Application advanced to the next hiring stage.");
       setPendingAdvanceApp(null);
     } catch {
       toast.error("Failed to advance application");
+      announce("Failed to advance application. Please try again.");
     } finally {
       setAdvancingIds((current) => {
         const next = new Set(current);
@@ -103,6 +107,14 @@ export default function ApplicationsList() {
   return (
     <div>
       <SEO title="Applications" noIndex />
+      {/* Visually-hidden ARIA live region: announces status update / advance
+          outcomes to screen reader users. `polite` waits until the user is idle
+          so it does not interrupt them; `aria-atomic` re-reads the whole message.
+          Keyed on `announcement.key` so repeated identical outcomes remount the
+          node and are announced again. */}
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        <span key={announcement.key}>{announcement.text}</span>
+      </div>
       <ConfirmDialog
         open={pendingAdvanceApp !== null}
         title="Advance Candidate?"

--- a/client/src/module/recruiter/applications/ApplicationsList.tsx
+++ b/client/src/module/recruiter/applications/ApplicationsList.tsx
@@ -11,6 +11,17 @@ import { SEO } from "../../../components/SEO";
 import { useDebounce } from "../../../hooks/useDebounce";
 import { ConfirmDialog } from "../../../components/ui/ConfirmDialog";
 
+// Human-readable labels for the status codes, reused in the SR announcement
+// so screen reader users hear "Shortlisted" rather than "SHORTLISTED".
+const STATUS_LABELS: Record<string, string> = {
+  APPLIED: "Applied",
+  IN_PROGRESS: "In Progress",
+  SHORTLISTED: "Shortlisted",
+  REJECTED: "Rejected",
+  HIRED: "Hired",
+  WITHDRAWN: "Withdrawn",
+};
+
 export default function ApplicationsList() {
   const { id: jobId } = useParams();
   const queryClient = useQueryClient();


### PR DESCRIPTION
# Pull Request

## Description

This PR improves accessibility in `ApplicationsList.tsx` by adding a visually hidden ARIA live region to announce application status update outcomes to screen reader users.

Changes made:
- Added a persistent `aria-live="polite"` region with `role="status"`
- Added announcements for status update success and failure states
- Added announcements for application advancement success and failure states
- Added human-readable status labels for better screen reader output
- Ensured repeated announcements are announced correctly by screen readers

This preserves the existing visual toast notifications while providing equivalent feedback to assistive technology users.

## Related Issue

Fixes #1153

## Type of Change

- [x] Bug Fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing

- Verified status update success announcements
- Verified status update failure announcements
- Verified application advance success announcements
- Verified application advance failure announcements
- Confirmed existing toast notifications continue to work
- Confirmed no TypeScript errors in the modified file
- Confirmed ESLint passes for the modified file

## Screenshots / Video

_No visible UI changes in this PR._

## Checklist

- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No `.env`, credentials, or node_modules committed
- [x] No visible UI changes introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accessibility with live region announcements for application status updates and advance workflows, providing screen reader users with clear outcome notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->