### PR TITLE
fix: make /usage endpoint window-aware for daily vs monthly limits (#2427)

### DIFF
--- a/server/src/module/ats/ats.controller.ts
+++ b/server/src/module/ats/ats.controller.ts
@@ -2,7 +2,7 @@ import type { Request, Response, NextFunction } from "express";
 import type { AtsService } from "./ats.service.js";
 import { applySuggestionsSchema, scoreResumeSchema } from "./ats.validation.js";
 import { prisma } from "../../database/db.js";
-import { DAILY_LIMITS, getPlanTier } from "../../config/usage-limits.js";
+import { DAILY_LIMITS, MONTHLY_LIMITS, getPlanTier } from "../../config/usage-limits.js";
 import { sendEmail } from "../../utils/email.utils.js";
 import { atsScoreReportHtml } from "../../utils/email-templates.js";
 import { isPremiumUser } from "../../utils/premium.utils.js";
@@ -124,24 +124,45 @@ export class AtsController {
 
       const tier = getPlanTier(user.subscriptionPlan, user.subscriptionStatus, user.subscriptionEndDate);
 
-      const startOfDay = new Date();
+      const now = new Date();
+      const startOfDay = new Date(now);
       startOfDay.setHours(0, 0, 0, 0);
+      const startOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
 
-      const counts = await prisma.usageLog.groupBy({
+      const dailyCounts = await prisma.usageLog.groupBy({
         by: ["action"],
         where: { userId: req.user.id, createdAt: { gte: startOfDay } },
         _count: { id: true },
       });
+      const monthlyCounts = await prisma.usageLog.groupBy({
+        by: ["action"],
+        where: { userId: req.user.id, createdAt: { gte: startOfMonth } },
+        _count: { id: true },
+      });
 
-      const countMap = Object.fromEntries(
-        counts.map((c) => [c.action, c._count.id]),
+      const dailyCountMap = Object.fromEntries(
+        dailyCounts.map((c) => [c.action, c._count.id]),
+      );
+      const monthlyCountMap = Object.fromEntries(
+        monthlyCounts.map((c) => [c.action, c._count.id]),
       );
 
-      const usage = Object.entries(DAILY_LIMITS).map(([action, limits]) => ({
-        action,
-        used: (countMap[action] as number) ?? 0,
-        limit: limits[tier],
-      }));
+      const usage = Object.entries(DAILY_LIMITS).map(([action, limits]) => {
+        if (MONTHLY_LIMITS[action]) {
+          return {
+            action,
+            used: (monthlyCountMap[action] as number) ?? 0,
+            limit: MONTHLY_LIMITS[action]![tier],
+            window: "monthly" as const,
+          };
+        }
+        return {
+          action,
+          used: (dailyCountMap[action] as number) ?? 0,
+          limit: limits[tier],
+          window: "daily" as const,
+        };
+      });
 
       res.json({ tier, usage });
     } catch (err) {


### PR DESCRIPTION
**Fixes:** #2427

### Problem
ATS `/usage` endpoint always queried usage from start of day and returned `DAILY_LIMITS`, but `/score` route enforces **monthly** limits (`usageLimit("ATS_SCORE", "monthly")`). FREE users saw "2 of 2 used" after 2 daily uses, but only 1 monthly use remained — confusing UX.

### Changes
- Import `MONTHLY_LIMITS` alongside `DAILY_LIMITS`
- Query usage for both daily window (start of day) and monthly window (start of month)
- For actions with `MONTHLY_LIMITS` (ATS_SCORE, ROADMAP_GENERATION), return monthly count + monthly limit + `"window": "monthly"`
- For all other actions, return daily count + daily limit + `"window": "daily"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced ATS usage tracking with monthly and daily aggregation. Usage statistics now indicate the applicable time window (monthly or daily) for each tracked action, providing clearer visibility into usage limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->