### PR TITLE
fix: add missing /api suffix to VITE_API_URL in .env.example

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -3,6 +3,6 @@
 VITE_GOOGLE_CLIENT_ID=
 VITE_DODO_MODE=test_mode
 # API endpoint (for local dev outside Docker)
-VITE_API_URL=http://localhost:3000
+VITE_API_URL=http://localhost:3000/api
 # LeetCode import feature flag — set to false to disable (default: enabled)
 VITE_LEETCODE_IMPORT_ENABLED=true


### PR DESCRIPTION
## Description
This PR resolves Issue #2352 by fixing the documented API URL structure in the client's `.env.example` file.

## Changes Made
- Updated `client/.env.example`.
- Appended the missing `/api` suffix to `VITE_API_URL=http://localhost:3000`.
- Previously, new developers who copied the `.env.example` literally would encounter widespread 404 errors because their frontend constructed routes like `http://localhost:3000/auth/login` instead of targeting the backend's `/api` router. 
- The fallback logic works correctly, but the documented example needed to be corrected so local configurations don't override the working fallback with a broken string.

Fixes #2352


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration template for local development to ensure correct API endpoint routing during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->