### PR TITLE
fix : add aria-labels to icon-only buttons (#2350)

### DIFF
--- a/client/src/components/ui/PaginationControls.tsx
+++ b/client/src/components/ui/PaginationControls.tsx
@@ -88,7 +88,7 @@ export function PaginationControls({
               <PaginationItem key={page}>
                 <Button
                   variant={page === currentPage ? "outline" : "ghost"}
-                  mode="icon"
+                  mode="icon" aria-label={`Page ${page}`}
                   size="sm"
                   onClick={() => onPageChange(page as number)}
                 >

--- a/client/src/module/student/ats/LatexChatPanel.tsx
+++ b/client/src/module/student/ats/LatexChatPanel.tsx
@@ -194,6 +194,7 @@ export default function LatexChatPanel({ code, onApplyCode, onClose }: LatexChat
           <Button
             variant="ghost"
             mode="icon"
+            aria-label="Close"
             size="sm"
             onClick={onClose}
           >
@@ -395,6 +396,7 @@ export default function LatexChatPanel({ code, onApplyCode, onClose }: LatexChat
           <Button
             variant="primary"
             mode="icon"
+            aria-label="Send"
             size="md"
             onClick={handleSend}
             disabled={!input.trim() || loading}

--- a/client/src/module/student/behavioral/BehavioralTrainerPage.tsx
+++ b/client/src/module/student/behavioral/BehavioralTrainerPage.tsx
@@ -201,7 +201,7 @@ export default function BehavioralTrainerPage() {
                     {currentQuestion}
                   </p>
                 </div>
-                <Button variant="ghost" mode="icon" size="sm" onClick={handleShuffle} title="Next question">
+                <Button variant="ghost" mode="icon" aria-label="Next question" size="sm" onClick={handleShuffle} title="Next question">
                   <Shuffle className="w-4 h-4" />
                 </Button>
               </div>

--- a/client/src/module/student/companies/ReviewForm.tsx
+++ b/client/src/module/student/companies/ReviewForm.tsx
@@ -54,7 +54,7 @@ export default function ReviewForm({ slug, onClose, onSubmitted }: ReviewFormPro
       <div className="bg-white dark:bg-gray-900 rounded-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between p-5 border-b border-gray-100 dark:border-gray-800">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Write a Review</h2>
-          <Button variant="ghost" mode="icon" size="sm" onClick={onClose}>
+          <Button variant="ghost" mode="icon" aria-label="Close" size="sm" onClick={onClose}>
             <X className="w-5 h-5 text-gray-500 dark:text-gray-500" />
           </Button>
         </div>

--- a/client/src/module/student/companies/SuggestEditModal.tsx
+++ b/client/src/module/student/companies/SuggestEditModal.tsx
@@ -56,7 +56,7 @@ export default function SuggestEditModal({ slug, company, onClose }: SuggestEdit
       <div className="bg-white dark:bg-gray-900 rounded-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between p-5 border-b border-gray-100 dark:border-gray-800">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Suggest Edit</h2>
-          <Button variant="ghost" mode="icon" size="sm" onClick={onClose}>
+          <Button variant="ghost" mode="icon" aria-label="Close" size="sm" onClick={onClose}>
             <X className="w-5 h-5 text-gray-500 dark:text-gray-500" />
           </Button>
         </div>

--- a/client/src/module/student/dsa/DsaBookmarksPage.tsx
+++ b/client/src/module/student/dsa/DsaBookmarksPage.tsx
@@ -265,6 +265,7 @@ export default function DsaBookmarksPage() {
                     onClick={() => removeMutation.mutate(b.problemId)}
                     variant="ghost"
                     mode="icon"
+                    aria-label="Remove bookmark"
                     size="sm"
                     className="text-rose-500 dark:text-rose-400 hover:bg-rose-50 dark:hover:bg-rose-900/20 shrink-0"
                     title="Remove bookmark"

--- a/client/src/module/student/dsa/DsaCompaniesPage.tsx
+++ b/client/src/module/student/dsa/DsaCompaniesPage.tsx
@@ -714,6 +714,7 @@ export default function DsaCompaniesPage() {
                           <Button
                             variant="ghost"
                             mode="icon"
+                            aria-label="Toggle completion"
                             size="sm"
                             onClick={(e) => { e.stopPropagation(); toggleMutation.mutate(problem.id); }}
                             className="shrink-0"
@@ -768,6 +769,7 @@ export default function DsaCompaniesPage() {
                           <Button
                             variant="ghost"
                             mode="icon"
+                            aria-label="Toggle bookmark"
                             size="sm"
                             onClick={(e) => { e.stopPropagation(); bookmarkMutation.mutate(problem.id); }}
                             className="shrink-0"

--- a/client/src/module/student/dsa/DsaTopicDetailPage.tsx
+++ b/client/src/module/student/dsa/DsaTopicDetailPage.tsx
@@ -508,6 +508,7 @@ export const DsaProblemCard = React.memo(function DsaProblemCard({
           <Button
             variant="ghost"
             mode="icon"
+            aria-label="Toggle completion"
             size="sm"
             onClick={(e) => {
               e.stopPropagation();
@@ -576,6 +577,7 @@ export const DsaProblemCard = React.memo(function DsaProblemCard({
           <Button
             variant="ghost"
             mode="icon"
+            aria-label="Toggle bookmark"
             size="sm"
             onClick={(e) => {
               e.stopPropagation();

--- a/client/src/module/student/grants/GrantTrackerPage.tsx
+++ b/client/src/module/student/grants/GrantTrackerPage.tsx
@@ -149,6 +149,7 @@ const TrackedGrantCard = memo(function TrackedGrantCard({
           <Button
             variant="ghost"
             mode="icon"
+            aria-label="Delete grant"
             size="sm"
             onClick={() => setConfirmDelete(true)}
             className="text-gray-300 dark:text-gray-600 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 shrink-0"
@@ -269,7 +270,7 @@ function AddGrantModal({
           <h2 className="text-lg font-bold text-gray-900 dark:text-white">
             Add Grant to Tracker
           </h2>
-          <Button variant="ghost" mode="icon" size="sm" onClick={onClose}>
+          <Button variant="ghost" mode="icon" aria-label="Close modal" size="sm" onClick={onClose}>
             <X className="w-4 h-4 text-gray-500 dark:text-gray-500" />
           </Button>
         </div>

--- a/client/src/module/student/mock-interview/MockInterviewPage.tsx
+++ b/client/src/module/student/mock-interview/MockInterviewPage.tsx
@@ -344,6 +344,7 @@ function AiMockInterview({ onBack }: { onBack: () => void }) {
               <Button
                 variant="ghost"
                 mode="icon"
+                aria-label="Go back"
                 size="sm"
                 onClick={onBack}
                 className="bg-stone-100 hover:bg-stone-200 dark:bg-white/5 dark:hover:bg-white/10 rounded-md shrink-0"
@@ -543,6 +544,7 @@ function AiMockInterview({ onBack }: { onBack: () => void }) {
               <Button
                 variant="ghost"
                 mode="icon"
+                aria-label="Go back"
                 size="sm"
                 onClick={onBack}
                 className="bg-stone-100 hover:bg-stone-200 dark:bg-white/5 dark:hover:bg-white/10 rounded-md shrink-0"
@@ -709,6 +711,7 @@ function AiMockInterview({ onBack }: { onBack: () => void }) {
               <Button
                 variant="ghost"
                 mode="icon"
+                aria-label="Go back"
                 size="sm"
                 onClick={onBack}
                 className="bg-stone-100 hover:bg-stone-200 dark:bg-white/5 dark:hover:bg-white/10 rounded-md shrink-0"

--- a/client/src/module/student/opensource/FirstPRRoadmapPage.tsx
+++ b/client/src/module/student/opensource/FirstPRRoadmapPage.tsx
@@ -360,6 +360,7 @@ export default function FirstPRRoadmapPage() {
                 <Button
                   variant="ghost"
                   mode="icon"
+                  aria-label="Toggle completion"
                   size="sm"
                   onClick={(e) => {
                     e.preventDefault();

--- a/client/src/module/student/opensource/FirstPRSectionPage.tsx
+++ b/client/src/module/student/opensource/FirstPRSectionPage.tsx
@@ -232,6 +232,7 @@ export default function FirstPRSectionPage() {
             <Button
               variant="ghost"
               mode="icon"
+              aria-label="Previous"
               onClick={() =>
                 prev && navigate(`/student/opensource/first-pr/${prev.id}`)
               }
@@ -247,6 +248,7 @@ export default function FirstPRSectionPage() {
             <Button
               variant="ghost"
               mode="icon"
+              aria-label="Next"
               onClick={() =>
                 next && navigate(`/student/opensource/first-pr/${next.id}`)
               }

--- a/client/src/module/student/opensource/GSoCProposalAIReview.tsx
+++ b/client/src/module/student/opensource/GSoCProposalAIReview.tsx
@@ -362,7 +362,7 @@ export default function GSoCProposalAIReview() {
                           <BarChart3 className={`w-3.5 h-3.5 ${scoreColor(result.overallScore)}`} />
                           <span className={scoreColor(result.overallScore)}>{result.overallScore}/10</span>
                         </div>
-                        <Button variant="ghost" mode="icon" size="sm" onClick={handleReset} title="New review">
+                        <Button variant="ghost" mode="icon" aria-label="New review" size="sm" onClick={handleReset} title="New review">
                           <RefreshCw className="w-4 h-4" />
                         </Button>
                       </div>

--- a/client/src/module/student/opensource/GSoCProposalPage.tsx
+++ b/client/src/module/student/opensource/GSoCProposalPage.tsx
@@ -207,6 +207,7 @@ export default function GSoCProposalPage() {
                 <Button
                   variant="ghost"
                   mode="icon"
+                  aria-label="Toggle completion"
                   size="sm"
                   onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggle(step.id); }}
                   className="shrink-0"

--- a/client/src/module/student/opensource/components/GuideListPage.tsx
+++ b/client/src/module/student/opensource/components/GuideListPage.tsx
@@ -206,6 +206,7 @@ export default function GuideListPage({
                 <Button
                   variant="ghost"
                   mode="icon"
+                  aria-label="Toggle completion"
                   size="sm"
                   onClick={(e: React.MouseEvent) => { e.preventDefault(); e.stopPropagation(); toggle(step.id); }}
                   className="shrink-0"

--- a/client/src/module/student/opensource/components/GuideSectionPage.tsx
+++ b/client/src/module/student/opensource/components/GuideSectionPage.tsx
@@ -239,6 +239,7 @@ if (!step) return <Navigate to={basePath} replace />;
             <Button
               variant="ghost"
               mode="icon"
+              aria-label="Previous"
               onClick={() => prev && navigate(`${basePath}/${prev.id}`)}
               disabled={!prev}
               className="bg-stone-50 dark:bg-stone-800 rounded-md"
@@ -252,6 +253,7 @@ if (!step) return <Navigate to={basePath} replace />;
             <Button
               variant="ghost"
               mode="icon"
+              aria-label="Next"
               onClick={() => next && navigate(`${basePath}/${next.id}`)}
               disabled={!next}
               className="bg-stone-50 dark:bg-stone-800 rounded-md"

--- a/client/src/module/student/profile/GitHubImportModal.tsx
+++ b/client/src/module/student/profile/GitHubImportModal.tsx
@@ -179,6 +179,7 @@ export default function GitHubImportModal({
                 <Button
                   variant="ghost"
                   mode="icon"
+                  aria-label="Close"
                   onClick={handleClose}
                   className="text-gray-500"
                 >

--- a/client/src/module/student/roadmap/RoadmapCanvasPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapCanvasPage.tsx
@@ -1154,6 +1154,7 @@ export default function RoadmapCanvasPage() {
                 <Button
                   variant="ghost"
                   mode="icon"
+                  aria-label="Linear View"
                   size="sm"
                   onClick={() => setViewMode("LINEAR")}
                   title="Linear View"
@@ -1168,6 +1169,7 @@ export default function RoadmapCanvasPage() {
                 <Button
                   variant="ghost"
                   mode="icon"
+                  aria-label="Grid View"
                   size="sm"
                   onClick={() => setViewMode("GRID")}
                   title="Grid View"
@@ -1182,6 +1184,7 @@ export default function RoadmapCanvasPage() {
                 <Button
                   variant="ghost"
                   mode="icon"
+                  aria-label="Graph View"
                   size="sm"
                   onClick={() => setViewMode("GRAPH")}
                   title="Graph View"
@@ -1394,6 +1397,7 @@ export default function RoadmapCanvasPage() {
                   <Button
                     variant="ghost"
                     mode="icon"
+                    aria-label="Close drawer"
                     size="sm"
                     onClick={() => setDrawerTopicId(null)}
                   >
@@ -1633,6 +1637,7 @@ export default function RoadmapCanvasPage() {
                   <Button
                     variant="ghost"
                     mode="icon"
+                    aria-label="Close drawer"
                     size="sm"
                     onClick={() => setShowBuddyDrawer(false)}
                   >


### PR DESCRIPTION
## Description
This PR addresses issue #2350 by ensuring all icon-only buttons across the frontend platform are fully accessible to screen readers. 

Previously, when the `<Button>` component was used with `mode="icon"`, screen readers (such as VoiceOver and NVDA) would read out generic labels like "button", providing no context to visually impaired users. 

This update adds descriptive, context-aware `aria-label` attributes based on the specific actions each button performs (e.g., "Close", "Delete", "Toggle bookmark", "Go back").

## Changes Made
- Audited all usages of `<Button mode="icon">` in `client/src`.
- Programmatically applied relevant `aria-label` properties based on the inner icon and event handler context.
- Ensured we do not overwrite existing accessibility labels where they were already defined correctly.
- Affected components span across multiple modules, including Roadmap, Open Source, Mock Interviews, DSA Tracking, and Companies.

## Related Issues
Closes #2350 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility improvement

## Checklist
- [x] My code follows the code style guidelines of the project
- [x] I have tested the changes with a screen reader/Chrome DevTools accessibility tree
- [x] No new warnings or errors are introduced.

Fixes #2350 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added descriptive labels to icon-only buttons across the application, including pagination, navigation, modal controls, and action buttons throughout the student interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->