### PR TITLE
fix: replace hardcoded admin alert email with environment variable

### DIFF
--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -4,7 +4,7 @@ import { prisma } from "../database/db.js";
 import { sendEmail } from "../utils/email.utils.js";
 import { FileUploadError } from "../lib/errors.js";
 
-const ADMIN_ALERT_EMAIL = "mrsachinchaurasiya@gmail.com";
+const ADMIN_ALERT_EMAIL = process.env["ADMIN_ALERT_EMAIL"] ?? "";
 
 const SENSITIVE_KEYS = new Set([
   "password", "newPassword", "confirmPassword", "currentPassword",
@@ -69,7 +69,7 @@ function logErrorToDb(req: Request, statusCode: number, message: string, rawErr?
     console.error("[ErrorLog] Failed to write:", dbErr);
   });
 
-  if (statusCode >= 500) {
+  if (statusCode >= 500 && ADMIN_ALERT_EMAIL) {
     const rawDetails = rawErr ? formatRawError(rawErr) : "No stack trace";
     sendEmail({
       to: ADMIN_ALERT_EMAIL,


### PR DESCRIPTION
## Description
This PR resolves Issue #2354 by removing a hardcoded personal email address from the error reporting middleware.

## Changes Made
- Updated `server/src/middleware/error.middleware.ts`.
- Removed the hardcoded string and replaced it with `process.env["ADMIN_ALERT_EMAIL"] ?? ""`.
- Updated the `statusCode >= 500` conditional block to only attempt to send the SES email alert if the `ADMIN_ALERT_EMAIL` variable is truthy.
- This secures the maintainer's private email address, stops it from being exposed in public source control, and allows anyone hosting or forking the project to easily configure their own alert destination.

Fixes #2354
