### PR TITLE
fix: restore conditional prerender to fix SEO for all public pages

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -43,8 +43,7 @@ const PRERENDER_ROUTES = [
 // so puppeteer can't launch and the prerender plugin hard-fails the build.
 // Skip the plugin on Vercel and rely on local prerendering (or skip SEO snapshot
 // for that deploy). Override via SKIP_PRERENDER=1 to disable elsewhere.
-const skipPrerender = true // Temporarily disabled due to Puppeteer connection timeout
-  // process.env.SKIP_PRERENDER === '1' || process.env.VERCEL === '1'
+const skipPrerender = process.env.SKIP_PRERENDER === '1' || process.env.VERCEL === '1'
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
﻿## Summary

Re-enables the conditional prerender check that was hardcoded to \	rue\, which silently disabled static HTML prerendering for all 38 SEO-critical public pages. Search engines were receiving empty JavaScript shells instead of actual content.

## Changes

- \client/vite.config.ts\ — changed \const skipPrerender = true\ to \const skipPrerender = process.env.SKIP_PRERENDER === '1' || process.env.VERCEL === '1'\

Closes #2403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to make prerendering behavior configurable via environment variables instead of using a hardcoded setting. This provides more flexibility for different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->