### PR TITLE
fix: recruiter registration doesn't require company name

### DIFF
--- a/server/src/module/auth/auth.validation.ts
+++ b/server/src/module/auth/auth.validation.ts
@@ -61,6 +61,13 @@ export const registerSchema = z.object({
         path: ["email"],
       });
     }
+    if (!data.company || !data.company.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Company name is required for recruiter accounts",
+        path: ["company"],
+      });
+    }
   }
 });
 


### PR DESCRIPTION
Adds validation requiring the company name field for recruiter registrations. Previously, recruiters could create accounts without a company name, leading to incomplete profiles. Now company is mandatory when role is RECRUITER. Closes #2255