### PR TITLE
fix: use rejectRequestSchema instead of approveRequestOverrideSchema for rejection

### DIFF
--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -6,6 +6,7 @@ import {
   gsocOrgsQuerySchema,
   submitRepoRequestSchema,
   approveRequestOverrideSchema,
+  rejectRequestSchema,
   repoIdSchema,
   repoOwnerNameSchema,
   firstPrProgressUpdateSchema,
@@ -273,7 +274,7 @@ export class OpensourceController {
         return;
       }
 
-      const body = approveRequestOverrideSchema.safeParse(req.body);
+      const body = rejectRequestSchema.safeParse(req.body);
       if (!body.success) {
         res.status(400).json({
           message: "Validation failed",

--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -12,6 +12,8 @@ import {
   bookmarkBodySchema,
   bulkMigrateBookmarksSchema,
   guideFeedbackSchema,
+  issueCertificateSchema,
+  contributionTrendQuerySchema,
 } from "./opensource.validation.js";
 import { parsePagination } from "../../utils/pagination.utils.js";
 
@@ -298,7 +300,15 @@ export class OpensourceController {
     next: NextFunction,
   ) {
     try {
-      const { startDate, endDate } = req.query as { startDate?: string; endDate?: string };
+      const parsed = contributionTrendQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        res.status(400).json({
+          message: "Invalid query parameters",
+          errors: parsed.error.flatten().fieldErrors,
+        });
+        return;
+      }
+      const { startDate, endDate } = parsed.data;
       const result = await service.getStudentContributionTrend(req.user!.id, startDate, endDate);
       res.json(result);
     } catch (err) {

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -64,16 +64,6 @@ export const submitRepoRequestSchema = z.object({
     .max(1000),
 });
 
-export const bulkRepoRequestSchema = z.object({
-  ids: z
-    .array(z.number().int().positive("Invalid ID in request list"))
-    .min(1, "At least one ID must be specified"),
-  action: z.enum(["approve", "reject"], {
-    message: "Action must be either 'approve' or 'reject'",
-  }),
-  adminNote: z.string().max(1000).optional(),
-});
-
 export const gsocOrgsQuerySchema = z.object({
   page: z.coerce.number().int().positive().optional().default(1),
   limit: z.coerce.number().int().positive().max(100).optional().default(20),

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -125,6 +125,12 @@ export const bookmarkBodySchema = z.object({
   repoId: z.number().int().positive("repoId must be a positive integer"),
 });
 
+const dateStringRegex = /^\d{4}-\d{2}-\d{2}$/;
+export const contributionTrendQuerySchema = z.object({
+  startDate: z.string().regex(dateStringRegex, "startDate must be YYYY-MM-DD").optional(),
+  endDate: z.string().regex(dateStringRegex, "endDate must be YYYY-MM-DD").optional(),
+});
+
 export const bulkMigrateBookmarksSchema = z.object({
   repoIds: z
     .array(z.number().int().positive())

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -73,6 +73,10 @@ export const gsocOrgsQuerySchema = z.object({
   year: z.coerce.number().int().optional(),
 });
 
+export const rejectRequestSchema = z.object({
+  adminNote: z.string().max(2000).optional(),
+});
+
 export const approveRequestOverrideSchema = z.object({
   adminNote: z.string().max(2000).optional(),
   name: z.string().min(1, "Repository name is required").max(300).optional(),


### PR DESCRIPTION
﻿The rejectRepoRequest endpoint used approveRequestOverrideSchema, which accepts approval-specific fields (name, description, domain, difficulty, tags) that are irrelevant for rejection. Created rejectRequestSchema (adminNote only) and switched the endpoint to use it.

Fixes #2431
