### PR TITLE
fix: restore conditional skipPrerender env check instead of hardcoded true (#2403)

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -43,8 +43,7 @@ const PRERENDER_ROUTES = [
 // so puppeteer can't launch and the prerender plugin hard-fails the build.
 // Skip the plugin on Vercel and rely on local prerendering (or skip SEO snapshot
 // for that deploy). Override via SKIP_PRERENDER=1 to disable elsewhere.
-const skipPrerender = true // Temporarily disabled due to Puppeteer connection timeout
-  // process.env.SKIP_PRERENDER === '1' || process.env.VERCEL === '1'
+const skipPrerender = process.env.SKIP_PRERENDER === '1' || process.env.VERCEL === '1'
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
**Fixes:** #2403

### Problem
`skipPrerender` was hardcoded to `true`, disabling prerendering for all 38+ SEO-critical public pages. Search engines saw empty shells instead of actual content.

### Changes
Restored the original environment check: `process.env.SKIP_PRERENDER === '1' || process.env.VERCEL === '1'`
