### PR TITLE
fix: show error toast on role mismatch in ProtectedRoute

### DIFF
--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -33,7 +33,7 @@ export function ProtectedRoute({ children, role, redirectTo = "/login" }: Protec
   }
 
   if (role && user?.role !== role) {
-    return <Navigate to="/" replace />;
+    return <RedirectWithToast to="/" />;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
Fixes the ProtectedRoute role mismatch handling to show an error toast before redirecting to the homepage. Previously, users were silently redirected without any explanation when they lacked the required role for a page. Now they see a 'Please login to access this resource' message. Closes #2257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced access control feedback. Users now receive a notification when redirected due to insufficient permissions, providing clearer context for access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->