### PR TITLE
fix: admin alert email hardcoded in error middleware

### DIFF
--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -4,7 +4,7 @@ import { prisma } from "../database/db.js";
 import { sendEmail } from "../utils/email.utils.js";
 import { FileUploadError } from "../lib/errors.js";
 
-const ADMIN_ALERT_EMAIL = "mrsachinchaurasiya@gmail.com";
+const ADMIN_ALERT_EMAIL = process.env["ADMIN_ALERT_EMAIL"] ?? "mrsachinchaurasiya@gmail.com";
 
 const SENSITIVE_KEYS = new Set([
   "password", "newPassword", "confirmPassword", "currentPassword",


### PR DESCRIPTION
Moves the hardcoded admin alert email address to an environment variable with the original value as fallback. This allows fork operators and self-hosted instances to configure their own alert destination without modifying source code. Closes #2254