### PR TITLE
fix: log Pyodide preload failures instead of silently swallowing (#2404)

### DIFF
--- a/client/src/module/student/python/lib/python-engine.ts
+++ b/client/src/module/student/python/lib/python-engine.ts
@@ -58,7 +58,9 @@ function loadPyodide(): Promise<PyodideInstance> {
 class PythonEngine {
   /** Begin loading Pyodide in the background. */
   preload(): void {
-    loadPyodide().catch(() => {});
+    loadPyodide().catch((err) => {
+      console.error("[PythonEngine] Failed to preload Pyodide:", err);
+    });
   }
 
   isReady(): boolean {


### PR DESCRIPTION
**Fixes:** #2404

### Problem
`preload()` used `.catch(() => {})` which completely silenced all Pyodide load failures. Users saw a broken Python editor with no indication of what went wrong.

### Changes
Added `console.error` logging so failures are visible in devtools console.

### Also applicable
Same pattern in #2405 (camera) and #2406 (fullscreen) — addressing those separately if needed.
