### PR TITLE
fix: remove fake random contribution data from opensource activity endpoint (#2368)

### DIFF
--- a/server/src/module/opensource/opensource.routes.ts
+++ b/server/src/module/opensource/opensource.routes.ts
@@ -75,16 +75,6 @@ opensourceRouter.get("/activity", authMiddleware, async (req, res, next) => {
       getOrInit(date).repoSuggestions += 1;
     }
 
-    const now = new Date();
-    for (let i = 0; i < 90; i += 3) {
-      const d = new Date(now);
-      d.setDate(d.getDate() - i);
-      const dateStr = d.toISOString().split("T")[0];
-      const entry = getOrInit(dateStr);
-      if (i % 5 === 0) entry.guideSteps += Math.floor(Math.random() * 3) + 1;
-      if (i % 7 === 0) entry.prsMerged += Math.floor(Math.random() * 2) + 1;
-    }
-
     const result = Array.from(activityMap.entries()).map(([date, counts]) => {
       const total = counts.guideSteps + counts.repoSuggestions + counts.prsMerged;
       let level = 0;


### PR DESCRIPTION
**Fixes:** #2368

### Problem
The `GET /api/opensource/activity` endpoint injected randomly generated data into the contribution activity map:
- `guideSteps` — random values when i % 5 === 0
- `prsMerged` — random values when i % 7 === 0

This caused the activity chart to show fabricated contribution data unrelated to any real user action.

### Changes
Removed the 90-day fake data generation loop. The activity map now only contains real data from the database (repo request submissions).