### PR TITLE
fix(server): restore prisma config in build, db push entrypoint, deterministic cookie tests

### DIFF
--- a/server/docker-entrypoint.dev.sh
+++ b/server/docker-entrypoint.dev.sh
@@ -3,6 +3,6 @@ set -e
 cd /app
 
 npx prisma generate --config src/database/prisma.config.ts
-npx prisma migrate deploy --config src/database/prisma.config.ts
+npx prisma db push --config src/database/prisma.config.ts
 
 exec npm run dev

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "prisma generate --schema=src/database/prisma/schema && tsc",
+    "build": "prisma generate --config src/database/prisma.config.ts && tsc",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.api.json",
     "test": "vitest run",

--- a/server/src/__tests__/cookie.test.ts
+++ b/server/src/__tests__/cookie.test.ts
@@ -1,9 +1,15 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import type { Response } from "express";
 import { setTokenCookie, clearTokenCookie } from "../utils/cookie.utils.js";
 
 describe("cookie.utils", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("should set the token cookie correctly", () => {
+    vi.stubEnv("NODE_ENV", "test");
+
     const res = {
       cookie: vi.fn(),
     } as unknown as Response;
@@ -20,8 +26,7 @@ describe("cookie.utils", () => {
   });
 
   it("should set secure cookie when NODE_ENV is production", () => {
-    const originalEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
 
     const res = {
       cookie: vi.fn(),
@@ -36,11 +41,11 @@ describe("cookie.utils", () => {
       maxAge: 7 * 24 * 60 * 60 * 1000,
       path: "/",
     });
-
-    process.env.NODE_ENV = originalEnv;
   });
 
   it("should clear the token cookie correctly", () => {
+    vi.stubEnv("NODE_ENV", "test");
+
     const res = {
       clearCookie: vi.fn(),
     } as unknown as Response;


### PR DESCRIPTION
## Description
Three small server fixes bundled:

1. **Restore `prisma.config.ts` in the build script** (commit from a prior session). PR #2189 changed `build` to `prisma generate --schema=...`, which bypasses `prisma.config.ts` (adapter/datasource/seed/migrations). Reverted to the `--config` form so generate uses the project's Prisma config.
2. **`docker-entrypoint.dev.sh`: use `prisma db push`** instead of `prisma migrate deploy`, syncing the schema directly on dev startup.
3. **Deterministic cookie tests.** `cookie.utils` sets `secure: NODE_ENV === "production"`. The tests hard-coded `secure: false`, so they failed on any environment where `NODE_ENV=production`. Now each test stubs `NODE_ENV` via `vi.stubEnv` and clears it in `afterEach`, so assertions are deterministic.

## Type of Change
- [x] Bug Fix

## Testing
- `npm run build` (server): passes (prisma generate + tsc, no type errors)
- `npm run lint` (server): clean
- `npm test` (server): **212/212 passing**

## Checklist
- [x] No new compile/type errors
- [x] Tested locally
- [x] No UI changes