### PR TITLE
fix: log fullscreen exit failures instead of swallowing them

### DIFF
--- a/client/src/module/student/skill-verification/SkillTestPage.tsx
+++ b/client/src/module/student/skill-verification/SkillTestPage.tsx
@@ -200,7 +200,11 @@ export default function SkillTestPage() {
         }
 
         if (document.fullscreenElement) {
-          document.exitFullscreen().catch(() => { });
+          try {
+            await document.exitFullscreen();
+          } catch (fsErr) {
+            console.warn("[SkillTest] Failed to exit fullscreen:", fsErr);
+          }
         }
       } catch (err: unknown) {
         const e = err as { response?: { data?: { error?: string } } };


### PR DESCRIPTION
﻿## Summary

Replaced the silent catch on \document.exitFullscreen()\ with a logged warning. If fullscreen exit fails, the error is now visible in console diagnostics, helping developers and support identify the issue.

## Changes

- \client/src/module/student/skill-verification/SkillTestPage.tsx\ — added error logging and await to fullscreen exit

Closes #2406
