### PR TITLE
fix: add 10s timeout to Google OAuth2Client to prevent hanging on verifyIdToken

### DIFF
--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -55,7 +55,10 @@ export class AuthService {
   private googleClient: OAuth2Client;
 
   constructor() {
-    this.googleClient = new OAuth2Client(process.env["GOOGLE_CLIENT_ID"] ?? "");
+    this.googleClient = new OAuth2Client({
+      clientId: process.env["GOOGLE_CLIENT_ID"] ?? "",
+      requestOptions: { timeout: 10000 },
+    });
   }
 
   async register(data: RegisterInput) {


### PR DESCRIPTION
## Description

The `googleAuth` method calls `OAuth2Client.verifyIdToken()` without a timeout, causing the authentication request to hang indefinitely when Google's API is slow or unreachable. Users report that Google sign-in "fails" and the request "times out".

## Fix

Pass `requestOptions: { timeout: 10000 }` to the `OAuth2Client` constructor so the token verification request fails with a clear error after 10 seconds instead of hanging silently.

## Testing

- `git diff --check` — no whitespace errors  
- Verified the constructor accepts the object-format options in google-auth-library v7+

Closes #2317