### PR TITLE
fix: surface fullscreen exit failures instead of silently swallowing (#2406)

### DIFF
--- a/client/src/module/student/skill-verification/SkillTestPage.tsx
+++ b/client/src/module/student/skill-verification/SkillTestPage.tsx
@@ -200,7 +200,9 @@ export default function SkillTestPage() {
         }
 
         if (document.fullscreenElement) {
-          document.exitFullscreen().catch(() => { });
+          document.exitFullscreen().catch(() => {
+            toast.error("Failed to exit fullscreen mode");
+          });
         }
       } catch (err: unknown) {
         const e = err as { response?: { data?: { error?: string } } };


### PR DESCRIPTION
**Fixes:** #2406

### Problem
`document.exitFullscreen().catch(() => {})` silently swallowed fullscreen exit failures. If the browser denied the exit request (common with user-gesture requirements in modern browsers), there was no indication to the user.

### Changes
Replaced empty catch with `toast.error` to surface the failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when exiting fullscreen mode during skill tests—users will now receive a notification if the action fails instead of errors being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->