### PR TITLE
fix: store file upload validation errors in local state instead of field value

### DIFF
--- a/client/src/components/DynamicFieldRenderer.tsx
+++ b/client/src/components/DynamicFieldRenderer.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { CustomFieldDefinition } from "../lib/types";
 
 interface DynamicFieldRendererProps {
@@ -20,6 +21,52 @@ export function DynamicFieldRenderer({ fields, values, onChange, onFileSelect, d
           {renderField(field, values[field.id], (val) => onChange(field.id, val), disabled, onFileSelect ? (file) => onFileSelect(field.id, file) : undefined)}
         </div>
       ))}
+    </div>
+  );
+}
+
+function FileUploadField({ field, value, onChange, onFileSelect, disabled }: {
+  field: CustomFieldDefinition;
+  value: unknown;
+  onChange: (val: unknown) => void;
+  onFileSelect?: (file: File) => void;
+  disabled?: boolean;
+}) {
+  const [fileError, setFileError] = useState<string | null>(null);
+  const maxSize = field.validation?.maxFileSize || 5 * 1024 * 1024;
+  const allowedTypes = field.validation?.allowedTypes;
+  return (
+    <div>
+      <input
+        type="file"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          setFileError(null);
+          if (!file) return;
+          if (file.size > maxSize) {
+            setFileError(`File exceeds ${Math.round(maxSize / 1024 / 1024)}MB limit`);
+            e.target.value = "";
+            return;
+          }
+          if (allowedTypes?.length && !allowedTypes.some((t) => file.type === t || file.name.endsWith(t))) {
+            setFileError(`Only ${allowedTypes.join(", ")} files allowed`);
+            e.target.value = "";
+            return;
+          }
+          onChange(file.name);
+          onFileSelect?.(file);
+        }}
+        disabled={disabled}
+        className="block w-full text-sm text-gray-500 dark:text-gray-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-gray-900 file:text-white dark:file:bg-white dark:file:text-gray-950 hover:file:bg-gray-700 dark:hover:file:bg-gray-200 file:cursor-pointer"
+        accept={allowedTypes?.join(",")}
+      />
+      {fileError && (
+        <p className="mt-1 text-sm text-red-500">{fileError}</p>
+      )}
+      {!fileError && typeof value === "string" && value && (
+        <p className="mt-1 text-sm text-gray-500">Selected: {value}</p>
+      )}
+      <p className="mt-0.5 text-xs text-gray-400">Max {Math.round(maxSize / 1024 / 1024)}MB</p>
     </div>
   );
 }
@@ -147,42 +194,8 @@ function renderField(
         </div>
       );
 
-    case "FILE_UPLOAD": {
-      const maxSize = field.validation?.maxFileSize || 5 * 1024 * 1024; // default 5MB
-      const allowedTypes = field.validation?.allowedTypes;
-      return (
-        <div>
-          <input
-            type="file"
-            onChange={(e) => {
-              const file = e.target.files?.[0];
-              if (!file) return;
-              if (file.size > maxSize) {
-                onChange(`Error: File exceeds ${Math.round(maxSize / 1024 / 1024)}MB limit`);
-                e.target.value = "";
-                return;
-              }
-              if (allowedTypes?.length && !allowedTypes.some((t) => file.type === t || file.name.endsWith(t))) {
-                onChange(`Error: Only ${allowedTypes.join(", ")} files allowed`);
-                e.target.value = "";
-                return;
-              }
-              onChange(file.name);
-              onFileSelect?.(file);
-            }}
-            disabled={disabled}
-            className="block w-full text-sm text-gray-500 dark:text-gray-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-gray-900 file:text-white dark:file:bg-white dark:file:text-gray-950 hover:file:bg-gray-700 dark:hover:file:bg-gray-200 file:cursor-pointer"
-            accept={allowedTypes?.join(",")}
-          />
-          {typeof value === "string" && value && (
-            <p className={`mt-1 text-sm ${value.startsWith("Error:") ? "text-red-500" : "text-gray-500"}`}>
-              {value.startsWith("Error:") ? value : `Selected: ${value}`}
-            </p>
-          )}
-          <p className="mt-0.5 text-xs text-gray-400">Max {Math.round(maxSize / 1024 / 1024)}MB</p>
-        </div>
-      );
-    }
+    case "FILE_UPLOAD":
+      return <FileUploadField field={field} value={value} onChange={onChange} onFileSelect={onFileSelect} disabled={disabled} />;
 
     default:
       return (


### PR DESCRIPTION
Fixes the DynamicFieldRenderer file upload validation so error messages are stored in local component state instead of being written to the field value via onChange(). Previously, validation errors like 'File exceeds 5MB limit' were set as the field value, corrupting form data on submission. Now errors are displayed visually while the field value remains clean. Closes #2256