### PR TITLE
fix: surface camera playback errors instead of swallowing them

### DIFF
--- a/client/src/hooks/useFaceDetection.ts
+++ b/client/src/hooks/useFaceDetection.ts
@@ -91,7 +91,15 @@ export function useFaceDetection(config: FaceDetectionConfig) {
     // Attach to video element
     if (videoRef.current) {
       videoRef.current.srcObject = stream;
-      await videoRef.current.play().catch(() => {});
+      try {
+        await videoRef.current.play();
+      } catch (playErr) {
+        const msg = "Failed to start camera preview. Please check your camera.";
+        setError(msg);
+        onErrorRef.current(msg);
+        setIsLoading(false);
+        return;
+      }
     }
 
     // 2. Load MediaPipe Face Detector


### PR DESCRIPTION
﻿## Summary

The camera preview \ideo.play()\ call in \useFaceDetection.ts\ had a silent catch handler that swallowed all playback errors. When autoplay was blocked by the browser (common on mobile or after permission grants), the camera preview remained frozen with no user feedback, and the face detection loop would run on a video with no frames.

## Changes

- \client/src/hooks/useFaceDetection.ts\ — replaced \wait videoRef.current.play().catch(() => {});\ with a try/catch that reports the error and halts initialization

Closes #2405
