### PR TITLE
perf(opensource): eliminate upsert-on-read for GitHub repo stats (#2202)

### DIFF
--- a/server/src/cron/github-contributions.cron.ts
+++ b/server/src/cron/github-contributions.cron.ts
@@ -1,16 +1,24 @@
 import cron from "node-cron";
 import { GithubService } from "../module/github/github.service.js";
+import { OpensourceService } from "../module/opensource/opensource.service.js";
 import { withAdvisoryLock } from "../utils/cron-lock.js";
 import { createLogger } from "../utils/logger.js";
 
 const logger = createLogger("GithubContributionsCron");
 const githubService = new GithubService();
+const opensourceService = new OpensourceService();
 let cronJob: cron.ScheduledTask | null = null;
 
 export async function runGithubContributionsSync() {
   logger.info("Starting GitHub contributions sync...");
   const result = await githubService.syncStaleConnections();
   logger.info("GitHub contributions sync finished:", result);
+}
+
+export async function runOpensourceRepoStatsRefresh() {
+  logger.info("Starting opensource repo stats refresh...");
+  const result = await opensourceService.refreshStaleRepoStats();
+  logger.info("Opensource repo stats refresh finished:", result);
 }
 
 export function startGithubContributionsCron(schedule = "0 2 * * *"): void {
@@ -27,6 +35,15 @@ export function startGithubContributionsCron(schedule = "0 2 * * *"): void {
         }
       }).catch((err) => {
         logger.error("Advisory lock for GitHub contributions failed:", err);
+      });
+      withAdvisoryLock("opensource-repo-stats-refresh", async () => {
+        try {
+          await runOpensourceRepoStatsRefresh();
+        } catch (err) {
+          logger.error("Opensource repo stats refresh failed:", err);
+        }
+      }).catch((err) => {
+        logger.error("Advisory lock for opensource repo stats refresh failed:", err);
       });
     },
     { timezone: "Etc/UTC" },

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -251,7 +251,7 @@ export class OpensourceService {
     });
     console.info(`[github] updated stats & health score for ${name}: ${healthScore}`);
 
-    const parsed = this.getRepoOwnerAndNameFromUrl(url);
+    const parsed = await this.getRepoOwnerAndNameFromUrl(url);
     if (parsed) {
       await cacheDel(`opensource:repo:id:${id}`);
       await cacheDel(`opensource:repo:owner:${parsed.owner.toLowerCase()}:${parsed.name.toLowerCase()}`);

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -7,7 +7,7 @@ import {
   repoRequestApprovedHtml,
 } from "../../utils/email-templates.js";
 import { UserService } from "../user/user.service.js";
-import { cacheGet, cacheSet } from "../../utils/cache.js";
+import { cacheGet, cacheSet, cacheDel } from "../../utils/cache.js";
 
 interface ListReposQuery {
   page: number;
@@ -250,6 +250,12 @@ export class OpensourceService {
       },
     });
     console.info(`[github] updated stats & health score for ${name}: ${healthScore}`);
