### PR TITLE
fix: extract hardcoded S3 bucket URL into S3_BUCKET_URL env variable

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -138,6 +138,9 @@ app.set("trust proxy", 1);
 const PORT = process.env["PORT"] || 3000;
 const PAYMENT_WEBHOOK_PATH = "/api/payments/webhook";
 
+// ── S3 bucket URL (configurable for different environments) ──
+const S3_BUCKET_URL = process.env["S3_BUCKET_URL"] || "https://intern-hack-prod-bucket.s3.ap-south-1.amazonaws.com";
+
 // ── Security headers ──
 app.use(
   helmet({
@@ -147,7 +150,7 @@ app.use(
         scriptSrc: ["'self'", "https://accounts.google.com", "https://apis.google.com", "https://www.googletagmanager.com", "https://www.google-analytics.com"],
         styleSrc: ["'self'", "'unsafe-inline'", "https://accounts.google.com", "https://fonts.googleapis.com"],
         imgSrc: ["'self'", "data:", "https:", "blob:"],
-        connectSrc: ["'self'", "https://accounts.google.com", "https://generativelanguage.googleapis.com", "https://www.google-analytics.com", "https://analytics.google.com", "https://intern-hack-prod-bucket.s3.ap-south-1.amazonaws.com"],
+        connectSrc: ["'self'", "https://accounts.google.com", "https://generativelanguage.googleapis.com", "https://www.google-analytics.com", "https://analytics.google.com", S3_BUCKET_URL],
         frameSrc: ["https://accounts.google.com", "https://checkout.dodopayments.com", "blob:"],
         fontSrc: ["'self'", "https:", "data:"],
       },


### PR DESCRIPTION
﻿## Summary

Extracted the hardcoded S3 bucket URL from the Content Security Policy into an environment variable \S3_BUCKET_URL\. Previously, changing the bucket name, region, or storage backend required a code deployment. Now it can be configured per-environment via env var.

## Changes

- \server/src/index.ts\ — added \S3_BUCKET_URL\ env var with current URL as default, used in CSP \connectSrc\

Closes #2408
