### PR TITLE
fix(#2323): handle out-of-order webhooks in subscription activation

### DIFF
--- a/client/src/module/student/sql/SqlExercisePage.tsx
+++ b/client/src/module/student/sql/SqlExercisePage.tsx
@@ -120,24 +120,19 @@ export default function SqlExercisePage() {
   const [dbReady, setDbReady] = useState(false);
   const [solved, setSolved] = useState(false);
 
-  const [prevExerciseId, setPrevExerciseId] = useState(exercise?.id);
+  // Reset and load exercise
+  useEffect(() => {
+    if (!exercise || !section) return;
 
-  if (exercise?.id !== prevExerciseId) {
-    setPrevExerciseId(exercise?.id);
     setDbReady(false);
     setResult(null);
     setValidation(null);
     setShowHints(0);
     setShowExpected(false);
 
-    const savedEntry = exercise ? progress[exercise.id] : undefined;
-    setCode(savedEntry?.code || exercise?.starterCode || "");
+    const savedEntry = progress[exercise.id];
+    setCode(savedEntry?.code || exercise.starterCode || "");
     setSolved(!!savedEntry?.solved);
-  }
-
-  // Load database and exercise
-  useEffect(() => {
-    if (!exercise || !section) return;
 
     const load = async () => {
       const datasetSql = datasets[exercise.dataset];

--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -194,12 +194,10 @@ export class PaymentService {
         return;
       }
 
-      // Link subscription ID and mark payment SUCCESS first, then activate the user.
-      // Order matters: payment record must be linked before any code looks it up by subscription_id.
-      // Only link payments that have already been marked SUCCESS by the
-      // payment.succeeded webhook. This prevents abandoned PENDING checkout
-      // sessions from being incorrectly linked to the subscription.
-      const payment = await tx.payment.findFirst({
+      // Link payment record to subscription. Try SUCCESS first (normal flow),
+      // then fall back to the most recent PENDING record to handle the race
+      // where subscription.active arrives before payment.succeeded.
+      let payment = await tx.payment.findFirst({
         where: {
           userId,
           dodoSubscriptionId: null,
@@ -212,15 +210,41 @@ export class PaymentService {
       });
 
       if (!payment) {
-        return;
+        payment = await tx.payment.findFirst({
+          where: {
+            userId,
+            dodoSubscriptionId: null,
+            status: "PENDING",
+          },
+          orderBy: {
+            createdAt: "desc",
+          },
+          select: { id: true },
+        });
       }
 
-      await tx.payment.update({
-        where: { id: payment.id },
-        data: {
-          dodoSubscriptionId: sub.subscription_id,
-        },
-      });
+      if (!payment) {
+        // No payment record exists yet — create a placeholder that will be
+        // updated to SUCCESS when payment.succeeded arrives
+        await tx.payment.create({
+          data: {
+            userId,
+            amount: 0,
+            currency: "USD",
+            status: "PENDING",
+            dodoSubscriptionId: sub.subscription_id,
+            plan,
+            billing: sub.metadata["billing"] ?? "monthly",
+          },
+        });
+      } else {
+        await tx.payment.update({
+          where: { id: payment.id },
+          data: {
+            dodoSubscriptionId: sub.subscription_id,
+          },
+        });
+      }
 
       // Update user subscription status atomically
       await tx.user.update({


### PR DESCRIPTION
Fixes #2323

When \subscription.active\ webhook arrives before \payment.succeeded\:
- Falls back to the most recent PENDING payment record linked to the user
- If no payment record exists at all, creates a placeholder PENDING payment
- Activates the subscription regardless of webhook order
- The payment.succeeded webhook later updates the payment to SUCCESS