### PR TITLE
feat: discoverable keyboard-shortcut hint for guide step navigation

### DIFF
--- a/client/src/module/student/opensource/components/GuideSectionPage.tsx
+++ b/client/src/module/student/opensource/components/GuideSectionPage.tsx
@@ -3,7 +3,7 @@ import { useParams, Link, Navigate, useNavigate } from "react-router";
 import { motion } from "framer-motion";
 import {
   ArrowRight, ChevronLeft, ChevronRight,
-  CheckCircle2, ExternalLink, Lightbulb, Info,
+  CheckCircle2, ExternalLink, Lightbulb, Info, X
 } from "lucide-react";
 import { VideoEmbed } from "../../../../components/ui/VideoEmbed";
 import { SEO } from "../../../../components/SEO";
@@ -218,8 +218,7 @@ if (!step) return <Navigate to={basePath} replace />;
         </div>
       </motion.div>
 
-      {/*Dismissible keyboard shortcut hint.*/}
-      {/*Visibility is persisted in localStorage so it only needs to be shown once. */}
+      
       {showShortcutHint && (
         <div className="mb-4 flex items-center justify-between rounded-md border border-amber-100 dark:border-amber-800 bg-amber-50/80 dark:bg-amber-950/20 px-4 py-3">
           <div className="flex items-center gap-2">
@@ -229,14 +228,15 @@ if (!step) return <Navigate to={basePath} replace />;
             </p>
           </div>
 
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            mode="icon"
             onClick={dismissShortcutHint}
-            className="text-xs text-stone-500 hover:text-stone-900 dark:hover:text-white"
             aria-label="Dismiss keyboard shortcuts hint"
+            title="Dismiss"
           >
-            ✕
-          </button>
+            <X className="h-4 w-4" />
+          </Button>
         </div>
       )}
 

--- a/client/src/module/student/opensource/components/GuideSectionPage.tsx
+++ b/client/src/module/student/opensource/components/GuideSectionPage.tsx
@@ -56,6 +56,14 @@ export default function GuideSectionPage({ steps, storageKey, basePath, seoSuffi
   const [submitted, setSubmitted] = useState(false);
   const [showReasons, setShowReasons] = useState(false);
 
+  const [showShortcutHint, setShowShortcutHint] = useState(() => {
+  try {
+    return localStorage.getItem("guide-hint-dismissed") !== "true";
+  } catch {
+    return true;
+  }
+});
+
 
   const toggleComplete = useCallback(() => {
     setCompleted((prev) => {
@@ -67,6 +75,15 @@ export default function GuideSectionPage({ steps, storageKey, basePath, seoSuffi
       return next;
     });
   }, [step, storageKey]);
+
+  const dismissShortcutHint = () => {
+  try {
+    localStorage.setItem("guide-hint-dismissed", "true");
+  } catch {
+    
+  }
+  setShowShortcutHint(false);
+};
 
   useEffect(() => {
     if (!step) return;
@@ -200,6 +217,28 @@ if (!step) return <Navigate to={basePath} replace />;
           </div>
         </div>
       </motion.div>
+
+      {/*Dismissible keyboard shortcut hint.*/}
+      {/*Visibility is persisted in localStorage so it only needs to be shown once. */}
+      {showShortcutHint && (
+        <div className="mb-4 flex items-center justify-between rounded-md border border-amber-100 dark:border-amber-800 bg-amber-50/80 dark:bg-amber-950/20 px-4 py-3">
+          <div className="flex items-center gap-2">
+            <Lightbulb className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+            <p className="text-sm text-stone-600 dark:text-stone-400">
+             Press your keyboard's ← and → arrow keys to navigate between sections.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={dismissShortcutHint}
+            className="text-xs text-stone-500 hover:text-stone-900 dark:hover:text-white"
+            aria-label="Dismiss keyboard shortcuts hint"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       <div className="space-y-5">
         {step.mentor_guidance && (


### PR DESCRIPTION
# Pull Request

## Description
Adds a dismissible keyboard navigation hint to guide section pages to improve discoverability of the existing left and right arrow key navigation.

The hint:

- Informs users about keyboard navigation shortcuts.
- Can be dismissed with a close button.
- Persists dismissal using localStorage so it is shown only once.
- Supports both light and dark themes.

## Related Issue
Fixes #2219 

## Type of Change
- [ ] Bug Fix  
- [X] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
1. Open a guide that uses the shared GuideSectionPage component (e.g. CI/CD Basics) .
2. Verify the keyboard navigation hint is displayed below the guide header.
3. Confirm the hint clearly communicates the left and right arrow key shortcuts.
4. Verify left and right arrow keys navigate between guide sections.
Click the dismiss button on the hint.
5. Refresh the page and verify the hint remains hidden.
6. Verify the hint remains hidden when revisiting the guide.
7. Verify the UI renders correctly in both light and dark mode.
## Screenshots / Video
<img width="1587" height="1037" alt="Screenshot from 2026-06-18 08-20-26" src="https://github.com/user-attachments/assets/5bf494c3-71f1-46e4-be4b-89c102ece46d" />

<img width="1524" height="1015" alt="Screenshot from 2026-06-18 08-29-25" src="https://github.com/user-attachments/assets/cbdabbbe-08ba-486a-ad35-1682315b8e80" />


## Checklist
- [X] Code follows project guidelines
- [X] No new compile/type errors
- [X] Tested manually (include steps above)
- [X] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [X] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dismissible keyboard shortcut hint banner to help users navigate between sections more efficiently using keyboard commands.
  * Users can close the hint, and the dismissal preference is saved for future visits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->