### PR TITLE
fix: send full language array in repo filter and add multi-language t…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/dummy"
+
 jobs:
   typecheck-client:
     name: Typecheck Client

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,8 @@
     "build": "npx puppeteer browsers install chrome && vite build",
     "lint": "eslint .",
     "typecheck": "tsc -b",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@codemirror/lang-cpp": "^6.0.3",

--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -98,7 +98,7 @@ export const queryKeys = {
   // Open Source
   opensource: {
     all: ["opensource"] as const,
-    list: (params?: Record<string, string | number>) =>
+    list: (params?: Record<string, string | number | string[]>) =>
       ["opensource", "list", params] as const,
     detail: (id: number) => ["opensource", "detail", id] as const,
     myRequests: () => ["opensource", "my-requests"] as const,

--- a/client/src/module/student/opensource/RepoDiscoveryPage.tsx
+++ b/client/src/module/student/opensource/RepoDiscoveryPage.tsx
@@ -35,7 +35,7 @@ import { PaginationControls } from "../../../components/ui/PaginationControls";
 import type { OpenSourceRepo, Pagination } from "../../../lib/types";
 import { useAuthStore } from "../../../lib/auth.store";
 import { REPO_DOMAINS, DIFFICULTY_OPTIONS, SORT_OPTIONS, LANGUAGE_COLORS } from "./reposData";
-import { formatCount, difficultyBadge } from "./_shared/repo-utils";
+import { formatCount, difficultyBadge, buildLanguageParam } from "./_shared/repo-utils";
 import { RepoCard, RepoCardSkeleton } from "./RepoCard";
 import { GuidanceCards } from "./GuidanceCards";
 import { useRecentlyViewedRepos } from "./useRecentlyViewedRepos";
@@ -262,19 +262,14 @@ export default function RepoDiscoveryPage() {
   };
 
   const queryParams = useMemo(() => {
-    const params: Record<string, string | number> = { page, limit: 12, sort: sortKey, sortOrder: "desc" };
+    const params: Record<string, string | number | string[]> = { page, limit: 12, sort: sortKey, sortOrder: "desc" };
 
     if (search.trim()) params.search = search.trim();
     if (selectedDomain !== "ALL") params.domain = selectedDomain;
     if (selectedDifficulty !== "ALL") params.difficulty = selectedDifficulty;
 
-    if (languageMode === "auto") {
-      if (inferredLanguages.length > 0) {
-        params.language = inferredLanguages[0];
-      }
-    } else if (selectedLanguage.length > 0) {
-      params.language = selectedLanguage[0];
-    }
+    const languageParam = buildLanguageParam(languageMode, selectedLanguage, inferredLanguages);
+    if (languageParam) params.language = languageParam;
 
     if (trendingOnly) params.trending = "true";
     if (hacktoberfestOnly) params.hacktoberfest = "true";

--- a/client/src/module/student/opensource/_shared/repo-utils.test.ts
+++ b/client/src/module/student/opensource/_shared/repo-utils.test.ts
@@ -32,4 +32,16 @@ describe("buildLanguageParam", () => {
   it("returns undefined in auto mode with no inferred languages", () => {
     expect(buildLanguageParam("auto", ["Python"], [])).toBeUndefined();
   });
+
+  it("filters out empty strings, trims whitespace, and removes duplicates", () => {
+    expect(buildLanguageParam("manual", ["", "  ", "Python", "  JavaScript  ", "Python"], [])).toEqual([
+      "Python",
+      "JavaScript",
+    ]);
+  });
+
+  it("returns undefined if only empty/whitespace strings remain", () => {
+    expect(buildLanguageParam("manual", ["", "  "], [])).toBeUndefined();
+    expect(buildLanguageParam("auto", [], ["", "   "])).toBeUndefined();
+  });
 });

--- a/client/src/module/student/opensource/_shared/repo-utils.test.ts
+++ b/client/src/module/student/opensource/_shared/repo-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { buildLanguageParam } from "./repo-utils";
+
+describe("buildLanguageParam", () => {
+  it("returns full array for multiple manually selected languages", () => {
+    expect(buildLanguageParam("manual", ["Python", "JavaScript"], [])).toEqual([
+      "Python",
+      "JavaScript",
+    ]);
+  });
+
+  it("returns single-element array for one selected language", () => {
+    expect(buildLanguageParam("manual", ["Go"], [])).toEqual(["Go"]);
+  });
+
+  it("returns undefined when no languages are selected (manual mode)", () => {
+    expect(buildLanguageParam("manual", [], [])).toBeUndefined();
+  });
+
+  it("uses inferred languages in auto mode", () => {
+    expect(
+      buildLanguageParam("auto", [], ["TypeScript", "Java"]),
+    ).toEqual(["TypeScript", "Java"]);
+  });
+
+  it("ignores selectedLanguage in auto mode, uses only inferred", () => {
+    expect(
+      buildLanguageParam("auto", ["Python"], ["TypeScript"]),
+    ).toEqual(["TypeScript"]);
+  });
+
+  it("returns undefined in auto mode with no inferred languages", () => {
+    expect(buildLanguageParam("auto", ["Python"], [])).toBeUndefined();
+  });
+});

--- a/client/src/module/student/opensource/_shared/repo-utils.ts
+++ b/client/src/module/student/opensource/_shared/repo-utils.ts
@@ -68,8 +68,10 @@ export function buildLanguageParam(
   selectedLanguage: string[],
   inferredLanguages: string[],
 ): string[] | undefined {
-  if (languageMode === "auto") {
-    return inferredLanguages.length > 0 ? inferredLanguages : undefined;
-  }
-  return selectedLanguage.length > 0 ? selectedLanguage : undefined;
+  const normalize = (langs: string[]) =>
+    [...new Set(langs.map((l) => l.trim()).filter(Boolean))];
+
+  const raw = languageMode === "auto" ? inferredLanguages : selectedLanguage;
+  const normalized = normalize(raw);
+  return normalized.length > 0 ? normalized : undefined;
 }

--- a/client/src/module/student/opensource/_shared/repo-utils.ts
+++ b/client/src/module/student/opensource/_shared/repo-utils.ts
@@ -58,3 +58,18 @@ export function parseGithubRepoUrl(raw: string): { owner: string; name: string }
   if (!nameRe.test(owner) || !nameRe.test(name)) return null;
   return { owner, name };
 }
+
+/**
+ * Builds the language query parameter for the repo list API call.
+ * Returns undefined when no languages should be filtered (i.e. show all).
+ */
+export function buildLanguageParam(
+  languageMode: string,
+  selectedLanguage: string[],
+  inferredLanguages: string[],
+): string[] | undefined {
+  if (languageMode === "auto") {
+    return inferredLanguages.length > 0 ? inferredLanguages : undefined;
+  }
+  return selectedLanguage.length > 0 ? selectedLanguage : undefined;
+}

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/server/src/__tests__/opensource.service.test.ts
+++ b/server/src/__tests__/opensource.service.test.ts
@@ -15,6 +15,7 @@ vi.mock("../database/db.js", () => ({
       create: vi.fn(),
       findMany: vi.fn(),
       findUnique: vi.fn(),
+      count: vi.fn(),
     },
     opensourceBookmark: {
       findMany: vi.fn(),
@@ -184,5 +185,80 @@ describe("OpensourceService.approveRepoRequest", () => {
     });
     expect(result).toBeDefined();
     expect(result.id).toBe(REPO_ID);
+  });
+});
+
+describe("OpensourceService.listRepos — multi-language filter", () => {
+  const baseQuery = {
+    page: 1,
+    limit: 20,
+    sortBy: "stars",
+    sortOrder: "desc" as const,
+  };
+
+  it("queries with { in: [...] } for multiple languages", async () => {
+    vi.mocked(prisma.opensourceRepo.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.opensourceRepo.count).mockResolvedValue(0);
+
+    await service.listRepos({
+      ...baseQuery,
+      language: ["Python", "TypeScript"],
+    });
+
+    expect(prisma.opensourceRepo.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          language: { in: ["Python", "TypeScript"], mode: "insensitive" },
+        }),
+      }),
+    );
+  });
+
+  it("still works correctly with a single language", async () => {
+    vi.mocked(prisma.opensourceRepo.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.opensourceRepo.count).mockResolvedValue(0);
+
+    await service.listRepos({ ...baseQuery, language: ["Go"] });
+
+    expect(prisma.opensourceRepo.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          language: { in: ["Go"], mode: "insensitive" },
+        }),
+      }),
+    );
+  });
+
+  it("returns empty result when no repos match any selected language", async () => {
+    vi.mocked(prisma.opensourceRepo.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.opensourceRepo.count).mockResolvedValue(0);
+
+    const result = await service.listRepos({
+      ...baseQuery,
+      language: ["NonexistentLang"],
+    });
+
+    expect(result.repos).toEqual([]);
+    expect(result.pagination.total).toBe(0);
+  });
+
+  it("does not filter by language when none are selected", async () => {
+    vi.mocked(prisma.opensourceRepo.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.opensourceRepo.count).mockResolvedValue(0);
+
+    await service.listRepos({ ...baseQuery, language: undefined });
+
+    const callArgs = vi.mocked(prisma.opensourceRepo.findMany).mock.calls[0][0];
+    expect(callArgs.where).not.toHaveProperty("language");
+  });
+
+  it("does not filter by language for empty array", async () => {
+    vi.mocked(prisma.opensourceRepo.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.opensourceRepo.count).mockResolvedValue(0);
+
+    await service.listRepos({ ...baseQuery, language: [] });
+
+    const callArgs = vi.mocked(prisma.opensourceRepo.findMany).mock.calls[0][0];
+    expect(callArgs.where).not.toHaveProperty("language");
   });
 });

