### PR TITLE
fix: add query validation for getStudentContributionTrend

### DIFF
--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -12,6 +12,8 @@ import {
   bookmarkBodySchema,
   bulkMigrateBookmarksSchema,
   guideFeedbackSchema,
+  issueCertificateSchema,
+  contributionTrendQuerySchema,
 } from "./opensource.validation.js";
 import { parsePagination } from "../../utils/pagination.utils.js";
 
@@ -298,7 +300,15 @@ export class OpensourceController {
     next: NextFunction,
   ) {
     try {
-      const { startDate, endDate } = req.query as { startDate?: string; endDate?: string };
+      const parsed = contributionTrendQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        res.status(400).json({
+          message: "Invalid query parameters",
+          errors: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+      const { startDate, endDate } = parsed.data;
       const result = await service.getStudentContributionTrend(req.user!.id, startDate, endDate);
       res.json(result);
     } catch (err) {

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -125,6 +125,12 @@ export const bookmarkBodySchema = z.object({
   repoId: z.number().int().positive("repoId must be a positive integer"),
 });
 
+const dateStringRegex = /^\d{4}-\d{2}-\d{2}$/;
+export const contributionTrendQuerySchema = z.object({
+  startDate: z.string().regex(dateStringRegex, "startDate must be YYYY-MM-DD").optional(),
+  endDate: z.string().regex(dateStringRegex, "endDate must be YYYY-MM-DD").optional(),
+});
+
 export const bulkMigrateBookmarksSchema = z.object({
   repoIds: z
     .array(z.number().int().positive())


### PR DESCRIPTION
﻿The getStudentContributionTrend endpoint accepts optional startDate and endDate query params but did not validate them. Invalid date strings (e.g. "not-a-date") would create Invalid Date objects, potentially causing unexpected behavior.

Adds contributionTrendQuerySchema with YYYY-MM-DD regex validation for both params, and uses safeParse in the controller.

Fixes #2429
