### PR TITLE
fix: refetch submissions on window focus to prevent stale counts

### DIFF
--- a/client/src/module/student/opensource/MySubmissionsPage.tsx
+++ b/client/src/module/student/opensource/MySubmissionsPage.tsx
@@ -30,9 +30,10 @@ export default function MySubmissionsPage() {
   const { data, isLoading } = useQuery<RepoRequest[]>({
     queryKey: ["my-repo-requests"],
     queryFn: () => api.get("/opensource/requests/mine").then((r) => r.data),
-    staleTime: 30_000,
+    staleTime: 0,
+    refetchOnWindowFocus: true,
   });
-
+  
   const filtered = useMemo(() => {
     return (data ?? []).filter((r) => r.status === activeTab);
   }, [data, activeTab]);

--- a/server/src/module/ambassador/ambassador.service.ts
+++ b/server/src/module/ambassador/ambassador.service.ts
@@ -2,6 +2,31 @@ import { prisma } from "../../database/db.js";
 import { slugify } from "../../utils/slug.utils.js";
 import crypto from "crypto";
 
+/**
+ * Minimum number of guides a user must complete to qualify as an ambassador.
+ * Corresponds to all 6 official InternHack guides in the program requirements.
+ */
+const MIN_GUIDES_COMPLETED = 6;
+
+/**
+ * Minimum number of repositories a user must have contributed to.
+ * Ensures ambassadors have demonstrated real open-source activity.
+ */
+const MIN_REPOS_CONTRIBUTED = 3;
+
+/**
+ * Minimum account age in days before a user can become an ambassador.
+ * A 30-day window filters out newly created or spam accounts.
+ */
+const MIN_ACCOUNT_AGE_DAYS = 30;
+
+/**
+ * Leaderboard rank threshold for ambassador eligibility.
+ * Only users in the top 100 contributors qualify.
+ */
+const MAX_LEADERBOARD_RANK = 100;
+
+
 const GUIDE_NAMES = [
   "Open Source Guide",
   "Hackathon Guide",
@@ -66,13 +91,13 @@ export class AmbassadorService {
       WHERE "userId" = ${userId}
     `;
     const leaderboardRank = rankRows.length > 0 ? Number(rankRows[0]!.rank) : null;
-    const inTop100 = leaderboardRank !== null && leaderboardRank <= 100;
+    const inTop100 = leaderboardRank !== null && leaderboardRank <= MAX_LEADERBOARD_RANK;
 
-    const accountAgeOk = accountAgeDays >= 30;
+    const accountAgeOk = accountAgeDays >= MIN_ACCOUNT_AGE_DAYS;
 
     const eligible =
-      guidesCompleted >= 6 &&
-      reposContributed >= 3 &&
+      guidesCompleted >= MIN_GUIDES_COMPLETED &&
+      reposContributed >= MIN_REPOS_CONTRIBUTED &&
       accountAgeOk &&
       inTop100;
 


### PR DESCRIPTION
## Description
Set staleTime to 0 and enabled refetchOnWindowFocus in the MySubmissionsPage query so counts stay accurate after cross-tab approval/rejection.

## Related Issue
Fixes #2208

## Type of Change
- [x] Bug Fix

## Testing
- Open submissions page in two tabs
- Approve/reject in one tab
- Switch back to the other tab — counts now refresh automatically

## Screenshots / Video
_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Student submissions page now automatically refreshes when you return to the browser window after switching tabs or applications, ensuring submission data is always current.

* **Refactor**
  * Improved ambassador eligibility criteria implementation with clearer structure for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->