### PR TITLE
fix(accessibility): add visible keyboard focus state to RepoCard

### DIFF
--- a/client/src/module/student/opensource/RepoCard.tsx
+++ b/client/src/module/student/opensource/RepoCard.tsx
@@ -33,7 +33,7 @@ export const RepoCard = React.memo(React.forwardRef<HTMLDivElement, RepoCardProp
       <button
         aria-label={`${repo.name} by ${repo.owner}, ${repo.difficulty} difficulty, ${repo.stars} stars, ${repo.openIssues} open issues${bookmarked ? ", Bookmarked" : ""}`}
         onClick={() => onSelect(repo)}
-        className="group relative flex flex-col h-full w-full text-left bg-white dark:bg-stone-900 rounded-md border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25 transition-colors cursor-pointer"
+        className="group relative flex flex-col h-full w-full text-left bg-white dark:bg-stone-900 rounded-md border border-stone-200 dark:border-white/10 hover:border-stone-400 dark:hover:border-white/25 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-stone-950"
       >
         {repo.trending && (
           <div className="absolute -top-2 right-12 inline-flex items-center gap-1 rounded-md bg-stone-900 dark:bg-stone-50 px-2 py-0.5 text-[10px] font-mono uppercase tracking-widest text-lime-400">
@@ -93,7 +93,7 @@ export const RepoCard = React.memo(React.forwardRef<HTMLDivElement, RepoCardProp
                   e.preventDefault();
                   onToggleBookmark(repo.id);
                 }}
-                className="p-1 text-stone-400 hover:text-lime-600 dark:hover:text-lime-400 transition-colors"
+                className="p-1 text-stone-400 hover:text-lime-600 dark:hover:text-lime-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lime-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-stone-900 rounded-sm"
               >
                 {bookmarked ? <BookmarkCheck size={16} className="text-lime-600 dark:text-lime-400" /> : <Bookmark size={16} />}
               </button>


### PR DESCRIPTION
# Pull Request

## Description
Add visible focus styling to the student repo card and bookmark action so keyboard users can clearly see which interactive element is focused.

## Related Issue
Fixes #2209 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
Verified the repo card component receives the new `focus-visible` ring styles and confirmed the interactive button remains keyboard-accessible.

## Screenshots / Video

> **REQUIRED for any UI change.** PRs that modify visible UI (layout, components, styles, pages) will be rejected without this.

<!-- Add a screenshot or screen recording below. Drag and drop images/GIFs here, or paste a video link. -->

<img width="1918" height="868" alt="image" src="https://github.com/user-attachments/assets/dbdb2348-e598-479d-94d6-d39181e0d2e4" />
<img width="1919" height="872" alt="image" src="https://github.com/user-attachments/assets/e4f161b9-9ae6-41f0-9022-91f9f25391e0" />

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved keyboard focus visibility for buttons, providing clearer visual feedback when navigating via keyboard.
  * Enhanced bookmark button styling with better focus states and refined appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->