### PR TITLE
fix: move dynamic /:id route after static routes in scraper

### DIFF
--- a/server/src/module/scraper/scraper.routes.ts
+++ b/server/src/module/scraper/scraper.routes.ts
@@ -6,11 +6,10 @@ import { requireRole } from "../../middleware/role.middleware.js";
 const controller = new ScraperController();
 export const scraperRouter = Router();
 
-// Public endpoints
+// Public endpoints — static routes before param-based routes
 scraperRouter.get("/", (req, res, next) => controller.getScrapedJobs(req, res, next));
 scraperRouter.get("/sources", (req, res) => controller.getSources(req, res));
 scraperRouter.get("/stats", (req, res, next) => controller.getStats(req, res, next));
-scraperRouter.get("/:id", (req, res, next) => controller.getScrapedJobById(req, res, next));
 
 // Protected: Only recruiters can manually trigger scraping
 scraperRouter.post(
@@ -19,6 +18,9 @@ scraperRouter.post(
   requireRole("RECRUITER"),
   (req, res, next) => controller.triggerScrape(req, res, next)
 );
+
+// Dynamic route must be registered after all static routes
+scraperRouter.get("/:id", (req, res, next) => controller.getScrapedJobById(req, res, next));
 
 // Export controller for cron initialization
 export { controller as scraperController };


### PR DESCRIPTION
## Description

In `scraper.routes.ts`, the dynamic `GET /:id` route was registered before `POST /trigger`. While the POST method doesn't currently conflict, this ordering is fragile — any future `GET /trigger` would be silently shadowed by `/:id`. This same issue is documented with warnings in `opensource.routes.ts`.

## Changes
- Moved `GET /:id` to the end of the route registration, after all static routes
- Added comment noting the ordering requirement

Closes #2240
