### PR TITLE
fix: show an error toast when guide progress fails to persist

### DIFF
--- a/client/src/module/student/opensource/components/GuideSectionPage.tsx
+++ b/client/src/module/student/opensource/components/GuideSectionPage.tsx
@@ -13,6 +13,8 @@ import { canonicalUrl } from "../../../../lib/seo.utils";
 import { QuizBlock, type QuizQuestion } from "../../../../components/quiz/QuizBlock";
 import api from "../../../../lib/axios";
 import { notifyLearningPathProgressChanged } from "../learning-paths.data";
+import toast from "../../../../components/ui/toast";
+
 
 interface Resource { title: string; url: string; type: string }
 interface Command { label: string; code: string }
@@ -59,12 +61,19 @@ export default function GuideSectionPage({ steps, storageKey, basePath, seoSuffi
 
   const toggleComplete = useCallback(() => {
     setCompleted((prev) => {
+      if (!step) return prev;
       const next = new Set(prev);
-      if (!step) return next;
       if (next.has(step.id)) next.delete(step.id); else next.add(step.id);
-      try { localStorage.setItem(storageKey, JSON.stringify([...next])); } catch { /* */ }
-      notifyLearningPathProgressChanged();
-      return next;
+      try { 
+        localStorage.setItem(storageKey, JSON.stringify([...next])); 
+        notifyLearningPathProgressChanged();
+        return next;
+      } 
+      catch { 
+        toast.error("Couldn't save progress");
+        return prev; 
+      }
+      
     });
   }, [step, storageKey]);
 


### PR DESCRIPTION
# Pull Request

## Description
Improves guide completion persistence handling by properly managing localStorage write failures.

Changes made:
- Displays a user facing error toast when guide progress cannot be persisted.
- Prevents the completion state from updating when persistence fails.
- Keeps the UI state consistent with the actual saved progress.

## Related Issue
Fixes #2206

## Type of Change
- [X] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
1. Open a guide that uses the shared GuideSectionPage component.
2. Mark a guide step as complete and verify the completion state updates successfully.
3. Refresh the page and verify the completion state persists.
4. Simulate a localStorage write failure.
5. Verify an error toast with the message "Couldn't save progress" is displayed.
6. Verify the completion state does not change when persistence fails.


## Screenshots / Video
<img width="1554" height="1026" alt="Screenshot from 2026-06-18 15-01-03" src="https://github.com/user-attachments/assets/592891ca-6cfb-4789-9175-5836e3af8e83" />

<img width="1554" height="1026" alt="Screenshot from 2026-06-18 15-01-25" src="https://github.com/user-attachments/assets/3f0ddf76-2e13-4875-8e4f-f879961cccb9" />

## Checklist
- [X] Code follows project guidelines
- [X] No new compile/type errors
- [X] Tested manually (include steps above)
- [X] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [X] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error notification when marking progress complete fails, providing users with feedback instead of silently failing to save.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->