### PR TITLE
fix: logout() duplicates API_BASE URL construction

### DIFF
--- a/client/src/lib/auth.store.ts
+++ b/client/src/lib/auth.store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { QueryClient } from "@tanstack/react-query";
+import { API_BASE } from "./axios";
 import type { User } from "./types";
 
 // Shared query client reference for cache invalidation on auth changes
@@ -37,10 +38,7 @@ export const useAuthStore = create<AuthState>((set) => {
       set({ user: null, isAuthenticated: false });
       _queryClient?.clear();
       // Clear httpOnly cookie server-side (fire-and-forget)
-      fetch(
-        `${(import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:3000/api"}/auth/logout`,
-        { method: "POST", credentials: "include" },
-      ).catch(() => {});
+      fetch(`${API_BASE}/auth/logout`, { method: "POST", credentials: "include" }).catch(() => {});
     },
 
     setUser: (user) => {

--- a/client/src/lib/axios.ts
+++ b/client/src/lib/axios.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { useAuthStore } from "./auth.store";
 
-const API_BASE = (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:3000/api";
+export const API_BASE = (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:3000/api";
 export const SERVER_URL = API_BASE.replace(/\/api\/?$/, "");
 
 const api = axios.create({


### PR DESCRIPTION
Fixes the logout() function to reuse the shared API_BASE constant from axios.ts instead of duplicating the VITE_API_URL fallback logic. This eliminates a maintainability risk where updating the API base URL in one place could silently break logout in the other. Closes #2261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized API base URL configuration to be reused across authentication and API modules, improving code consistency and reducing duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->