### PR TITLE
fix: move botSeoMiddleware before API routes to ensure headers apply

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -201,6 +201,9 @@ app.use((req, res, next) => {
   next();
 });
 
+// ── Bot SEO headers (Vary: User-Agent, X-Is-Bot for CDN routing) ──
+app.use(botSeoMiddleware);
+
 // ── HTTP request logging (dev only) ──
 if (process.env["NODE_ENV"] !== "production") {
   app.use(morgan("dev"));
@@ -308,8 +311,6 @@ app.get("/api/external-jobs", (req, res) => publicAdminController.getPublicExter
 // ── Sitemap (served at root, not /api) ──
 app.use(sitemapRouter);
 
-// ── Bot SEO headers (Vary: User-Agent, X-Is-Bot for CDN routing) ──
-app.use(botSeoMiddleware);
 
 // ── Static files (public folder) ──
 app.use(express.static(path.join(__dirname, "../public"), { dotfiles: "deny", index: false }));


### PR DESCRIPTION
## Description
This PR resolves Issue #2353 by fixing the registration order of `botSeoMiddleware` in the Express application.

## Changes Made
- Updated `server/src/index.ts`.
- Moved `app.use(botSeoMiddleware)` from line 311 to line 204 (after Request ID tracing, but before all API router mountings).
- Previously, the middleware was mounted after all `/api/*` routes. In Express, middleware executes in registration order, meaning API requests were handled and terminated before the SEO middleware ever ran.
- Now, the `Vary: User-Agent` headers are correctly appended to all API responses, ensuring CDNs properly cache variants for real users vs. search bots.

Fixes #2353
