### PR TITLE
fix: add missing authMiddleware to logout route

### DIFF
--- a/server/src/module/auth/auth.routes.ts
+++ b/server/src/module/auth/auth.routes.ts
@@ -66,7 +66,7 @@ authRouter.post("/verify-email", verifyEmailRateLimit, validateBody(verifyEmailS
 authRouter.post("/resend-otp", resendOtpRateLimit, validateBody(resendOtpSchema), (req, res) => authController.resendOtp(req, res));
 authRouter.post("/forgot-password", forgotPasswordRateLimit, validateBody(forgotPasswordSchema), (req, res) => authController.forgotPassword(req, res));
 authRouter.post("/reset-password", resetPasswordRateLimit, validateBody(resetPasswordSchema), (req, res) => authController.resetPassword(req, res));
-authRouter.post("/logout", (req, res) => authController.logout(req, res));
+authRouter.post("/logout", authMiddleware, (req, res) => authController.logout(req, res));
 authRouter.get("/me", authMiddleware, (req, res) => authController.getProfile(req, res));
 authRouter.put("/me", authMiddleware, validateBody(updateProfileSchema), (req, res) => authController.updateProfile(req, res));
 authRouter.post("/import-github", authMiddleware, validateBody(importGitHubSchema), (req, res) => authController.importGitHub(req, res));


### PR DESCRIPTION
## Description

The `POST /logout` route in `auth.routes.ts` had no `authMiddleware`, unlike every other user-specific endpoint in the auth module. While clearing the cookie is low-impact, the missing guard is inconsistent with the codebase pattern and could become a real issue if logout logic expands to include server-side side effects.

## Changes
- Added `authMiddleware` to the logout route at `auth.routes.ts:69`

Closes #2239
