### PR TITLE
fix: remove undefined ipKeyGenerator import from express-rate-limit

### DIFF
--- a/server/src/middleware/rate-limit.middleware.ts
+++ b/server/src/middleware/rate-limit.middleware.ts
@@ -1,4 +1,4 @@
-import { rateLimit, ipKeyGenerator } from "express-rate-limit";
+import { rateLimit } from "express-rate-limit";
 import { createRateLimitStore } from "../utils/rate-limit-store.js";
 
 // Rate limiting for AI roadmap generation to prevent abuse and API quota drains
@@ -13,7 +13,7 @@ export const aiRoadmapLimiter = rateLimit({
     if (req.user?.id) {
       return `user_${req.user.id}`;
     }
-    return ipKeyGenerator(req.ip || "unknown_ip");
+    return `ip_${req.ip || "unknown_ip"}`;
   },
   message: { 
     message: "Too many AI roadmap generation requests. Please try again later."
@@ -27,7 +27,7 @@ export const contactLimiter = rateLimit({
   legacyHeaders: false,
   store: createRateLimitStore("contact"),
   keyGenerator: (req) => {
-    return ipKeyGenerator(req.ip || "unknown_ip");
+    return `ip_${req.ip || "unknown_ip"}`;
   },
   message: {
     message: "Too many contact submissions. Please try again later."
@@ -46,7 +46,7 @@ export const githubSyncLimiter = rateLimit({
     if (req.user?.id) {
       return `user_${req.user.id}`;
     }
-    return ipKeyGenerator(req.ip || "unknown_ip");
+    return `ip_${req.ip || "unknown_ip"}`;
   },
   message: {
     message: "Too many GitHub sync requests. Please try again later."


### PR DESCRIPTION
﻿## Summary

Removes the ipKeyGenerator named import from express-rate-limit which does not exist in v8.x and would cause a TypeError at runtime. Replaces all three usages (iRoadmapLimiter, contactLimiter, githubSyncLimiter) with a direct \ip_\\` string, matching the package's internal IP key format.

## Changes

- server/src/middleware/rate-limit.middleware.ts — removed ipKeyGenerator import, replaced 3 ipKeyGenerator() calls with inline IP string

Closes #2402


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced rate-limiting mechanism to provide consistent tracking of API requests across both authenticated and non-authenticated users, ensuring more reliable rate limit enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->