### PR TITLE
fix: align README Prisma commands between Docker and manual setup (#2410)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ cd server
 # Generate Prisma client using prisma.config.ts
 npx prisma generate --config src/database/prisma.config.ts
 
-# Push schema to database
-npx prisma db push --config src/database/prisma.config.ts
+# Apply migrations to database
+npx prisma migrate deploy --config src/database/prisma.config.ts
 ```
 
 


### PR DESCRIPTION
**Fixes:** #2410

### Problem
Docker setup uses `prisma migrate deploy` but manual setup instructs `prisma db push`. These behave differently — `migrate deploy` applies migration files in order, `db push` syncs schema directly without tracking migration history.

### Changes
Changed manual setup from `prisma db push` → `prisma migrate deploy` to match the Docker Compose path.

### Impact
Consistent database setup instructions — both Docker and manual paths now use the same migration-based workflow.
