### PR TITLE
fix(client): handle clipboard permission denial with text fallback for referral link (#2207)

### DIFF
--- a/client/src/module/student/opensource/AmbassadorPage.tsx
+++ b/client/src/module/student/opensource/AmbassadorPage.tsx
@@ -122,8 +122,29 @@ export default function AmbassadorPage() {
     },
   });
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text).then(() => toast.success("Copied!"));
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success("Referral link copied to clipboard!");
+      return;
+    } catch {
+      // navigator.clipboard unavailable or permission denied — fall through
+    }
+
+    try {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      textarea.style.left = "-9999px";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      toast.success("Referral link copied to clipboard!");
+    } catch {
+      toast.error("Failed to copy link automatically. Please select and copy the text manually.");
+    }
   };
 
   const isApproved = data?.ambassador?.status === "APPROVED";


### PR DESCRIPTION
## Description

Wrapped the asynchronous `navigator.clipboard.writeText()` logic inside a robust `try...catch` block to handle browser clipboard permission denials gracefully. Implemented a reliable fallback copy routine using a temporary DOM `<textarea>` element and `document.execCommand('copy')` for environments with blocked permissions or unsupported clipboard APIs. Integrated user-facing success and error toast notifications to provide immediate feedback on the operation's outcome.

## Related Issue

Fixes #2207

## Type of Change

* [x] Bug Fix
* [ ] Feature
* [ ] Enhancement
* [ ] Documentation

## Testing

1. Navigated to the ambassador dashboard referral section.
2. Clicked the copy button with normal browser permissions enabled and verified that the success toast appears and the text copies correctly.
3. Explicitly blocked the clipboard permission via Chrome site settings and clicked the copy button. Verified that the operation caught the error, executed the fallback mechanism seamlessly, and still successfully copied the link with the confirmation toast.

## Screenshots / Video

*No UI changes in this PR*

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [x] Docs updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced copy-to-clipboard functionality with improved fallback handling for unsupported environments.

* **Performance**
  * Optimized repository data retrieval through caching for faster load times.
  * Improved open source repository statistics refresh to maintain data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->