### PR TITLE
fix: remove unused bulkRepoRequestSchema export (#2430)

### DIFF
--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -64,16 +64,6 @@ export const submitRepoRequestSchema = z.object({
     .max(1000),
 });
 
-export const bulkRepoRequestSchema = z.object({
-  ids: z
-    .array(z.number().int().positive("Invalid ID in request list"))
-    .min(1, "At least one ID must be specified"),
-  action: z.enum(["approve", "reject"], {
-    message: "Action must be either 'approve' or 'reject'",
-  }),
-  adminNote: z.string().max(1000).optional(),
-});
-
 export const gsocOrgsQuerySchema = z.object({
   page: z.coerce.number().int().positive().optional().default(1),
   limit: z.coerce.number().int().positive().max(100).optional().default(20),


### PR DESCRIPTION
**Fixes:** #2430

### Changes
Removed unused `bulkRepoRequestSchema` from `opensource.validation.ts`. The schema was defined but never imported or used by any route or controller.

### Impact
Removes dead code, reducing maintenance burden.
