### PR TITLE
fix: correct sessionStorage key in lazyWithRetry to prevent infinite reload loop

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,7 +17,7 @@ function lazyWithRetry<T extends ComponentType<unknown>>(factory: () => Promise<
       factory().catch((err: unknown) => {
         const key = "chunk_reload";
         if (!sessionStorage.getItem(key)) {
-          sessionStorage.setItem("1", "1");
+          sessionStorage.setItem(key, "1");
           window.location.reload();
           return new Promise<never>(() => { }); // never resolves, page is reloading
         }


### PR DESCRIPTION
## Description

The `lazyWithRetry` utility in `client/src/App.tsx` stores the retry flag under the literal string `"1"` instead of the variable `key` (`"chunk_reload"`). This causes an infinite page reload loop on chunk load failure because the flag is never found on subsequent loads.

## Changes
- Changed `sessionStorage.setItem("1", "1")` to `sessionStorage.setItem(key, "1")` at `App.tsx:20`

Closes #2232


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a chunk reload tracking issue that was causing unnecessary repeated reload attempts. The application now properly records reload attempts in session storage, preventing excessive reloads when handling resource loading errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->