### PR TITLE
fix(#2326): move render-phase state mutations into useEffect on SqlExercisePage

### DIFF
--- a/client/src/module/student/sql/SqlExercisePage.tsx
+++ b/client/src/module/student/sql/SqlExercisePage.tsx
@@ -120,24 +120,19 @@ export default function SqlExercisePage() {
   const [dbReady, setDbReady] = useState(false);
   const [solved, setSolved] = useState(false);
 
-  const [prevExerciseId, setPrevExerciseId] = useState(exercise?.id);
+  // Reset and load exercise
+  useEffect(() => {
+    if (!exercise || !section) return;
 
-  if (exercise?.id !== prevExerciseId) {
-    setPrevExerciseId(exercise?.id);
     setDbReady(false);
     setResult(null);
     setValidation(null);
     setShowHints(0);
     setShowExpected(false);
 
-    const savedEntry = exercise ? progress[exercise.id] : undefined;
-    setCode(savedEntry?.code || exercise?.starterCode || "");
+    const savedEntry = progress[exercise.id];
+    setCode(savedEntry?.code || exercise.starterCode || "");
     setSolved(!!savedEntry?.solved);
-  }
-
-  // Load database and exercise
-  useEffect(() => {
-    if (!exercise || !section) return;
 
     const load = async () => {
       const datasetSql = datasets[exercise.dataset];


### PR DESCRIPTION
Fixes #2326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state management when switching between SQL exercises, ensuring previous results, validation states, and hints are properly reset and exercise data loads correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->