### PR TITLE
fix: add usageLimit middleware to latex-chat routes

### DIFF
--- a/server/src/module/ats/ats.routes.ts
+++ b/server/src/module/ats/ats.routes.ts
@@ -37,5 +37,5 @@ atsRouter.get("/cover-letter/history/:id", (req, res, next) => coverLetterContro
 atsRouter.delete("/cover-letter/history/:id", (req, res, next) => coverLetterController.deleteOne(req, res, next));
 atsRouter.post("/generate-resume", usageLimit("GENERATE_RESUME"), (req, res, next) => resumeGenController.generate(req, res, next));
 atsRouter.get("/resume-history", (req, res, next) => resumeGenController.getHistory(req, res, next));
-atsRouter.post("/latex-chat", (req, res, next) => latexChatController.chat(req, res, next));
-atsRouter.post("/latex-optimize-jd", (req, res, next) => latexChatController.optimizeForJD(req, res, next));
+atsRouter.post("/latex-chat", usageLimit("GENERATE_RESUME"), (req, res, next) => latexChatController.chat(req, res, next));
+atsRouter.post("/latex-optimize-jd", usageLimit("GENERATE_RESUME"), (req, res, next) => latexChatController.optimizeForJD(req, res, next));


### PR DESCRIPTION
Both \POST /latex-chat\ and \POST /latex-optimize-jd\ were missing \usageLimit\ middleware, unlike every other AI endpoint in the same router (\/score\, \/cover-letter\, \/generate-resume\, \/apply-suggestions\).

Uses \GENERATE_RESUME\ (the closest existing UsageAction) since latex features are resume-generation workflows. Creating a new action value would require a Prisma migration.

Fixes #2426