### PR TITLE
fix: set ROADMAP_GENERATION daily FREE limit to 1

### DIFF
--- a/server/src/config/usage-limits.ts
+++ b/server/src/config/usage-limits.ts
@@ -25,7 +25,7 @@ export const DAILY_LIMITS: Record<UsageAction, Record<PlanTier, number>> = {
   AI_JOB_CHAT:     { FREE: 2,  PREMIUM: 50 },
   CODE_RUN:        { FREE: 0,  PREMIUM: 50 },
   GITHUB_STATS:    { FREE: 20, PREMIUM: 9999 },
-  ROADMAP_GENERATION: { FREE: 0, PREMIUM: 10 }, // placeholder — actual limits in MONTHLY_LIMITS
+  ROADMAP_GENERATION: { FREE: 1, PREMIUM: 10 },
   STREAK_TICK: { FREE: 1, PREMIUM: 10 },
 };
 


### PR DESCRIPTION
## Description

`ROADMAP_GENERATION` had a daily limit of `{ FREE: 0, PREMIUM: 10 }` in `usage-limits.ts`. While monthly limits existed (`FREE: 5, PREMIUM: 50`), the usage-limit middleware defaults to checking daily limits, causing every FREE-tier request to be rejected with 429.

## Changes
- Changed `ROADMAP_GENERATION` daily limit from `{ FREE: 0, PREMIUM: 10 }` to `{ FREE: 1, PREMIUM: 10 }` in `usage-limits.ts`
- Removed stale placeholder comment

Closes #2235
