### PR TITLE
fix: add usageLimit middleware to latex chat routes, remove manual usageLog (#2426)

### DIFF
--- a/server/src/module/ats/ats.routes.ts
+++ b/server/src/module/ats/ats.routes.ts
@@ -37,5 +37,5 @@ atsRouter.get("/cover-letter/history/:id", (req, res, next) => coverLetterContro
 atsRouter.delete("/cover-letter/history/:id", (req, res, next) => coverLetterController.deleteOne(req, res, next));
 atsRouter.post("/generate-resume", usageLimit("GENERATE_RESUME"), (req, res, next) => resumeGenController.generate(req, res, next));
 atsRouter.get("/resume-history", (req, res, next) => resumeGenController.getHistory(req, res, next));
-atsRouter.post("/latex-chat", (req, res, next) => latexChatController.chat(req, res, next));
-atsRouter.post("/latex-optimize-jd", (req, res, next) => latexChatController.optimizeForJD(req, res, next));
+atsRouter.post("/latex-chat", usageLimit("GENERATE_RESUME"), (req, res, next) => latexChatController.chat(req, res, next));
+atsRouter.post("/latex-optimize-jd", usageLimit("GENERATE_RESUME"), (req, res, next) => latexChatController.optimizeForJD(req, res, next));

--- a/server/src/module/ats/latex-chat.controller.ts
+++ b/server/src/module/ats/latex-chat.controller.ts
@@ -1,8 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import type { LatexChatService } from "./latex-chat.service.js";
 import { latexChatSchema, latexJDOptimizeSchema } from "./latex-chat.validation.js";
-import { prisma } from "../../database/db.js";
-import type { UsageAction } from "@prisma/client";
 import { isPremiumUser } from "../../utils/premium.utils.js";
 
 export class LatexChatController {
@@ -28,10 +26,6 @@ export class LatexChatController {
       }
 
       const response = await this.chatService.chat(result.data, req.user.id);
-
-      await prisma.usageLog.create({
-        data: { userId: req.user.id, action: "GENERATE_RESUME" as UsageAction },
-      });
 
       res.json(response);
     } catch (err) {
@@ -63,10 +57,6 @@ export class LatexChatController {
         result.data.jobDescription,
         req.user.id,
       );
-
-      await prisma.usageLog.create({
-        data: { userId: req.user.id, action: "GENERATE_RESUME" as UsageAction },
-      });
 
       res.json(response);
     } catch (err) {


### PR DESCRIPTION
**Fixes:** #2426

### Problem
`/latex-chat` and `/latex-optimize-jd` routes bypassed `usageLimit()` middleware. The controller manually created usageLog entries with a fragile `as UsageAction` type assertion, but limits were never enforced — premium users could call these endpoints unlimited times.

### Changes
- Added `usageLimit("GENERATE_RESUME")` middleware to both routes
- Removed manual `prisma.usageLog.create()` calls and their unused imports from controller


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal usage tracking architecture for resume and job description optimization features, ensuring consistent rate limiting across content generation endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->