### PR TITLE
fix: remove unused deleteResumeSchema export (#2374)

### DIFF
--- a/server/src/module/upload/upload.validation.ts
+++ b/server/src/module/upload/upload.validation.ts
@@ -16,10 +16,6 @@ const validateS3Url = (url: string): boolean => {
   return validPatterns.some((pattern) => url.startsWith(pattern));
 };
 
-export const deleteResumeSchema = z.object({
-  url: z.string().url("Valid resume URL is required"),
-});
-
 export const presignRequestSchema = z.object({
   fileName: z.string().min(1, "fileName is required"),
   fileType: z.string().min(1, "fileType is required"),


### PR DESCRIPTION
**Fixes:** #2374

Removes unused `deleteResumeSchema` from `upload.validation.ts`. The schema is never imported or used by any route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resume upload validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->