### PR TITLE
fix: set non-zero FREE daily limits for MOCK_INTERVIEW and CODE_RUN

### DIFF
--- a/server/src/config/usage-limits.ts
+++ b/server/src/config/usage-limits.ts
@@ -20,10 +20,10 @@ export const DAILY_LIMITS: Record<UsageAction, Record<PlanTier, number>> = {
   COVER_LETTER:    { FREE: 2,  PREMIUM: 20 },
   GENERATE_RESUME: { FREE: 1,  PREMIUM: 20 },
   JOB_APPLICATION: { FREE: 10, PREMIUM: 9999 },
-  MOCK_INTERVIEW:  { FREE: 0,  PREMIUM: 99 },
+  MOCK_INTERVIEW:  { FREE: 1,  PREMIUM: 99 },
   BEHAVIORAL_EVAL: { FREE: 5,  PREMIUM: 999999 },
   AI_JOB_CHAT:     { FREE: 2,  PREMIUM: 50 },
-  CODE_RUN:        { FREE: 0,  PREMIUM: 50 },
+  CODE_RUN:        { FREE: 3,  PREMIUM: 50 },
   GITHUB_STATS:    { FREE: 20, PREMIUM: 9999 },
   ROADMAP_GENERATION: { FREE: 0, PREMIUM: 10 }, // placeholder — actual limits in MONTHLY_LIMITS
   STREAK_TICK: { FREE: 1, PREMIUM: 10 },


### PR DESCRIPTION
## Description

`MOCK_INTERVIEW` had a daily FREE limit of 0 and `CODE_RUN` had a daily FREE limit of 0, preventing free-tier users from trying these features at all. Set non-zero limits so they can experience the feature before upgrading.

## Changes
- Changed `MOCK_INTERVIEW` daily limit from `{ FREE: 0, PREMIUM: 99 }` to `{ FREE: 1, PREMIUM: 99 }`
- Changed `CODE_RUN` daily limit from `{ FREE: 0, PREMIUM: 50 }` to `{ FREE: 3, PREMIUM: 50 }`

Closes #2241


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FREE plan users now have access to mock interviews (1 per day) and code execution (3 per day).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->