### PR TITLE
fix: return 409 Conflict on duplicate email registration (#2422)

### DIFF
--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -38,7 +38,7 @@ export class AuthController {
       return res.status(201).json({ message: "Registration successful. Please verify your email to continue.", user: data.user });
     } catch (error) {
       if (error instanceof Error && error.message === "Email already registered") {
-        return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });
+        return res.status(409).json({ message: "An account with this email already exists." });
       }
       console.error(error);
       return res.status(500).json({ message: "Internal Server Error" });


### PR DESCRIPTION
**Fixes:** #2422

### Changes
Changed HTTP status from **201 Created** → **409 Conflict** when a user tries to register with an already-registered email.

### Before
```typescript
return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });
```

### After
```typescript
return res.status(409).json({ message: "An account with this email already exists." });
```

### Impact
Frontend can now distinguish between a successful registration and a duplicate attempt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed registration error handling to properly return an error response when attempting to register with an email address that is already associated with an existing account, improving API reliability and user feedback accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->