### PR TITLE
fix: log Pyodide preload failures instead of swallowing them

### DIFF
--- a/client/src/module/student/python/lib/python-engine.ts
+++ b/client/src/module/student/python/lib/python-engine.ts
@@ -58,7 +58,9 @@ function loadPyodide(): Promise<PyodideInstance> {
 class PythonEngine {
   /** Begin loading Pyodide in the background. */
   preload(): void {
-    loadPyodide().catch(() => {});
+    loadPyodide().catch((err) => {
+      console.warn("[PythonEngine] Pyodide preload failed, will retry on first execute():", err);
+    });
   }
 
   isReady(): boolean {


### PR DESCRIPTION
﻿## Summary

The Pyodide preload method was silently swallowing load failures with an empty \.catch(() => {})\. If the CDN was unreachable, a network error occurred, or the browser was incompatible, there was no diagnostic information anywhere. This change logs the error so developers and support can identify the root cause.

## Changes

- \client/src/module/student/python/lib/python-engine.ts\ — added error logging to the preload catch handler

Closes #2404
