### PR TITLE
fix: add partial-match fallback to error middleware status mapping

### DIFF
--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -148,6 +148,21 @@ export function errorMiddleware(err: Error, req: Request, res: Response, _next: 
     return;
   }
 
+  // Fallback: try partial matches for dynamic error messages
+  const msg = err.message.toLowerCase();
+  if (msg.includes("not found")) {
+    respond(req, res, 404, err.message, err);
+    return;
+  }
+  if (msg.includes("already") && (msg.includes("exists") || msg.includes("registered") || msg.includes("applied"))) {
+    respond(req, res, 409, err.message, err);
+    return;
+  }
+  if (msg.includes("unauthorized") || msg.includes("not authorized")) {
+    respond(req, res, 403, err.message, err);
+    return;
+  }
+
   // Unknown errors - don't leak details in production
   const isDev = process.env["NODE_ENV"] === "development";
   console.error("Unhandled error:", isDev ? err.stack : err.message);


### PR DESCRIPTION
## Description

The `error.middleware.ts` `clientErrors` map matched errors purely by exact `err.message` string. Minor changes in message phrasing (trailing punctuation, dynamic interpolation) would silently fall through to a generic 500 response instead of the intended HTTP status.

## Changes
- Added partial-match fallback after the exact match: checks for keywords like "not found" (→404), "already" with "exists/registered/applied" (→409), and "unauthorized/not authorized" (→403)
- This handles dynamic error messages without requiring every variation to be listed

Closes #2238
