### PR TITLE
perf(db): optimize study buddy matchmaking and active pair lookups

### DIFF
--- a/server/src/__tests__/study-buddy.test.ts
+++ b/server/src/__tests__/study-buddy.test.ts
@@ -325,6 +325,29 @@ describe("StudyBuddyService", () => {
 
       const res = await service.findAndCreateMatch(1, 10);
 
+      expect(prisma.roadmapEnrollment.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 50,
+          where: expect.objectContaining({
+            roadmapId: 10,
+            user: expect.objectContaining({
+              studentAPairs: {
+                none: {
+                  roadmapId: 10,
+                  active: true,
+                },
+              },
+              studentBPairs: {
+                none: {
+                  roadmapId: 10,
+                  active: true,
+                },
+              },
+            }),
+          }),
+        }),
+      );
+
       expect(prisma.roadmapStudyBuddyPair.create).toHaveBeenCalledWith({
         data: {
           roadmapId: 10,
@@ -444,6 +467,29 @@ describe("StudyBuddyService", () => {
       );
 
       const result = await service.findAndCreateMatch(1, 10);
+
+      expect(prisma.roadmapEnrollment.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 50,
+          where: expect.objectContaining({
+            roadmapId: 10,
+            user: expect.objectContaining({
+              studentAPairs: {
+                none: {
+                  roadmapId: 10,
+                  active: true,
+                },
+              },
+              studentBPairs: {
+                none: {
+                  roadmapId: 10,
+                  active: true,
+                },
+              },
+            }),
+          }),
+        }),
+      );
 
       expect(prisma.roadmapStudyBuddyPair.create).toHaveBeenCalledWith({
         data: {

--- a/server/src/__tests__/study-buddy.test.ts
+++ b/server/src/__tests__/study-buddy.test.ts
@@ -287,9 +287,6 @@ describe("StudyBuddyService", () => {
       const mockPref = { enabled: true, preferSameCollege: true };
       vi.mocked(prisma.roadmapStudyBuddyPreference.findUnique).mockResolvedValue(mockPref as any);
 
-      // Active pairs in roadmap (empty)
-      vi.mocked(prisma.roadmapStudyBuddyPair.findMany).mockResolvedValue([]);
-
       // Candidates
       const mockCandidates = [
         {
@@ -337,6 +334,127 @@ describe("StudyBuddyService", () => {
         },
       });
       expect(res).toEqual(mockCreatedPair);
+    });
+
+    it("should handle concurrent match creation race (P2002) and return existing pair", async () => {
+      vi.mocked(prisma.roadmapStudyBuddyPair.findFirst)
+        .mockResolvedValueOnce(null) // existing pair check
+        .mockResolvedValueOnce(null) // lastPair
+        .mockResolvedValueOnce(null) // tx userActivePair
+        .mockResolvedValueOnce(null) // candidate availability
+        .mockResolvedValueOnce({
+          id: 99,
+          roadmapId: 10,
+          studentAId: 1,
+          studentBId: 2,
+          active: true,
+        } as any); // concurrent pair lookup
+
+      vi.mocked(prisma.roadmapEnrollment.findUnique).mockResolvedValue({
+        experienceLevel: "BEGINNER",
+        roadmap: { topicCount: 10 },
+        user: { college: "Harvard" },
+        _count: { topicProgress: 4 },
+      } as any);
+
+      vi.mocked(prisma.roadmapStudyBuddyPreference.findUnique).mockResolvedValue({
+        enabled: true,
+        preferSameCollege: false,
+      } as any);
+
+      vi.mocked(prisma.roadmapEnrollment.findMany).mockResolvedValue([
+        {
+          userId: 2,
+          experienceLevel: "BEGINNER",
+          _count: { topicProgress: 4 },
+          user: {
+            college: "Harvard",
+            studyBuddyPreferences: [{}],
+          },
+        },
+      ] as any);
+
+      vi.mocked(prisma.roadmapStudyBuddyPair.create).mockRejectedValue({
+        code: "P2002",
+      });
+
+      const result = await service.findAndCreateMatch(1, 10);
+
+      expect(result).toEqual({
+        id: 99,
+        roadmapId: 10,
+        studentAId: 1,
+        studentBId: 2,
+        active: true,
+      });
+    });
+    it("should avoid rematching the most recent buddy when other candidates exist", async () => {
+      vi.mocked(prisma.roadmapStudyBuddyPair.findFirst)
+        .mockResolvedValueOnce(null) // existing pair check
+        .mockResolvedValueOnce({
+          studentAId: 1,
+          studentBId: 2,
+        } as any) // lastPair -> buddy 2
+        .mockResolvedValueOnce(null) // tx userActivePair
+        .mockResolvedValueOnce(null); // candidate availability
+
+      vi.mocked(prisma.roadmapEnrollment.findUnique).mockResolvedValue({
+        experienceLevel: "BEGINNER",
+        roadmap: { topicCount: 10 },
+        user: { college: "Harvard" },
+        _count: { topicProgress: 4 },
+      } as any);
+
+      vi.mocked(prisma.roadmapStudyBuddyPreference.findUnique).mockResolvedValue({
+        enabled: true,
+        preferSameCollege: false,
+      } as any);
+
+      vi.mocked(prisma.roadmapEnrollment.findMany).mockResolvedValue([
+        {
+          userId: 2, // previous buddy
+          experienceLevel: "BEGINNER",
+          _count: { topicProgress: 4 },
+          user: {
+            college: "Harvard",
+            studyBuddyPreferences: [{}],
+          },
+        },
+        {
+          userId: 3, // new candidate
+          experienceLevel: "BEGINNER",
+          _count: { topicProgress: 4 },
+          user: {
+            college: "Harvard",
+            studyBuddyPreferences: [{}],
+          },
+        },
+      ] as any);
+
+      const createdPair = {
+        id: 100,
+        roadmapId: 10,
+        studentAId: 1,
+        studentBId: 3,
+        active: true,
+      };
+
+      vi.mocked(prisma.roadmapStudyBuddyPair.create).mockResolvedValue(
+        createdPair as any,
+      );
+
+      const result = await service.findAndCreateMatch(1, 10);
+
+      expect(prisma.roadmapStudyBuddyPair.create).toHaveBeenCalledWith({
+        data: {
+          roadmapId: 10,
+          studentAId: 1,
+          studentBId: 3,
+          active: true,
+        },
+      });
+
+      expect(result).toEqual(createdPair);
     });
   });
 });

--- a/server/src/database/prisma/schema/roadmap.prisma
+++ b/server/src/database/prisma/schema/roadmap.prisma
@@ -232,6 +232,11 @@ model roadmapStudyBuddyPair {
   @@index([roadmapId])
   @@index([studentAId])
   @@index([studentBId])
+
+  @@index([roadmapId, active])
+  @@index([roadmapId, active, studentAId])
+  @@index([roadmapId, active, studentBId])
+
   @@unique([roadmapId, studentAId], map: "unique_active_pair_student_a", where: { active: true })
   @@unique([roadmapId, studentBId], map: "unique_active_pair_student_b", where: { active: true })
 }

--- a/server/src/module/roadmap/study-buddy.service.ts
+++ b/server/src/module/roadmap/study-buddy.service.ts
@@ -272,28 +272,7 @@ export class StudyBuddyService {
       ? (lastPair.studentAId === userId ? lastPair.studentBId : lastPair.studentAId)
       : null;
 
-    // 4. Fetch all active pairs to know who is already paired (outside transaction)
-    const activePairs = await prisma.roadmapStudyBuddyPair.findMany({
-      where: { roadmapId, active: true },
-      select: { studentAId: true, studentBId: true },
-    });
-    const pairedUserIds = new Set(activePairs.flatMap((p) => [p.studentAId, p.studentBId]));
-
-    // Double-check if the user themselves became paired concurrently
-    if (pairedUserIds.has(userId)) {
-      const currentActivePair = await prisma.roadmapStudyBuddyPair.findFirst({
-        where: {
-          roadmapId,
-          active: true,
-          OR: [
-            { studentAId: userId },
-            { studentBId: userId },
-          ],
-        },
-      });
-      return currentActivePair;
-    }
-
+    
     // 5. Query candidate roadmap enrollments in same roadmap (outside transaction, using filtered _count)
     const candidates = await prisma.roadmapEnrollment.findMany({
       where: {
@@ -306,6 +285,18 @@ export class StudyBuddyService {
             some: {
               roadmapId,
               enabled: true,
+            },
+          },
+          studentAPairs: {
+            none: {
+              roadmapId,
+              active: true,
+            },
+          },
+          studentBPairs: {
+            none: {
+              roadmapId,
+              active: true,
             },
           },
         },
@@ -331,10 +322,11 @@ export class StudyBuddyService {
           },
         },
       },
+      take: 50,
     });
 
     // Filter out candidates that are already paired
-    let eligibleCandidates = candidates.filter((c) => !pairedUserIds.has(c.userId));
+    let eligibleCandidates = candidates;
 
     if (eligibleCandidates.length === 0) return null;
 


### PR DESCRIPTION
## Description

Optimizes Study Buddy matchmaking by reducing database scans and pushing availability filtering into the database layer.

## Changes

* Moved active pair availability filtering into the candidate query using relation filters.
* Eliminated fetching and scanning all active pairs in memory.
* Limited candidate retrieval before scoring using `take: 50`.
* Added indexes to improve active pair lookups:

  * `@@index([roadmapId, active])`
  * `@@index([roadmapId, active, studentAId])`
  * `@@index([roadmapId, active, studentBId])`
* Added test coverage for:

  * Concurrent match creation race handling (`P2002`)
  * Rematch behavior (avoids immediately rematching the most recent buddy when alternatives exist)

## Related Issue

Fixes #2313

## Type of Change

* [ ] Bug Fix
* [ ] Feature
* [x] Enhancement
* [ ] Documentation

## Testing

Verified using the Study Buddy test suite.

```text
✓ src/__tests__/study-buddy.test.ts
Tests: 14 passed (14)
```

Additional coverage added for:

* Race condition handling during match creation
* Rematch behavior when multiple candidates are available

## Screenshot

<img width="1404" height="828" alt="image" src="https://github.com/user-attachments/assets/fe9bb2a5-cf44-402f-9db3-173df2180398" />

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (include steps above)
* [x] No `.env`, credentials, or `node_modules` committed
* [x] Docs updated (if needed)
* [x] Screenshot or video attached for every UI change (N/A - no UI changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded study buddy matching coverage, including concurrent pair-creation race handling and prevention of re-pairing with the most recently matched buddy.
* **Performance**
  * Improved study buddy candidate matching by filtering out already-active pairings at the database level and limiting candidate results to reduce unnecessary processing.
  * Added indexes to speed up active lookup queries for study buddy pairings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->