### PR TITLE
fix(server): make helmet/express-rate-limit imports resolve on Vercel

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,7 +6,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import helmet from "helmet";
 import morgan from "morgan";
-import rateLimit from "express-rate-limit";
+import { rateLimit } from "express-rate-limit";
 import { createRateLimitStore } from "./utils/rate-limit-store.js";
 import { authRouter } from "./module/auth/auth.routes.js";
 import { jobRouter } from "./module/job/job.routes.js";

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,6 +9,12 @@
     // See also https://aka.ms/tsconfig/module
     "module": "nodenext",
     "target": "esnext",
+    // Allow default-importing CJS packages whose types expose the value only as
+    // a named `default` (e.g. helmet). nodenext resolves the ESM types locally,
+    // but a clean Vercel install can resolve the CJS variant, where the default
+    // import is not callable without interop. Type-level only: verbatimModuleSyntax
+    // still controls emit, so no interop helpers are injected at runtime.
+    "esModuleInterop": true,
     "types": [],
     // For nodejs:
     // "lib": ["esnext"],


### PR DESCRIPTION
## Problem
Vercel build failed `tsc` with TS2349 "This expression is not callable" for `helmet(...)` and `rateLimit(...)`, plus a cascading TS7006 on the rate-limit `skip(req)` param. Local typecheck passed with identical versions.

## Cause
helmet and express-rate-limit ship dual ESM/CJS. `nodenext` resolves the ESM `.d.mts` locally (default export callable), but a clean Vercel install resolves the CJS variant where a default import of a CJS module is not callable without interop. express/morgan/etc. are unaffected because their `@types` use `export =` (native nodenext interop), whereas helmet exposes its function only as a named `default`.

## Fix
- `import { rateLimit } from "express-rate-limit"` (named export, resolution-proof).
- Enable `esModuleInterop` so helmet's default import is callable under CJS resolution too.

Type-level only: `verbatimModuleSyntax` still governs emit, so no interop helpers are injected at runtime. Verified with `npm run build` (exit 0).
