### PR TITLE
fix: return 409 Conflict instead of 201 Created for duplicate email registration

### DIFF
--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -27,7 +27,7 @@ export class AuthController {
       return res.status(201).json({ message: "Registration successful. Please verify your email to continue.", user: data.user });
     } catch (error) {
       if (error instanceof Error && error.message === "Email already registered") {
-        return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });
+        return res.status(409).json({ message: "An account with this email address already exists. Please log in or use a different email." });
       }
       console.error(error);
       return res.status(500).json({ message: "Internal Server Error" });


### PR DESCRIPTION
## Description

When a user registers with an already-registered email, `auth.controller.ts` returns HTTP `201 Created` with a success message. This incorrectly leads the client to believe registration succeeded, and the user waits for a verification email that will never arrive.

## Changes
- Changed status code from `201` to `409` in `auth.controller.ts:30`
- Updated error message to clearly indicate the email is already registered

Closes #2233


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for registration attempts with an existing email address. Users now receive a more informative message and correct HTTP status code, directing them to log in to their existing account or register with a different email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->