### PR TITLE
fix: move SqlExercisePage state resets into useEffect to prevent rend…

### DIFF
--- a/client/src/module/student/sql/SqlExercisePage.tsx
+++ b/client/src/module/student/sql/SqlExercisePage.tsx
@@ -120,10 +120,7 @@ export default function SqlExercisePage() {
   const [dbReady, setDbReady] = useState(false);
   const [solved, setSolved] = useState(false);
 
-  const [prevExerciseId, setPrevExerciseId] = useState(exercise?.id);
-
-  if (exercise?.id !== prevExerciseId) {
-    setPrevExerciseId(exercise?.id);
+  useEffect(() => {
     setDbReady(false);
     setResult(null);
     setValidation(null);
@@ -133,7 +130,8 @@ export default function SqlExercisePage() {
     const savedEntry = exercise ? progress[exercise.id] : undefined;
     setCode(savedEntry?.code || exercise?.starterCode || "");
     setSolved(!!savedEntry?.solved);
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [exercise?.id]);
 
   // Load database and exercise
   useEffect(() => {


### PR DESCRIPTION
## Description
This PR resolves Issue #2357 by fixing a React 18 concurrent mode anti-pattern in the SQL exercise page.

## Changes Made
- Updated `client/src/module/student/sql/SqlExercisePage.tsx`.
- Removed the `prevExerciseId` state variable and the direct `if` block that was calling `setState` during the render phase.
- Replaced the logic with a standard `useEffect` hook that depends on `[exercise?.id]` to reset UI elements (editor code, hints, validation, database readiness) when the user navigates between exercises.
- This prevents potential infinite re-render loops and UI tearing that can occur when mutating state while React is calculating the virtual DOM.

Fixes #2357
