### PR TITLE
fix(#2260): add role=menuitem to MobileNavLink for ARIA compliance

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -418,6 +418,7 @@ function MobileNavLink({
     <Link
       to={href}
       onClick={onClick}
+      role="menuitem"
       className="block px-3 py-2 text-sm text-stone-700 hover:text-stone-900 hover:bg-stone-100 dark:text-stone-300 dark:hover:text-stone-50 dark:hover:bg-white/5 rounded-md transition-all font-medium no-underline"
     >
       {children}


### PR DESCRIPTION
Fixes the ARIA menu accessibility violation by adding role='menuitem' to the MobileNavLink component. The parent div uses role='menu' so all child links must have role='menuitem' per the ARIA specification. This improves screen reader navigation. Closes #2260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved semantic markup for mobile navigation menu items to enhance support for assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->