### PR TITLE
fix(#2259): add null guard in ProfileRedirect for unauthenticated users

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -319,7 +319,8 @@ function ApplyRedirect() {
 function ProfileRedirect() {
   const { id } = useParams();
   const { user } = useAuthStore();
-  const base = user?.role === "ADMIN" ? "/admin" : "/recruiters";
+  if (!user) return <Navigate to="/login" replace />;
+  const base = user.role === "ADMIN" ? "/admin" : "/recruiters";
   return <Navigate to={`${base}/profile/${id}`} replace />;
 }
 


### PR DESCRIPTION
Fixes ProfileRedirect to explicitly handle the unauthenticated case. Previously, when user was null the ternary defaulted to /recruiters path. Now null users are redirected to /login. Closes #2259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile redirection to ensure users are logged in before accessing their profile and are properly routed to their role-specific area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->