### PR TITLE
fix: correct ipKeyGenerator argument in rate limiters

### DIFF
--- a/server/src/middleware/rate-limit.middleware.ts
+++ b/server/src/middleware/rate-limit.middleware.ts
@@ -1,4 +1,4 @@
-import rateLimit, { ipKeyGenerator } from "express-rate-limit";
+import rateLimit from "express-rate-limit";
 import { createRateLimitStore } from "../utils/rate-limit-store.js";
 
 // Rate limiting for AI roadmap generation to prevent abuse and API quota drains
@@ -13,7 +13,7 @@ export const aiRoadmapLimiter = rateLimit({
     if (req.user?.id) {
       return `user_${req.user.id}`;
     }
-    return ipKeyGenerator(req.ip || "unknown_ip");
+    return req.ip || "unknown_ip";
   },
   message: { 
     message: "Too many AI roadmap generation requests. Please try again later."
@@ -27,7 +27,7 @@ export const contactLimiter = rateLimit({
   legacyHeaders: false,
   store: createRateLimitStore("contact"),
   keyGenerator: (req) => {
-    return ipKeyGenerator(req.ip || "unknown_ip");
+    return req.ip || "unknown_ip";
   },
   message: {
     message: "Too many contact submissions. Please try again later."
@@ -46,7 +46,7 @@ export const githubSyncLimiter = rateLimit({
     if (req.user?.id) {
       return `user_${req.user.id}`;
     }
-    return ipKeyGenerator(req.ip || "unknown_ip");
+    return req.ip || "unknown_ip";
   },
   message: {
     message: "Too many GitHub sync requests. Please try again later."

--- a/server/src/module/job-agent/job-agent.routes.ts
+++ b/server/src/module/job-agent/job-agent.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import rateLimit, { ipKeyGenerator } from "express-rate-limit";
+import rateLimit from "express-rate-limit";
 import { createRateLimitStore } from "../../utils/rate-limit-store.js";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
 import { requireRole } from "../../middleware/role.middleware.js";
@@ -20,7 +20,7 @@ const chatBurstLimiter = rateLimit({
   store: createRateLimitStore("chat-burst"),
   keyGenerator: (req) => {
     const userId = req.user?.id;
-    return userId ? `u:${userId}` : `ip:${ipKeyGenerator(req.ip || "unknown_ip")}`;
+    return userId ? `u:${userId}` : `ip:${req.ip || "unknown_ip"}`;
   },
   message: { message: "You're sending messages too quickly. Please wait a moment and try again." },
 });


### PR DESCRIPTION
## Description

`ipKeyGenerator` from `express-rate-limit` was called with a string argument (`req.ip || "unknown_ip"`) instead of the expected `Request` object. This caused rate-limit keys to be generated incorrectly, making rate limiting unreliable across three limiters (AI roadmap, contact, GitHub sync) and the job-agent chat burst limiter.

## Changes
- Replaced `ipKeyGenerator(req.ip || "unknown_ip")` with `req.ip || "unknown_ip"` in:
  - `rate-limit.middleware.ts` (3 occurrences)
  - `job-agent.routes.ts` (1 occurrence)
- Removed unused `ipKeyGenerator` imports

Closes #2237
