### PR TITLE
fix: replace empty catch blocks with error logging in student modules (#2487)

### DIFF
--- a/client/src/module/student/opensource/components/GuideSectionPage.tsx
+++ b/client/src/module/student/opensource/components/GuideSectionPage.tsx
@@ -79,14 +79,14 @@ export default function GuideSectionPage({ steps, storageKey, basePath, seoSuffi
           if (hasLocalIds) {
             api.patch(`/opensource/guide-progress/${encodeURIComponent(storageKey)}`, {
               completedStepIds: [...union],
-            }).catch(() => { /* non-blocking */ });
+            }).catch(() => { console.warn("Failed to sync guide progress to server"); });
           }
 
-          try { localStorage.setItem(storageKey, JSON.stringify([...union])); } catch { /* */ }
+          try { localStorage.setItem(storageKey, JSON.stringify([...union])); } catch { console.warn("Failed to persist guide progress to localStorage"); }
           return union;
         });
       })
-      .catch(() => { /* 404 means no progress yet — keep localStorage default */ })
+      .catch(() => { console.warn("No server progress found — using localStorage default"); })
       .finally(() => {
         if (!cancelled) hydratingRef.current = false;
       });
@@ -97,6 +97,7 @@ export default function GuideSectionPage({ steps, storageKey, basePath, seoSuffi
   try {
     return localStorage.getItem("guide-hint-dismissed") !== "true";
   } catch {
+    console.warn("Failed to read shortcut hint dismissal from localStorage");
     return true;
   }
 });
@@ -108,12 +109,12 @@ export default function GuideSectionPage({ steps, storageKey, basePath, seoSuffi
       const next = new Set(prev);
       if (next.has(step.id)) next.delete(step.id); else next.add(step.id);
       const ids = [...next];
-      try { localStorage.setItem(storageKey, JSON.stringify(ids)); } catch { /* */ }
+      try { localStorage.setItem(storageKey, JSON.stringify(ids)); } catch { console.warn("Failed to persist guide progress to localStorage"); }
       notifyLearningPathProgressChanged();
 
       if (isAuthenticated && !hydratingRef.current) {
         api.patch(`/opensource/guide-progress/${encodeURIComponent(storageKey)}`, { completedStepIds: ids })
-          .catch(() => { /* non-blocking */ });
+          .catch(() => { console.warn("Failed to sync guide progress to server"); });
       }
 
       return next;

--- a/client/src/module/student/sql/SqlExercisePage.tsx
+++ b/client/src/module/student/sql/SqlExercisePage.tsx
@@ -39,6 +39,7 @@ function getLocalProgress(): SqlProgress {
   try {
     return JSON.parse(localStorage.getItem("sql-progress") || "{}");
   } catch {
+    console.warn("Failed to parse sql-progress from localStorage");
     return {};
   }
 }


### PR DESCRIPTION
Closes #2487

## Summary

Empty catch blocks in GuideSectionPage.tsx and SqlExercisePage.tsx silently hide localStorage and API errors. Replaced with console.warn to surface failures during debugging while preserving fallback behavior.

### Files changed:
- `GuideSectionPage.tsx`: 6 catch blocks — API sync failures, localStorage persistence, shortcut hint reading
- `SqlExercisePage.tsx`: 1 catch block — localStorage sql-progress parse failure

## Type of Change
- [x] Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error logging in guide and SQL exercise modules. Console warnings are now displayed when data synchronization or persistence operations encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->