### PR TITLE
fix: add proper TypeScript generic to res.json override in cache middleware

### DIFF
--- a/server/src/middleware/cache.middleware.ts
+++ b/server/src/middleware/cache.middleware.ts
@@ -44,7 +44,7 @@ export const cacheMiddleware = (ttl?: number, keyPrefix?: string) => {
     }
 
     const originalJson = res.json;
-    res.json = function (data) {
+    res.json = function <TBody>(data: TBody) {
       if (res.statusCode >= 200 && res.statusCode < 300 && !res.locals["skipCache"]) {
         appCache.set(key, data, cacheConfig.ttl);
       }


### PR DESCRIPTION
﻿## Summary

Added proper TypeScript generic \<TBody>\ to the \es.json\ override in the cache middleware so type narrowing on response bodies is preserved during type-checking.

## Changes

- \server/src/middleware/cache.middleware.ts\ — changed \unction (data)\ to \unction <TBody>(data: TBody)\

Closes #2407
