### PR TITLE
fix: add Retry button to ErrorBoundary for chunk load recovery (#2411)

### DIFF
--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -31,9 +31,14 @@ export class ErrorBoundary extends Component<Props, State> {
           <div className="text-center p-8">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">Something went wrong</h1>
             <p className="text-gray-600 dark:text-gray-400 mb-6">{this.state.error?.message || "An unexpected error occurred"}</p>
-            <Button variant="primary" onClick={() => { this.setState({ hasError: false, error: null }); window.location.href = "/"; }}>
-              Go Home
-            </Button>
+            <div className="flex gap-3 justify-center">
+              <Button variant="primary" onClick={() => { this.setState({ hasError: false, error: null }); window.location.href = "/"; }}>
+                Go Home
+              </Button>
+              <Button variant="secondary" onClick={() => { window.location.reload(); }}>
+                Retry
+              </Button>
+            </div>
           </div>
         </div>
       );


### PR DESCRIPTION
**Fixes:** #2411

### Problem
After lazy chunk reload fails, ErrorBoundary only shows "Go Home" button. Navigating back to the same page would trigger the same failing lazy import with no recovery path.

### Changes
Added a "Retry" button alongside "Go Home" that calls `window.location.reload()`, resetting the module-level `hasReloaded` flag and giving the lazy chunk another chance to load.
