### PR TITLE
fix: skip Login/Signup redirect for authenticated users on homepage CTAs

### DIFF
--- a/client/src/components/AudienceSection.tsx
+++ b/client/src/components/AudienceSection.tsx
@@ -1,6 +1,7 @@
 import { motion } from "framer-motion";
 import { Link } from "react-router";
 import { ArrowRight, GraduationCap, Briefcase, Target } from "lucide-react";
+import { useAuthStore } from "../lib/auth.store";
 
 const REVEAL_IN_VIEW = { opacity: 1, y: 0 };
 const REVEAL_VIEWPORT = { once: true };
@@ -51,6 +52,9 @@ const AUDIENCES = [
 ];
 
 export function AudienceSection() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const ctaHref = isAuthenticated ? "/student/applications" : "/register";
+
   return (
     <section className="relative py-24 md:py-32 bg-white dark:bg-stone-950 border-t border-stone-200 dark:border-white/10">
       <div className="max-w-6xl mx-auto px-6">
@@ -120,7 +124,7 @@ export function AudienceSection() {
                 ))}
               </ul>
 
-              <Link to={a.cta.href} className="no-underline mt-10">
+              <Link to={ctaHref} className="no-underline mt-10">
                 <span className="inline-flex items-center gap-2 text-sm font-bold text-stone-900 dark:text-stone-50 border-b border-stone-900 dark:border-stone-50 pb-0.5 group-hover:gap-3 transition-all duration-300">
                   {a.cta.label}
                   <ArrowRight className="w-4 h-4" />

--- a/client/src/components/CTASection.tsx
+++ b/client/src/components/CTASection.tsx
@@ -2,6 +2,7 @@ import { motion, useInView } from "framer-motion";
 import { ArrowRight, Play } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
+import { useAuthStore } from "../lib/auth.store";
 
 function useCountUp(target: number, isInView: boolean, duration = 2000) {
   const [count, setCount] = useState(0);
@@ -60,6 +61,8 @@ function StatItem({ target, label, isInView, duration }: StatItemProps) {
 export function CTASection() {
   const statsRef = useRef(null);
   const isInView = useInView(statsRef, { once: true, margin: "-100px" });
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const ctaHref = isAuthenticated ? "/student/applications" : "/register";
 
   return (
     <section className="relative py-24 md:py-32 bg-stone-50 dark:bg-stone-950 border-t border-stone-200 dark:border-white/10">
@@ -103,7 +106,7 @@ export function CTASection() {
               </p>
 
               <div className="mt-10 flex flex-col sm:flex-row gap-3">
-                <Link to="/register" className="no-underline">
+                <Link to={ctaHref} className="no-underline">
                   <button className="group inline-flex items-center gap-2 px-6 py-3.5 bg-lime-400 text-stone-950 rounded-lg text-sm font-bold hover:bg-lime-300 transition-colors cursor-pointer border-0">
                     Start free
                     <ArrowRight className="w-4 h-4 group-hover:translate-x-0.5 transition-transform" />


### PR DESCRIPTION
## Problem

Authenticated users clicking the homepage CTA buttons — **"Start free"**, **"Upgrade my resume"**, and **"Track my search"** — were being redirected to the `/register` page instead of navigating directly to their dashboard. This created a broken user experience where logged-in users saw the signup flow unnecessarily.

## Root Cause

All four CTA `<Link>` elements across `CTASection.tsx` and `AudienceSection.tsx` had their `to` prop hardcoded to `"/register"`, with no check for the user's authentication state. The `HeroSection.tsx` component already handled this correctly using `useAuthStore`, but the pattern was not applied to the other homepage CTAs.

## Changes

### `client/src/components/CTASection.tsx`
- Imported `useAuthStore` from the auth store
- Added auth-aware href computation: authenticated users → `/student/applications`, unauthenticated → `/register`
- Updated the **"Start free"** `<Link>` to use the computed href
 
### `client/src/components/AudienceSection.tsx`
- Imported `useAuthStore` from the auth store
- Added auth-aware href computation (same logic)
- Updated the shared `<Link>` used by all three audience cards (**"Start free"**, **"Upgrade my resume"**, **"Track my search"**) to use the computed href

## Affected Buttons

| Button | Component | Section |
|--------|-----------|---------|
| Start free | `CTASection` | Bottom dark CTA card |
| Start free | `AudienceSection` | "01 / students" card |
| Upgrade my resume | `AudienceSection` | "02 / industry pros" card |
| Track my search | `AudienceSection` | "03 / active job seekers" card |


## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Authenticated user clicks CTA | Redirected to `/register` | Navigates to `/student/applications` |
| Unauthenticated user clicks CTA | Redirected to `/register` | Redirected to `/register` (no change) |


## Testing
- Verified authenticated users can access CTA destinations without re-authenticating.
- Verified unauthenticated users are still redirected to the registration flow.
- Verified behavior remains consistent after page refresh.
- Tested all affected homepage CTA buttons.

Fixes #2192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Call-to-action buttons throughout the application now intelligently route users based on authentication status. Authenticated users are directed to view their applications, while unauthenticated users are guided to the registration page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->