### PR TITLE
fix: use fieldAnswerValueSchema in applyToJobSchema for nested record support (#2373)

### DIFF
--- a/server/src/module/student/student.validation.ts
+++ b/server/src/module/student/student.validation.ts
@@ -9,7 +9,7 @@ const fieldAnswerValueSchema = z.union([
 ]);
 
 export const applyToJobSchema = z.object({
-  customFieldAnswers: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.array(z.string())])).default({}),
+  customFieldAnswers: z.record(z.string(), fieldAnswerValueSchema).default({}),
   resumeUrl: z.string().optional(),
   coverLetter: z.string().optional(),
 });


### PR DESCRIPTION
**Fixes:** #2373

### Problem
`applyToJobSchema.customFieldAnswers` used an inline union (`string | number | boolean | string[]`) that was missing the nested record variant. The existing `fieldAnswerValueSchema` already included `z.record(z.string(), z.number())` but was only used by `submitRoundSchema`. This caused Zod validation errors when custom field values contained nested objects.

### Changes
Replaced the inline union in `applyToJobSchema.customFieldAnswers` with the shared `fieldAnswerValueSchema`.