### PR TITLE
fix: add Zod validation schema for issueCertificate

### DIFF
--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -12,6 +12,7 @@ import {
   bookmarkBodySchema,
   bulkMigrateBookmarksSchema,
   guideFeedbackSchema,
+  issueCertificateSchema,
 } from "./opensource.validation.js";
 import { parsePagination } from "../../utils/pagination.utils.js";
 
@@ -382,12 +383,15 @@ export class OpensourceController {
 
   async issueCertificate(req: Request, res: Response, next: NextFunction) {
     try {
-      const { guideName } = req.body;
-      if (!guideName) {
-        res.status(400).json({ message: "guideName is required" });
+      const parsed = issueCertificateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({
+          message: "Validation failed",
+          errors: parsed.error.flatten().fieldErrors,
+        });
         return;
       }
-      const certificate = await service.issueCertificate(req.user!.id, guideName);
+      const certificate = await service.issueCertificate(req.user!.id, parsed.data.guideName);
       res.status(201).json({ certificate });
     } catch (err) {
       next(err);

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -125,6 +125,10 @@ export const bookmarkBodySchema = z.object({
   repoId: z.number().int().positive("repoId must be a positive integer"),
 });
 
+export const issueCertificateSchema = z.object({
+  guideName: z.string().min(1, "guideName is required").max(200),
+});
+
 export const bulkMigrateBookmarksSchema = z.object({
   repoIds: z
     .array(z.number().int().positive())


### PR DESCRIPTION
Replaces the manual truthiness check on guideName with a proper Zod schema (issueCertificateSchema) following the same pattern used by submitGuideFeedback, addBookmark, and other POST endpoints in this module.

Changes:
- opensource.validation.ts - adds issueCertificateSchema with guideName: z.string().min(1).max(200)
- opensource.controller.ts - replaces manual if (!guideName) with safeParse

Fixes #2434