### PR TITLE
fix: remove duplicate /learn prefix from readiness route

### DIFF
--- a/server/src/module/learn/learn.routes.ts
+++ b/server/src/module/learn/learn.routes.ts
@@ -12,7 +12,7 @@ export const learnRouter = Router();
 
 // New Feature: AI Evaluation Job-Readiness Scorecard (#1088)
 learnRouter.post(
-  "/learn/readiness",
+  "/readiness",
   authMiddleware,
   requireRole("STUDENT"),
   (req, res) => learnController.getInterviewReadinessReport(req, res),


### PR DESCRIPTION
## Description

In `learn.routes.ts`, the route is defined as `/learn/readiness` but the router is mounted at `/api/learn` in `index.ts`, making the actual path `/api/learn/learn/readiness`. Any client calling the intended `/api/learn/readiness` receives a 404.

## Changes
- Changed route from `/learn/readiness` to `/readiness` in `learn.routes.ts:15`

Closes #2234
