### PR TITLE
fix: remove unused length/targetWords from saveGenerated data type

### DIFF
--- a/server/src/module/ats/cover-letter.controller.ts
+++ b/server/src/module/ats/cover-letter.controller.ts
@@ -66,8 +66,6 @@ export class CoverLetterController {
         tone:           result.data.tone ?? "professional",
         useProfile:     result.data.useProfile ?? false,
         keySkills:      result.data.keySkills,
-        length:         result.data.length,
-        targetWords:    result.data.targetWords ?? 300,
       }).catch((err) => console.error("Failed to log cover letter usage:", err));
 
       const usage = req.usageInfo

--- a/server/src/module/ats/cover-letter.service.ts
+++ b/server/src/module/ats/cover-letter.service.ts
@@ -29,8 +29,6 @@ export class CoverLetterService {
       tone: string;
       useProfile: boolean;
       keySkills?: string;
-      length?: "short" | "medium" | "long";
-      targetWords?: number;
     }
   ) {
     const excerpt = data.content.slice(0, 120).replace(/\n/g, " ").trim();


### PR DESCRIPTION
The \saveGenerated\ method accepted \length\ and \	argetWords\ in its data parameter type but the Prisma model has no such columns — the fields were silently dropped by the \create\ call.

This removes the fields from the method signature and its sole call site so the type system accurately reflects what gets persisted.

Fixes #2425