### PR TITLE
fix: clear subscriptionPlan on hold to match expireSubscription pattern (#2428)

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -315,7 +315,7 @@ export class PaymentService {
 
     await prisma.user.update({
       where: { id: payment.userId },
-      data: { subscriptionStatus: "EXPIRED" },
+      data: { subscriptionStatus: "EXPIRED", subscriptionPlan: "FREE" },
     });
     await invalidateUserTierCache(payment.userId);
   }


### PR DESCRIPTION
**Fixes:** #2428

### Problem
`holdSubscription` set `subscriptionStatus: "EXPIRED"` but left `subscriptionPlan` as `MONTHLY`/`YEARLY`, creating an inconsistent state (`EXPIRED + MONTHLY`). `expireSubscription` correctly clears plan to `"FREE"`.

### Changes
Aligned `holdSubscription` with `expireSubscription` by also setting `subscriptionPlan: "FREE"` when a subscription goes on hold.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired subscriptions now correctly update both subscription status and plan information to reflect the free tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->