### PR TITLE
fix: use dedicated rejectRequestSchema instead of approveRequestOverrideSchema (#2431)

### DIFF
--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -6,6 +6,7 @@ import {
   gsocOrgsQuerySchema,
   submitRepoRequestSchema,
   approveRequestOverrideSchema,
+  rejectRequestSchema,
   repoIdSchema,
   repoOwnerNameSchema,
   firstPrProgressUpdateSchema,
@@ -271,7 +272,7 @@ export class OpensourceController {
         return;
       }
 
-      const body = approveRequestOverrideSchema.safeParse(req.body);
+      const body = rejectRequestSchema.safeParse(req.body);
       if (!body.success) {
         res.status(400).json({
           message: "Validation failed",

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -109,6 +109,10 @@ export const approveRequestOverrideSchema = z.object({
   tags: z.array(z.string()).optional(),
 });
 
+export const rejectRequestSchema = z.object({
+  adminNote: z.string().max(2000).optional(),
+});
+
 export const firstPrProgressUpdateSchema = z.object({
   stepId: z.string().min(1, "Step ID is required").max(200),
   completed: z.boolean(),


### PR DESCRIPTION
**Fixes:** #2431

### Problem
`rejectRepoRequest` validated against `approveRequestOverrideSchema` which includes approval-specific fields (name, description, domain, difficulty, tags). If the approval schema is later updated to require mandatory fields, the rejection endpoint would break.

### Changes
- Added `rejectRequestSchema` (only `adminNote` optional field) to `opensource.validation.ts`
- Updated controller to use it instead of `approveRequestOverrideSchema`
