### PR TITLE
fix: pass email via React Router state to prevent PII leak in URL

### DIFF
--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -29,7 +29,7 @@ export function ProtectedRoute({ children, role, redirectTo = "/login" }: Protec
   }
 
   if (user && !user.isVerified && user.role !== "ADMIN") {
-    return <Navigate to={`/verify-email?email=${encodeURIComponent(user.email)}`} replace />;
+    return <Navigate to="/verify-email" state={{ email: user.email }} replace />;
   }
 
   if (role && user?.role !== role) {


### PR DESCRIPTION
## Description
This PR resolves Issue #2356 by removing Personally Identifiable Information (PII) from the authentication redirect URL.

## Changes Made
- Updated `client/src/components/ProtectedRoute.tsx`.
- Changed the `<Navigate>` component for unverified users from embedding the email in the query parameters (`/verify-email?email=user@example.com`) to passing it via React Router's internal state mechanism (`state={{ email: user.email }}`).
- This security fix ensures that sensitive user data is no longer recorded in browser histories, leaked via `Referer` headers, or captured by third-party analytics and CDN logs.

Fixes #2356