--- a/server/src/__tests__/opensource.service.test.ts
+++ b/server/src/__tests__/opensource.service.test.ts
@@ -249,7 +249,7 @@ describe("OpensourceService.listRepos — multi-language filter", () => {
     await service.listRepos({ ...baseQuery, language: undefined });
 
     const callArgs = vi.mocked(prisma.opensourceRepo.findMany).mock.calls[0][0];
-    expect(callArgs.where).not.toHaveProperty("language");
+    expect(callArgs!.where).not.toHaveProperty("language");
   });
 
   it("does not filter by language for empty array", async () => {
@@ -259,6 +259,6 @@ describe("OpensourceService.listRepos — multi-language filter", () => {
     await service.listRepos({ ...baseQuery, language: [] });
 
     const callArgs = vi.mocked(prisma.opensourceRepo.findMany).mock.calls[0][0];
-    expect(callArgs.where).not.toHaveProperty("language");
+    expect(callArgs!.where).not.toHaveProperty("language");
   });
 });

--- a/server/src/database/prisma.config.ts
+++ b/server/src/database/prisma.config.ts
@@ -17,6 +17,6 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: process.env.DATABASE_URL ? env("DATABASE_URL") : "postgresql://postgres:postgres@localhost:5432/dummy",
+    url: env("DATABASE_URL"),
   },
 });

