### PR TITLE
fix: ProtectedRoute toast on role mismatch (#2257), pass email via state (#2356)

### DIFF
--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -4,9 +4,9 @@ import toast from "@/components/ui/toast";
 import { useAuthStore } from "../lib/auth.store";
 import type { UserRole } from "../lib/types";
 
-function RedirectWithToast({ to }: { to: string }) {
+function RedirectWithToast({ to, message }: { to: string; message?: string }) {
   useEffect(() => {
-    toast.error("Please login to access this resource");
+    toast.error(message || "Please login to access this resource");
   }, []);
   return <Navigate to={to} replace />;
 }
@@ -29,11 +29,11 @@ export function ProtectedRoute({ children, role, redirectTo = "/login" }: Protec
   }
 
   if (user && !user.isVerified && user.role !== "ADMIN") {
-    return <Navigate to={`/verify-email?email=${encodeURIComponent(user.email)}`} replace />;
+    return <Navigate to="/verify-email" replace state={{ email: user.email }} />;
   }
 
   if (role && user?.role !== role) {
-    return <Navigate to="/" replace />;
+    return <RedirectWithToast to="/" message="You do not have permission to access this page" />;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
**Fixes:** #2356 and #2257

### Changes
1. **#2356**: Pass email via React Router `state` instead of URL query param to avoid leaking PII in browser history/URL bar.
2. **#2257**: Show a toast error before redirecting on role mismatch instead of silently dumping user on homepage.

### Before
- `/verify-email?email=user@example.com` — email visible in URL
- Silent redirect on role mismatch — no feedback to user

### After
- `<Navigate to="/verify-email" state={{ email: user.email }} />` — email stays in router state only
- `<RedirectWithToast ... message="You do not have permission to access this page" />` — user sees error toast before redirect


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ProtectedRoute now displays a clear notification when users lack permission to access a page, replacing silent redirects with user-friendly feedback.

* **Bug Fixes**
  * Email verification redirect process improved with enhanced state handling during authentication transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->