### PR TITLE
fix: remove permissive HTTPS fallback in isAllowedUrl to prevent SSRF (#2358)

### DIFF
--- a/server/src/module/ats/ats.validation.ts
+++ b/server/src/module/ats/ats.validation.ts
@@ -4,7 +4,7 @@ const S3_BUCKET = process.env["AWS_S3_BUCKET"] || "";
 
 function isAllowedUrl(url: string): boolean {
   if (url.startsWith("/uploads/")) return true;
-  if (!S3_BUCKET) return url.startsWith("https://");
+  if (!S3_BUCKET) return false;
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== "https:") return false;


### PR DESCRIPTION
**Fixes:** #2358

### Problem
`isAllowedUrl` in `ats.validation.ts` had a fallback: `if (!S3_BUCKET) return url.startsWith("https://")`. When `AWS_S3_BUCKET` env var was unset (common in development), ANY HTTPS URL passed validation, creating an SSRF vector — an attacker could submit `https://internal-service/admin` and the server would fetch it.

### Changes
Replaced the permissive fallback with `return false`. When the bucket is not configured, only local `/uploads/` paths are allowed.