--- a/server/src/database/prisma.config.ts
+++ b/server/src/database/prisma.config.ts
@@ -17,6 +17,6 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env.DATABASE_URL ? env("DATABASE_URL") : "postgresql://postgres:postgres@localhost:5432/dummy",
   },
 });

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -12,7 +12,7 @@ interface ListReposQuery {
   page: number;
   limit: number;
   search?: string;
-  language?: string;
+  language?: string[];
   difficulty?: string;
   domain?: string;
   sortBy: string;
@@ -125,7 +125,7 @@ export class OpensourceService {
     } = query;
     const skip = (page - 1) * limit;
     const where: Record<string, unknown> = {};
-    if (language) where.language = { equals: language, mode: "insensitive" };
+    if (language && language.length > 0) where.language = { in: language, mode: "insensitive" };
     if (difficulty) where["difficulty"] = difficulty;
     if (domain) where["domain"] = domain;
     if (trending === "true") where["trending"] = true;

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -7,7 +7,7 @@ export const opensourceListQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),
   search: z.string().optional(),
   language: z
-    .union([z.string(), z.array(z.string())])
+    .union([z.string().min(1), z.array(z.string().min(1))])
     .optional()
     .transform((val) => {
       if (val === undefined) return undefined;

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -6,7 +6,13 @@ export const opensourceListQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),
   search: z.string().optional(),
-  language: z.string().optional(),  
+  language: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .transform((val) => {
+      if (val === undefined) return undefined;
+      return Array.isArray(val) ? val : [val];
+    }),
   difficulty: z.string().optional(),
   domain: z.string().optional(),
   sort: z.enum(opensourceSortFields).optional(),


### PR DESCRIPTION
# Pull Request

## Description
- Frontend sent only `selectedLanguage[0]` to API; now sends full array via extracted `buildLanguageParam()` in `repo-utils.ts`
- Backend query uses `{ in: languages }` for OR-union instead of single exact match
- Validation schema accepts `string | string[]` and normalizes to array
- Updated query-keys type to support `string[]` params
- Added vitest to client, test for param builder (6 cases)
- Added backend service test for multi-lang query (5 cases)

## Related Issue
Fixes #2215

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
Verified the multi-language query logic via unit tests (`opensource.service.test.ts` on the backend and `repo-utils.test.ts` on the frontend). 

**Note on manual testing (`/api/opensource`):**
Was unable to verify the fix against live data because the `opensourceRepo` table in the dev database is missing the `hacktoberfest` column (Prisma error `P2022: ColumnNotFound`). This causes a `500 Database error` on both `main` and this branch, blocking local end-to-end testing for this endpoint.

## Screenshots / Video

> **REQUIRED for any UI change.** PRs that modify visible UI (layout, components, styles, pages) will be rejected without this.

_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [ ] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository discovery now supports filtering by multiple languages simultaneously, expanding filtering capabilities.

* **Tests**
  * Added comprehensive test coverage for multi-language filtering logic.

* **Chores**
  * Integrated Vitest testing framework.
  * Updated CI configuration with database setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->