### PR TITLE
a11y: add aria-label and aria-current to OrgBrowser pagination buttons

### DIFF
--- a/client/src/module/student/opensource/OrgBrowserPage.tsx
+++ b/client/src/module/student/opensource/OrgBrowserPage.tsx
@@ -554,6 +554,7 @@ export default function OrgBrowserPage({ programType }: OrgBrowserPageProps) {
               variant="outline"
               disabled={currentPage === 1}
               onClick={() => handlePageChange(currentPage - 1)}
+              aria-label="Go to previous page"
               className="rounded-md h-8 px-2 border-stone-200 dark:border-white/10 hover:bg-stone-100 dark:hover:bg-white/5"
             >
               <ChevronLeft className="w-4 h-4" />
@@ -568,6 +569,8 @@ export default function OrgBrowserPage({ programType }: OrgBrowserPageProps) {
                   size="sm"
                   variant={active ? "primary" : "outline"}
                   onClick={() => handlePageChange(page)}
+                  aria-label={`Go to page ${page}`}
+                  aria-current={active ? "page" : undefined}
                   className={`rounded-md h-8 w-8 min-w-0 p-0 ${
                     active
                       ? "bg-lime-500 text-stone-950 font-bold border-none"
@@ -585,14 +588,10 @@ export default function OrgBrowserPage({ programType }: OrgBrowserPageProps) {
               variant="outline"
               disabled={currentPage === totalPages}
               onClick={() => handlePageChange(currentPage + 1)}
+              aria-label="Go to next page"
               className="rounded-md h-8 px-2 border-stone-200 dark:border-white/10 hover:bg-stone-100 dark:hover:bg-white/5"
             >
               <ChevronRight className="w-4 h-4" />
             </Button>
           </div>
         )}
-
-      </div>
-    </div>
-  );
-}

--- a/client/src/module/student/opensource/OrgBrowserPage.tsx
+++ b/client/src/module/student/opensource/OrgBrowserPage.tsx
@@ -595,3 +595,8 @@ export default function OrgBrowserPage({ programType }: OrgBrowserPageProps) {
             </Button>
           </div>
         )}
+
+        </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Added aria-label and aria-current="page" to all pagination buttons in OrgBrowserPage so screen-reader users can identify the current page and navigate easily.

## Related Issue
Fixes #2212

## Type of Change
- [x] Enhancement

## Testing
No functional change — pagination works exactly as before. Accessibility attributes added only.

## Screenshots / Video
_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced pagination controls with improved screen reader support by adding descriptive ARIA labels to previous/next and page buttons, and marking the current page for accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->