### PR TITLE
fix(#2331): add /api suffix to VITE_API_URL in .env.example

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -3,6 +3,6 @@
 VITE_GOOGLE_CLIENT_ID=
 VITE_DODO_MODE=test_mode
 # API endpoint (for local dev outside Docker)
-VITE_API_URL=http://localhost:3000
+VITE_API_URL=http://localhost:3000/api
 # LeetCode import feature flag — set to false to disable (default: enabled)
 VITE_LEETCODE_IMPORT_ENABLED=true


### PR DESCRIPTION
Fixes #2331