### PR TITLE
fix(server): load helmet via createRequire so Vercel build resolves it

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,7 +4,9 @@ import express from "express";
 import cookieParser from "cookie-parser";
 import path from "path";
 import { fileURLToPath } from "url";
-import helmet from "helmet";
+import { createRequire } from "node:module";
+import type { HelmetOptions } from "helmet";
+import type { RequestHandler } from "express";
 import morgan from "morgan";
 import { rateLimit } from "express-rate-limit";
 import { createRateLimitStore } from "./utils/rate-limit-store.js";
@@ -88,6 +90,14 @@ import { redis } from "./config/redis.js";
 import { createLogger } from "./utils/logger.js";
 
 const logger = createLogger("Index");
+
+// helmet ships its callable as a default export, but a clean Vercel install
+// resolves its CJS types to a non-callable namespace (TS2349), unlike the local
+// nodenext resolution. Load the module value via createRequire (always the CJS
+// function at runtime) and type it from the named HelmetOptions export, so the
+// call site is fully typed regardless of how the default export resolves.
+const nodeRequire = createRequire(import.meta.url);
+const helmet = nodeRequire("helmet") as (options?: Readonly<HelmetOptions>) => RequestHandler;
 
 
 // ── Validate required environment variables ──

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,12 +9,6 @@
     // See also https://aka.ms/tsconfig/module
     "module": "nodenext",
     "target": "esnext",
-    // Allow default-importing CJS packages whose types expose the value only as
-    // a named `default` (e.g. helmet). nodenext resolves the ESM types locally,
-    // but a clean Vercel install can resolve the CJS variant, where the default
-    // import is not callable without interop. Type-level only: verbatimModuleSyntax
-    // still controls emit, so no interop helpers are injected at runtime.
-    "esModuleInterop": true,
     "types": [],
     // For nodejs:
     // "lib": ["esnext"],


### PR DESCRIPTION
## Problem
Follow-up to #2371. That PR fixed express-rate-limit (named import) but helmet still failed the Vercel build with `TS2349: This expression is not callable. Type 'typeof import(".../helmet/index")' has no call signatures`. `esModuleInterop` did **not** resolve it: Vercel's clean install resolves helmet's CJS types to a non-callable namespace, so the default import binds to the namespace rather than the callable.

## Fix
Stop depending on how helmet's default export resolves:
- Load the value via `createRequire(import.meta.url)("helmet")` — at runtime this is always the CJS function (verified: `module.exports = helmet`; `require("helmet")` is callable).
- Type the binding from the **type-only** `HelmetOptions` named export (present in both `.d.mts` and `.d.cts`), so the call site stays fully typed in any resolution mode.
- Reverted the `esModuleInterop` tsconfig change from #2371 since it had no effect and is no longer needed (express-rate-limit uses a named import, helmet uses require).

Verified: `npm run build` exit 0, `eslint` clean, and a runtime smoke test confirming `helmet({})` returns middleware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript and server configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->