### PR TITLE
fix: add CANCELLED enum value to SubscriptionStatus type in client

### DIFF
--- a/client/src/lib/types/user.types.ts
+++ b/client/src/lib/types/user.types.ts
@@ -47,7 +47,7 @@ export interface User {
   achievements?: AchievementItem[];
   createdAt?: string;
   subscriptionPlan?: "FREE" | "MONTHLY" | "YEARLY";
-  subscriptionStatus?: "ACTIVE" | "EXPIRED";
+  subscriptionStatus?: "ACTIVE" | "EXPIRED" | "CANCELLED";
   subscriptionEndDate?: string;
   ossTier?: string;
 }


### PR DESCRIPTION
## Description
This PR resolves Issue #2351 by fixing a missing enum value in the client-side TypeScript types that caused strict-mode validation gaps.

## Changes Made
- Updated `client/src/lib/types/user.types.ts`.
- Added the `"CANCELLED"` value to the `subscriptionStatus` union type.
- This brings the client types back into parity with the backend Prisma schema, ensuring that users with cancelled subscriptions don't bypass TypeScript checks or encounter incorrect UI rendering states.

Fixes #2351


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for tracking cancelled subscription status in user accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->