### PR TITLE
fix: add length truncation to formatRawError to prevent DB column overflow

### DIFF
--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -43,7 +43,8 @@ function formatRawError(err: Error): string {
     parts.push(stackLines.join("\n"));
   }
 
-  return parts.join("\n");
+  const MAX_RAW_ERROR_LENGTH = 10000;
+  return parts.join("\n").slice(0, MAX_RAW_ERROR_LENGTH);
 }
 
 function logErrorToDb(req: Request, statusCode: number, message: string, rawErr?: Error): void {


### PR DESCRIPTION
﻿## Summary

Added a 10,000 character limit to \ormatRawError()\ to prevent large error messages (deeply nested Prisma meta, long query strings, large payloads) from overflowing the \errorLog.rawError\ database column and causing cascading logging failures.

## Changes

- \server/src/middleware/error.middleware.ts\ — added \MAX_RAW_ERROR_LENGTH\ constant and slice to formatRawError return

Closes #2409