+
+    const parsed = this.getRepoOwnerAndNameFromUrl(url);
+    if (parsed) {
+      await cacheDel(`opensource:repo:id:${id}`);
+      await cacheDel(`opensource:repo:owner:${parsed.owner.toLowerCase()}:${parsed.name.toLowerCase()}`);
+    }
   }
 
   private async getRepoOwnerAndNameFromUrl(url: string) {

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../../database/db.js";
-import type { RepoDomain, RepoDifficulty } from "@prisma/client";
+import type { opensourceRepo, RepoDomain, RepoDifficulty } from "@prisma/client";
 import { fetchGithubGoodFirstIssues, fetchGithubStats, fetchRepoHealthData } from "../../lib/github.js";
 import { sendEmail } from "../../utils/email.utils.js";
 import {
@@ -7,6 +7,7 @@ import {
   repoRequestApprovedHtml,
 } from "../../utils/email-templates.js";
 import { UserService } from "../user/user.service.js";
+import { cacheGet, cacheSet } from "../../utils/cache.js";
 
 interface ListReposQuery {
   page: number;
@@ -53,6 +54,7 @@ interface GsocOrgsQuery {
 
 const userService = new UserService();
 
+const REPO_CACHE_TTL = 300; // 5 minutes - single-repo cache
 const STATS_TTL_MS = 5 * 60 * 1000; // 5 minutes
 let statsCache: {
   data: {
@@ -180,51 +182,30 @@ export class OpensourceService {
   }
 
   async getRepoById(id: number) {
-    const repo = await prisma.opensourceRepo.findUnique({
-      where: { id },
-    });
-    if (!repo) return null;
+    const cacheKey = `opensource:repo:id:${id}`;
+    const cached = await cacheGet<opensourceRepo>(cacheKey);
+    if (cached) return cached;
 
-    const SIX_HOURS = 6 * 60 * 60 * 1000;
-    const neverFetched = !repo.githubStatsUpdatedAt;
-    const isStale =
-      neverFetched ||
-      Date.now() - new Date(repo.githubStatsUpdatedAt!).getTime() > SIX_HOURS;
-
-    if (isStale && repo.url?.includes("github.com")) {
-      if (neverFetched) {
-        // First-ever fetch: await so the caller gets live stats, not 0s
-        await this.updateGithubStats(repo.id, repo.url, repo.name).catch((err) =>
-          console.error(`[github] initial stats fetch failed for ${id}:`, err),
-        );
-        return await prisma.opensourceRepo.findUnique({ where: { id } });
-      }
-      // Stale but previously fetched: update in background, return cached
-      this.updateGithubStats(repo.id, repo.url, repo.name).catch((err) =>
-        console.error(`[github] background update failed for ${id}:`, err),
-      );
+    const repo = await prisma.opensourceRepo.findUnique({ where: { id } });
+    if (repo) {
+      await cacheSet(cacheKey, repo, REPO_CACHE_TTL);
     }
     return repo;
   }
 
   async getRepoByOwnerAndName(owner: string, name: string) {
+    const cacheKey = `opensource:repo:owner:${owner.toLowerCase()}:${name.toLowerCase()}`;
+    const cached = await cacheGet<opensourceRepo>(cacheKey);
+    if (cached) return cached;
+
     const repo = await prisma.opensourceRepo.findFirst({
       where: {
         owner: { equals: owner, mode: "insensitive" },
         name: { equals: name, mode: "insensitive" },
       },
     });
-    if (!repo) return null;
-
-    const SIX_HOURS = 6 * 60 * 60 * 1000;
-    const isStale =
-      !repo.githubStatsUpdatedAt ||
-      Date.now() - new Date(repo.githubStatsUpdatedAt).getTime() > SIX_HOURS;
-
-    if (isStale && repo.url?.includes("github.com")) {
-      this.updateGithubStats(repo.id, repo.url, repo.name).catch((err) =>
-        console.error(`[github] background update failed for ${repo.id}:`, err),
-      );
+    if (repo) {
+      await cacheSet(cacheKey, repo, REPO_CACHE_TTL);
     }
     return repo;
   }
@@ -275,6 +256,32 @@ export class OpensourceService {
     const match = url.match(/github\.com\/([^\/]+)\/([^\/\s\.]+)/);
     if (!match) return null;
     return { owner: match[1], name: match[2].replace(".git", "") };
+  }
+
+  async refreshStaleRepoStats(batchSize = 50) {
+    const sixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000);
+    const staleRepos = await prisma.opensourceRepo.findMany({
+      where: {
+        url: { contains: "github.com" },
+        OR: [
+          { githubStatsUpdatedAt: null },
+          { githubStatsUpdatedAt: { lt: sixHoursAgo } },
+        ],
+      },
+      take: batchSize,
+      select: { id: true, url: true, name: true },
+    });
+
+    let updated = 0;
+    for (const repo of staleRepos) {
+      try {
+        await this.updateGithubStats(repo.id, repo.url, repo.name);
+        updated++;
+      } catch (err) {
+        console.error(`[github] cron stats refresh failed for repo ${repo.id}:`, err);
+      }
+    }
+    return { scanned: staleRepos.length, updated };
   }
 
   async getGsocOrgs(query: GsocOrgsQuery & { tech?: string }) {


### PR DESCRIPTION
## Description

This PR resolves a performance bottleneck caused by an "upsert-on-read" pattern in the open-source repository fetching module. Previously, fetching repository statistics via GET endpoints lazily updated GitHub data directly on the read path. Under high load or simultaneous stale requests, this resulted in heavy database write contention, connection pool exhaustion, and request timeouts.

### Key Changes
1. **Side-Effect-Free Read Paths (`opensource.service.ts`):**
   - Refactored `getRepoById` and `getRepoByOwnerAndName` to operate purely as read operations. 
   - Implemented a Redis cache-first approach using `cacheGet` and `cacheSet` with a **300-second (5-minute) TTL** to reduce direct database hits.
   - Removed any background inline `updateGithubStats` triggers from GET execution branches.

2. **Asynchronous Cron Job Integration (`opensource.service.ts` & `github-contributions.cron.ts`):**
   - Introduced a public `refreshStaleRepoStats(batchSize = 50)` helper that fetches up to 50 repos with missing or stale `githubStatsUpdatedAt` timestamps.
   - Processes updates sequentially within the batch to strictly avoid database connection pool exhaustion.
   - Enlisted a new function `runOpensourceRepoStatsRefresh()` under the daily 2 AM UTC cron engine, protected by a dedicated advisory lock (`opensource-repo-stats-refresh`).

3. **Write Path Isolation:**
   - Left explicit POST routes (like `approveRepoRequest`) untouched as fire-and-forget, maintaining correct separation of concerns.

## Related Issue
Fixes #2202

## Type of Change
- [ ] Bug Fix
- [ ] Feature
- [x] Enhancement
- [ ] Documentation

## Testing
- Verified that `getRepoById` and `getRepoByOwnerAndName` correctly populate and read from the Redis cache layer.
- Ensured that sequential batch updating handles independent repository update failures cleanly without crashing the overall cron runner.
- Validated that both the user-contributions sync and the repo-stats refresh run concurrently without interfering with one another's lock states.

## Screenshots / Video
_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually
- [x] No `.env`, credentials, or `node_modules` committed
- [x] Docs updated (if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated scheduled opensource repository stats refresh job with start/finish logging and advisory-lock controlled execution.
* **Performance**
  * Implemented short-lived caching for single-repo lookups to reduce repeated requests.
  * Refreshed stale GitHub-hosted repository stats in batches (6-hour threshold), with per-repo error isolation and automatic cache invalidation after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->