### PR TITLE
fix: map subscription.on_hold to ON_HOLD instead of EXPIRED

### DIFF
--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -1348,6 +1348,7 @@ enum SubscriptionStatus {
   ACTIVE
   EXPIRED
   CANCELLED
+  ON_HOLD
 }
 
 enum AIProviderType {

--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -315,7 +315,7 @@ export class PaymentService {
 
     await prisma.user.update({
       where: { id: payment.userId },
-      data: { subscriptionStatus: "EXPIRED" },
+      data: { subscriptionStatus: "ON_HOLD" },
     });
     await invalidateUserTierCache(payment.userId);
   }


### PR DESCRIPTION
﻿The holdSubscription handler mapped dodo subscription.on_hold events to "EXPIRED", causing the subscription to be treated as permanently expired. This adds ON_HOLD to the Prisma SubscriptionStatus enum and maps on_hold to "ON_HOLD" instead, correctly representing the temporarily-paused state.

Note: Running prisma generate is required after this change to regenerate the Prisma client with the new enum value. The getPlanTier function already returns FREE for any non-ACTIVE status, so ON_HOLD users correctly get FREE tier.

Fixes #2428
