### PR TITLE
fix: respect navigation state in ScrollToTop for scroll preservation

### DIFF
--- a/client/src/components/common/ScrollToTop.tsx
+++ b/client/src/components/common/ScrollToTop.tsx
@@ -7,11 +7,12 @@ import { useLocation } from "react-router";
  * It renders nothing — it only runs the side-effect.
  */
 export default function ScrollToTop() {
-  const { pathname } = useLocation();
+  const { pathname, state } = useLocation();
 
   useEffect(() => {
+    if ((state as { scrollToTop?: boolean } | null)?.scrollToTop === false) return;
     window.scrollTo(0, 0);
-  }, [pathname]);
+  }, [pathname, state]);
 
   return null;
 }


### PR DESCRIPTION
Updates ScrollToTop to respect location.state for scroll preservation. Now checks for a scrollToTop: false flag in the navigation state, allowing back-navigation to preserve scroll position on list pages. Closes #2258