### PR TITLE
fix: add q param to talentSearchSchema to prevent Zod validation bypass (#2370)

### DIFF
--- a/server/src/module/recruiter/recruiter.controller.ts
+++ b/server/src/module/recruiter/recruiter.controller.ts
@@ -295,8 +295,7 @@ export class RecruiterController {
       if (!result.success) return res.status(400).json({ message: "Validation failed", errors: result.error.flatten() });
 
       const filters = { ...result.data };
-      const q = (req.query as Record<string, unknown>).q as string | undefined;
-      if (q && !filters.search) filters.search = q;
+      if (filters.q && !filters.search) filters.search = filters.q;
 
       const data = await this.recruiterService.searchTalent(filters);
       return res.status(200).json(data);

--- a/server/src/module/recruiter/recruiter.validation.ts
+++ b/server/src/module/recruiter/recruiter.validation.ts
@@ -122,6 +122,7 @@ export const talentSearchSchema = z.object({
   minAtsScore: z.coerce.number().int().min(0).max(100).optional(),
   location: z.string().optional(),
   search: z.string().optional(),
+  q: z.string().optional(),
   jobStatus: z.string().optional(),
   ossTier: z.string().optional(),
 });


### PR DESCRIPTION
**Fixes:** #2370

### Problem
The `talentSearchSchema` didn't include `q` as a valid param. Zod strips unknown keys by default, so `?q=foo` was silently dropped. The controller then read `q` directly from `req.query` (cast to `any`), bypassing Zod validation entirely.

### Changes
1. Added `q: z.string().optional()` to `talentSearchSchema`
2. Updated controller to read `q` from `result.data` instead of raw `req.query`