### PR TITLE
fix(security): restrict ATS resumeUrl validation to expected S3 host …

### DIFF
--- a/server/src/module/ats/ats.validation.ts
+++ b/server/src/module/ats/ats.validation.ts
@@ -1,12 +1,24 @@
 import { z } from "zod";
 
+const BUCKET = process.env["AWS_S3_BUCKET"] || "";
+const REGION = process.env["AWS_REGION"] || "ap-south-1";
+const expectedHost = `${BUCKET}.s3.${REGION}.amazonaws.com`;
+
 export const scoreResumeSchema = z.object({
   resumeUrl: z
     .string()
     .min(1, "Resume URL is required")
     .refine(
-      (url) => url.startsWith("https://") || url.startsWith("/uploads/"),
-      "Resume URL must be an S3 URL or local upload path",
+      (url) => {
+        if (url.startsWith("/uploads/")) return true;
+        try {
+          const parsed = new URL(url);
+          return parsed.hostname === expectedHost;
+        } catch {
+          return false;
+        }
+      },
+      "Resume URL must be a valid S3 URL or local upload path",
     ),
   jobTitle: z.string().max(200).optional(),
   jobDescription: z.string().max(5000).optional(),


### PR DESCRIPTION
## Description
This PR resolves Issue #2358 by patching a Server-Side Request Forgery (SSRF) vulnerability in the ATS service.

## Changes Made
- Updated `server/src/module/ats/ats.validation.ts`.
- Changed the `scoreResumeSchema` validation so that it no longer accepts any generic `https://` URL.
- The schema now dynamically reads the expected S3 bucket domain from `process.env` and uses the native `URL` API to strictly verify the `hostname` matches our S3 infrastructure. 
- This ensures the server will only fetch resumes that actually belong to the InternHack application, protecting internal networks and metadata APIs from being accessed by malicious user inputs.

Fixes #2358
