### PR TITLE
fix: remove unused length/targetWords params from saveGenerated (#2425)

### DIFF
--- a/server/src/module/ats/cover-letter.controller.ts
+++ b/server/src/module/ats/cover-letter.controller.ts
@@ -66,8 +66,6 @@ export class CoverLetterController {
         tone:           result.data.tone ?? "professional",
         useProfile:     result.data.useProfile ?? false,
         keySkills:      result.data.keySkills,
-        length:         result.data.length,
-        targetWords:    result.data.targetWords ?? 300,
       }).catch((err) => console.error("Failed to log cover letter usage:", err));
 
       const usage = req.usageInfo

--- a/server/src/module/ats/cover-letter.service.ts
+++ b/server/src/module/ats/cover-letter.service.ts
@@ -29,8 +29,6 @@ export class CoverLetterService {
       tone: string;
       useProfile: boolean;
       keySkills?: string;
-      length?: "short" | "medium" | "long";
-      targetWords?: number;
     }
   ) {
     const excerpt = data.content.slice(0, 120).replace(/\n/g, " ").trim();


### PR DESCRIPTION
**Fixes:** #2425

### Changes
Removed `length` and `targetWords` parameters from `CoverLetterService.saveGenerated()` method signature and controller call site.

### Why
These parameters were passed to the service method but silently dropped — the Prisma model has no corresponding columns. Removing them from the method signature makes the API honest and prevents future confusion.

### Impact
Zero runtime change — these values were never persisted.
