### PR TITLE
feat: add useLocalStorage hook with cross-tab sync

### DIFF
--- a/client/src/hooks/useLocalStorage.ts
+++ b/client/src/hooks/useLocalStorage.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect, useCallback } from "react";
+
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+): [T, (value: T | ((prev: T) => T)) => void, () => void] {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+
+  const setValue = useCallback(
+    (value: T | ((prev: T) => T)) => {
+      setStoredValue((prev) => {
+        const next = value instanceof Function ? value(prev) : value;
+        try {
+          window.localStorage.setItem(key, JSON.stringify(next));
+        } catch {
+          /* quota exceeded or private mode */
+        }
+        return next;
+      });
+    },
+    [key],
+  );
+
+  const removeValue = useCallback(() => {
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      /* noop */
+    }
+    setStoredValue(initialValue);
+  }, [key, initialValue]);
+
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === key && e.newValue !== null) {
+        try {
+          setStoredValue(JSON.parse(e.newValue) as T);
+        } catch {
+          /* noop */
+        }
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, [key]);
+
+  return [storedValue, setValue, removeValue];
+}


### PR DESCRIPTION
## Summary

Adds a reusable `useLocalStorage` hook to `client/src/hooks/` that provides persistent state management with localStorage.

### Features
- SSR-safe initialization with fallback to `initialValue`
- Functional updater pattern (same API as `useState`)
- Cross-tab synchronization via the native `storage` event
- `removeValue` method to clear the stored key
- Graceful error handling for private browsing / quota exceeded

### Changes
- `client/src/hooks/useLocalStorage.ts` — new hook (55 lines)

### Related
Closes #2503
Part of gssoc26 contributions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New state persistence feature that stores application data in browser storage. Data automatically syncs across multiple tabs and windows, with safe error handling for quota or private browsing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->