### PR TITLE
fix: clear chunk_reload key on successful lazy load so retry works every time

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,7 +8,10 @@ import { LoadingScreen } from "./components/LoadingScreen";
 
 function lazyWithRetry(factory: () => Promise<{ default: ComponentType<unknown> }>) {
   return lazy(() =>
-    factory().catch((err: unknown) => {
+    factory().then((mod) => {
+      sessionStorage.removeItem("chunk_reload");
+      return mod;
+    }).catch((err: unknown) => {
       const key = "chunk_reload";
       if (!sessionStorage.getItem(key)) {
         sessionStorage.setItem(key, "1");


### PR DESCRIPTION
## Description

The `lazyWithRetry` helper sets `chunk_reload=1` in sessionStorage before calling `window.location.reload()`, but only clears it in the `catch` block on a *second* failure. A successful reload leaves the key stuck, preventing the retry-reload mechanism from ever firing again in the same session.

## Fix

Add a `.then()` handler that clears `chunk_reload` after a successful chunk load, so each independent chunk failure gets its own retry attempt.

## Testing

- `git diff --check` — no whitespace errors  
- Verified logic: key is cleared on both success (new `.then()`) and failure (existing `catch`)

Closes #2355