### PR TITLE
fix: prisma build script uses directory path for --schema

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "prisma generate --schema=src/database/prisma/schema && tsc",
+    "build": "prisma generate --config src/database/prisma.config.ts && tsc",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
Fixes the prisma build script which was using --schema with a directory path instead of --config with the prisma.config.ts file. This caused build failures in CI/deployment. Closes #2253