### PR TITLE
perf(db): reduce profile badge lookups with a compact public badge summary (#2305)

### DIFF
--- a/client/src/lib/types/skill-test.types.ts
+++ b/client/src/lib/types/skill-test.types.ts
@@ -134,3 +134,16 @@ export interface StudentBadge {
   badge: Badge;
   earnedAt: string;
 }
+
+/** Compact badge shape returned in public profile payload — no heavy criteria. */
+export interface BadgeDisplay {
+  id: number;
+  earnedAt: string;
+  badge: {
+    id: number;
+    name: string;
+    slug: string;
+    iconUrl?: string;
+    category: BadgeCategory;
+  };
+}

--- a/client/src/module/student/badges/BadgesSection.tsx
+++ b/client/src/module/student/badges/BadgesSection.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Award } from "lucide-react";
 import api from "../../../lib/axios";
 import { queryKeys } from "../../../lib/query-keys";
-import type { StudentBadge } from "../../../lib/types";
+import type { BadgeDisplay, StudentBadge } from "../../../lib/types";
 
 const fadeInUp = {
   hidden: { opacity: 0, y: 20 },
@@ -33,9 +33,10 @@ const categoryLabels: Record<string, string> = {
 interface BadgesSectionProps {
   studentId?: number;
   showTitle?: boolean;
+  badges?: BadgeDisplay[];
 }
 
-export function BadgesSection({ studentId, showTitle = true }: BadgesSectionProps) {
+export function BadgesSection({ studentId, showTitle = true, badges: propBadges }: BadgesSectionProps) {
   const { data, isLoading } = useQuery({
     queryKey: studentId
       ? queryKeys.badges.student(studentId)
@@ -45,9 +46,10 @@ export function BadgesSection({ studentId, showTitle = true }: BadgesSectionProp
       const res = await api.get(url);
       return res.data as { badges: StudentBadge[] };
     },
+    enabled: !propBadges,
   });
 
-  const badges = data?.badges ?? [];
+  const badges = (propBadges ?? data?.badges ?? []) as (BadgeDisplay | StudentBadge)[];
 
   if (isLoading) {
     return (

--- a/client/src/module/student/profile/PublicProfilePage.tsx
+++ b/client/src/module/student/profile/PublicProfilePage.tsx
@@ -14,7 +14,7 @@ import { BadgesSection } from "../badges/BadgesSection";
 import ContributionGraphs from "../../../components/ContributionGraphs";
 import GitHubStatsCard from "./GitHubStatsCard";
 import { OssContributionHeatmap } from "../../../components/OssContributionHeatmap";
-import type { ProjectItem, AchievementItem, VerifiedSkill } from "../../../lib/types";
+import type { ProjectItem, AchievementItem, VerifiedSkill, BadgeDisplay } from "../../../lib/types";
 
 interface PublicProfile {
   id: number;
@@ -42,6 +42,7 @@ interface PublicProfile {
   verifiedSkills: VerifiedSkill[];
   createdAt: string;
   ossTier?: string;
+  badges: BadgeDisplay[];
 }
 
 // ─── TIER COLORS ────────────────────────────────────────────────
@@ -316,10 +317,10 @@ export default function PublicProfilePage() {
             </motion.div>
           )}
 
-          {/* Badges */}
+          {/* Badges — uses compact list from profile payload, no separate API call */}
           <motion.div custom={4} variants={fadeInUp} initial="hidden" animate="visible"
             className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-5">
-            <BadgesSection studentId={profile.id} />
+            <BadgesSection badges={profile.badges} />
           </motion.div>
 
           <motion.div custom={5} variants={fadeInUp} initial="hidden" animate="visible">

--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -604,14 +604,17 @@ export class AuthService {
     if (!isOwner && !isVisitorAuthorized) {
       delete (rest as any).email;
       delete (rest as any).contactNo;
-      // We will keep resumes for now as per normal portfolio behavior, but sensitive identifiers are stripped.
     }
 
     await signProfileMedia(rest as Record<string, any>);
 
+    // Fetch lightweight badge display list — no heavy criteria JSON
+    const badges = await badgeService.getStudentBadgesDisplay(user.id);
+
     const result = {
       ...rest,
       bestAtsScore: atsScores[0]?.overallScore ?? null,
+      badges,
     };
     await cacheSet(cacheKey, result, PROFILE_TTL);
     return result;

--- a/server/src/module/badge/badge.service.ts
+++ b/server/src/module/badge/badge.service.ts
@@ -5,6 +5,8 @@ import type { Prisma, BadgeCategory, badge } from "@prisma/client";
 
 const BADGES_CACHE_KEY = "badges:active";
 const BADGES_TTL = 300; // 5 minutes
+const BADGE_DISPLAY_TTL = 300;
+const BADGE_DISPLAY_CACHE_PREFIX = "student:badges:";
 
 interface CreateBadgeInput {
   name: string;
@@ -36,6 +38,21 @@ export class BadgeService {
     });
   }
 
+  // Fields needed for badge display (excludes heavy JSON criteria)
+  private readonly displaySelect = {
+    id: true,
+    earnedAt: true,
+    badge: {
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        iconUrl: true,
+        category: true,
+      },
+    },
+  } as const;
+
   // ==================== STUDENT ====================
 
   async getStudentBadges(studentId: number) {
@@ -46,6 +63,22 @@ export class BadgeService {
         badge: true,
       },
     });
+  }
+
+  /** Lightweight badge display list — no criteria, cached per student. */
+  async getStudentBadgesDisplay(studentId: number) {
+    const cacheKey = `${BADGE_DISPLAY_CACHE_PREFIX}${studentId}`;
+    const cached = await cacheGet(cacheKey);
+    if (cached) return cached as never;
+
+    const badges = await prisma.studentBadge.findMany({
+      where: { studentId },
+      select: this.displaySelect,
+      orderBy: { earnedAt: "desc" },
+    });
+
+    await cacheSet(cacheKey, badges, BADGE_DISPLAY_TTL);
+    return badges;
   }
 
   // ==================== ADMIN CRUD ====================
@@ -313,6 +346,7 @@ export class BadgeService {
         data: toAward.map((badgeId) => ({ studentId, badgeId })),
         skipDuplicates: true,
       });
+      await cacheDel(`${BADGE_DISPLAY_CACHE_PREFIX}${studentId}`);
     }
 
     return newlyAwarded;


### PR DESCRIPTION
## Description

Optimized public profile performance by minimizing database query overhead and payload transit related to student badges. Refactored the backend query pipeline across the authentication/badge services to fetch a compact array summary consisting only of essential visual fields, omitting the heavy criteria JSON payloads entirely. Consolidated this data path into the public profile payload contract, successfully saving a database lookup during profile render sequences.

## Related Issue

Fixes #2305

## Type of Change

* [ ] Bug Fix
* [ ] Feature
* [x] Enhancement / Performance Optimization
* [ ] Documentation

## Testing

1. Requested a public profile view with visible badges while monitoring database transaction logs.
2. Verified that total database query counts dropped by at least one operation and no nested criteria fields are selected.
3. Inspected the network payload to ensure the badge properties are constrained only to UI display items.

## Screenshots / Video

*No UI changes in this PR*

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [x] Docs updated (if needed)
* [ ] **Screenshot or video attached for every UI change** (PR will be rejected if missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User badges are now displayed on public profiles, allowing community members to view the skills and achievements of other users.

* **Refactor**
  * Optimized badge data retrieval with efficient caching mechanisms to improve public profile page performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->