### PR TITLE
fix: pass email via React Router state instead of URL query param

### DIFF
--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -29,7 +29,7 @@ export function ProtectedRoute({ children, role, redirectTo = "/login" }: Protec
   }
 
   if (user && !user.isVerified && user.role !== "ADMIN") {
-    return <Navigate to={`/verify-email?email=${encodeURIComponent(user.email)}`} replace />;
+    return <Navigate to="/verify-email" replace state={{ email: user.email }} />;
   }
 
   if (role && user?.role !== role) {

--- a/client/src/module/auth/LoginPage.tsx
+++ b/client/src/module/auth/LoginPage.tsx
@@ -63,7 +63,7 @@ export default function LoginPage() {
     } catch (err: unknown) {
       const error = err as { response?: { data?: { message?: string; requiresVerification?: boolean; email?: string } } };
       if (error.response?.data?.requiresVerification && error.response?.data?.email) {
-        navigate(`/verify-email?email=${encodeURIComponent(error.response.data.email)}`);
+        navigate("/verify-email", { state: { email: error.response.data.email } });
         return;
       }
       setError(error.response?.data?.message || "Login failed");

--- a/client/src/module/auth/RegisterPage.tsx
+++ b/client/src/module/auth/RegisterPage.tsx
@@ -293,7 +293,7 @@ export default function RegisterPage() {
       if (ref) payload.ref = ref;
       const { data } = await api.post("/auth/register", payload);
       if (!data.user.isVerified) {
-        navigate(`/verify-email?email=${encodeURIComponent(form.email)}`);
+        navigate("/verify-email", { state: { email: form.email } });
       } else {
         login(data.user);
         redirectAfterAuth(data.user.role);

--- a/client/src/module/auth/VerifyEmailPage.tsx
+++ b/client/src/module/auth/VerifyEmailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router";
+import { Link, useNavigate, useSearchParams, useLocation } from "react-router";
 import { motion } from "framer-motion";
 import toast from "@/components/ui/toast";
 import api from "../../lib/axios";
@@ -9,8 +9,9 @@ import { SEO } from "../../components/SEO";
 
 export default function VerifyEmailPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
-  const email = searchParams.get("email") || "";
+  const email = (location.state as { email?: string } | null)?.email || searchParams.get("email") || "";
   const login = useAuthStore((s) => s.login);
 
   const [otp, setOtp] = useState<string[]>(["", "", "", "", "", ""]);


### PR DESCRIPTION
## Description

ProtectedRoute was leaking the user's email as a URL query parameter when redirecting unverified users to `/verify-email?email=user@example.com`. This exposed PII in browser history, Referer headers, analytics, and proxy logs.

## Fix

- Use `<Navigate state={{ email }}>` instead of query params in ProtectedRoute, LoginPage, and RegisterPage
- Update VerifyEmailPage to read from `location.state` first, falling back to `searchParams` for backward compatibility with existing bookmarks

## Testing

- `git diff --check` — no whitespace errors  
- The fallback pattern ensures existing direct navigation to /verify-email?email=... still works

Closes #2356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the email verification flow to use a more robust internal data-passing mechanism across authentication pages, improving the reliability of the verification process during login, registration, and access protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->