### PR TITLE
feat: add useOnClickOutside hook for detecting outside clicks/touches

### DIFF
--- a/client/src/hooks/useOnClickOutside.ts
+++ b/client/src/hooks/useOnClickOutside.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+type Handler = (event: MouseEvent | TouchEvent) => void;
+
+export function useOnClickOutside<T extends HTMLElement>(
+  handler: Handler,
+): RefObject<T | null> {
+  const ref = useRef<T | null>(null);
+
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      const el = ref.current;
+      if (!el || el.contains(event.target as Node)) return;
+      handler(event);
+    };
+
+    document.addEventListener("mousedown", listener);
+    document.addEventListener("touchstart", listener);
+
+    return () => {
+      document.removeEventListener("mousedown", listener);
+      document.removeEventListener("touchstart", listener);
+    };
+  }, [handler]);
+
+  return ref;
+}


### PR DESCRIPTION
## Summary

Adds a reusable `useOnClickOutside` hook to `client/src/hooks/` that detects clicks and touches outside a referenced element. Common pattern for closing dropdowns, modals, popovers, and menus.

### Features
- Returns a ref to attach to the target element
- Handles both `mousedown` and `touchstart` events for mobile support
- Cleans up event listeners on unmount
- Properly typed generic for the HTML element type

### Changes
- `client/src/hooks/useOnClickOutside.ts` — new hook (27 lines)

### Related
Closes #2507
Part of gssoc26 contributions.
