### PR TITLE
fix: add generic type param to cache middleware res.json override (#2407)

### DIFF
--- a/server/src/middleware/cache.middleware.ts
+++ b/server/src/middleware/cache.middleware.ts
@@ -44,7 +44,7 @@ export const cacheMiddleware = (ttl?: number, keyPrefix?: string) => {
     }
 
     const originalJson = res.json;
-    res.json = function (data) {
+    res.json = function <T>(data: T) {
       if (res.statusCode >= 200 && res.statusCode < 300 && !res.locals["skipCache"]) {
         appCache.set(key, data, cacheConfig.ttl);
       }


### PR DESCRIPTION
**Fixes:** #2407

### Changes
Added generic type `<T>` to the `res.json` override in cache middleware:
```typescript
res.json = function <T>(data: T) { ... }
```

### Impact
Restores TypeScript type narrowing on `res.json()` calls after cache middleware wraps the method. Passes `npm run typecheck`.
