### PR TITLE
fix: surface camera playback errors instead of silently swallowing (#2405)

### DIFF
--- a/client/src/hooks/useFaceDetection.ts
+++ b/client/src/hooks/useFaceDetection.ts
@@ -91,7 +91,12 @@ export function useFaceDetection(config: FaceDetectionConfig) {
     // Attach to video element
     if (videoRef.current) {
       videoRef.current.srcObject = stream;
-      await videoRef.current.play().catch(() => {});
+      try {
+        await videoRef.current.play();
+      } catch (err) {
+        setError("Failed to start camera preview. Please check your camera.");
+        return;
+      }
     }
 
     // 2. Load MediaPipe Face Detector


### PR DESCRIPTION
**Fixes:** #2405

### Problem
`videoRef.current.play().catch(() => {})` silently swallowed all camera playback failures. If the browser blocked autoplay, the proctoring camera preview appeared frozen with no error.

### Changes
Replaced `.catch(() => {})` with try/catch that calls `setError()` with a user-facing message and returns early.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when camera preview fails to start—users now receive clear, informative error messages instead of silent failures, providing better visibility into camera initialization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->