### PR TITLE
fix(security): resolve AI billing bypass and double billing

### DIFF
--- a/server/src/module/ats/ats.routes.ts
+++ b/server/src/module/ats/ats.routes.ts
@@ -37,5 +37,5 @@ atsRouter.get("/cover-letter/history/:id", (req, res, next) => coverLetterContro
 atsRouter.delete("/cover-letter/history/:id", (req, res, next) => coverLetterController.deleteOne(req, res, next));
 atsRouter.post("/generate-resume", usageLimit("GENERATE_RESUME"), (req, res, next) => resumeGenController.generate(req, res, next));
 atsRouter.get("/resume-history", (req, res, next) => resumeGenController.getHistory(req, res, next));
-atsRouter.post("/latex-chat", (req, res, next) => latexChatController.chat(req, res, next));
-atsRouter.post("/latex-optimize-jd", (req, res, next) => latexChatController.optimizeForJD(req, res, next));
+atsRouter.post("/latex-chat", usageLimit("GENERATE_RESUME"), (req, res, next) => latexChatController.chat(req, res, next));
+atsRouter.post("/latex-optimize-jd", usageLimit("GENERATE_RESUME"), (req, res, next) => latexChatController.optimizeForJD(req, res, next));

--- a/server/src/module/ats/latex-chat.controller.ts
+++ b/server/src/module/ats/latex-chat.controller.ts
@@ -1,8 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import type { LatexChatService } from "./latex-chat.service.js";
 import { latexChatSchema, latexJDOptimizeSchema } from "./latex-chat.validation.js";
-import { prisma } from "../../database/db.js";
-import type { UsageAction } from "@prisma/client";
 import { isPremiumUser } from "../../utils/premium.utils.js";
 
 export class LatexChatController {
@@ -28,10 +26,6 @@ export class LatexChatController {
       }
 
       const response = await this.chatService.chat(result.data, req.user.id);
-
-      await prisma.usageLog.create({
-        data: { userId: req.user.id, action: "GENERATE_RESUME" as UsageAction },
-      });
 
       res.json(response);
     } catch (err) {
@@ -63,10 +57,6 @@ export class LatexChatController {
         result.data.jobDescription,
         req.user.id,
       );
-
-      await prisma.usageLog.create({
-        data: { userId: req.user.id, action: "GENERATE_RESUME" as UsageAction },
-      });
 
       res.json(response);
     } catch (err) {

--- a/server/src/module/dsa/dsa.service.ts
+++ b/server/src/module/dsa/dsa.service.ts
@@ -1485,9 +1485,7 @@ Return ONLY a JSON array, no markdown fences:
 
     const hint = `${baseHint}${tagContext} (level: ${level})`;
 
-    await prisma.usageLog.create({
-      data: { userId, action: "CODE_RUN" },
-    });
+
 
     return {
       hint,
@@ -1579,9 +1577,7 @@ Return ONLY a JSON array, no markdown fences:
       // 5. Log success
       logAIRequest("DSA_CODE_REVIEW", response, true, undefined, studentId);
 
-      await prisma.usageLog.create({
-        data: { userId: studentId, action: "CODE_RUN" },
-      });
+
 
       return parsed;
     } catch (err) {

--- a/server/src/module/student/student.controller.ts
+++ b/server/src/module/student/student.controller.ts
@@ -78,7 +78,7 @@ export class StudentController {
     try {
       if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
-      const usage = (req as any).usageInfo;
+      const usage = req.usageInfo;
       const used = usage ? usage.used + 1 : 1;
       const limit = usage ? usage.limit : 1;
 

--- a/server/src/module/student/student.controller.ts
+++ b/server/src/module/student/student.controller.ts
@@ -78,30 +78,11 @@ export class StudentController {
     try {
       if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
-      const startOfMonth = new Date();
-      startOfMonth.setDate(1);
-      startOfMonth.setHours(0, 0, 0, 0);
+      const usage = (req as any).usageInfo;
+      const used = usage ? usage.used + 1 : 1;
+      const limit = usage ? usage.limit : 1;
 
-      // Fetch user plan and usage count in parallel.
-      const [user, used] = await Promise.all([
-        prisma.user.findUnique({
-          where: { id: req.user.id },
-          select: { subscriptionPlan: true, subscriptionStatus: true, subscriptionEndDate: true },
-        }),
-        prisma.usageLog.count({
-          where: { userId: req.user.id, action: "MOCK_INTERVIEW", createdAt: { gte: startOfMonth } },
-        }),
-      ]);
-      if (!user) return res.status(401).json({ message: "User not found" });
-
-      const tier = getPlanTier(user.subscriptionPlan, user.subscriptionStatus, user.subscriptionEndDate);
-      if (tier === "FREE") return res.status(403).json({ message: "Upgrade to Premium to book mock interviews." });
-
-      if (used >= 1) return res.status(429).json({ message: "Monthly mock interview limit reached.", used, limit: 1 });
-
-      await prisma.usageLog.create({ data: { userId: req.user.id, action: "MOCK_INTERVIEW" } });
-
-      return res.json({ message: "Mock interview booked successfully", used: used + 1, limit: 1 });
+      return res.json({ message: "Mock interview booked successfully", used, limit });
     } catch (err) {
       next(err);
     }

--- a/server/src/module/student/student.routes.ts
+++ b/server/src/module/student/student.routes.ts
@@ -41,5 +41,5 @@ studentRouter.get("/jobs/:jobId/save", (req, res) => studentController.isJobSave
 
 // Mock interview
 studentRouter.get("/mock-interview", (req, res, next) => studentController.getMockInterviewInfo(req, res, next));
-studentRouter.post("/mock-interview/book", (req, res, next) => studentController.bookMockInterview(req, res, next));
+studentRouter.post("/mock-interview/book", usageLimit("MOCK_INTERVIEW"), (req, res, next) => studentController.bookMockInterview(req, res, next));
 studentRouter.post("/mock-interview/feedback", (req, res) => studentController.generateMockInterviewFeedback(req, res));


### PR DESCRIPTION
Fixes #2513 

### Description
This PR patches critical security and billing vulnerabilities related to the AI endpoint usage limits. 

Specifically, this resolves two severe bugs:
1. **Financial DoS via AI Rate Limit Bypass:** The `/latex-chat` and `/latex-optimize-jd` AI endpoints, as well as `/mock-interview/book`, previously bypassed the `usageLimit` middleware. Premium users could exploit this to trigger infinite AI generation requests without their daily quota ever depleting. This patch adds the middleware to secure these routes.
2. **Double-Billing on Code Runs:** The DSA hints and code review features were previously double-billing users for a single action because the `CODE_RUN` credit was being deducted manually in the service layer, even though the rate limit middleware was already correctly deducting it at the route layer.

### Changes Made
- Added `usageLimit("GENERATE_RESUME")` to `POST /latex-chat` and `POST /latex-optimize-jd` in `ats.routes.ts`.
- Removed redundant manual `prisma.usageLog.create` calls in `latex-chat.controller.ts`.
- Added `usageLimit("MOCK_INTERVIEW")` to `POST /mock-interview/book` and refactored the controller to rely on the middleware's transaction-safe usage tracking instead of querying manually.
- Stripped duplicate `prisma.usageLog.create` calls from `generateHint` and `generateCodeReview` in `dsa.service.ts` to prevent double-deduction of credits.

### Testing Instructions
1. As a Premium User, verify you can successfully request a LaTeX AI optimization and observe exactly 1 `GENERATE_RESUME` usage log generated.
2. As a Premium User, hit your daily resume generation limit, and attempt to call the endpoint again. Verify the API successfully rejects the request with a `429 Too Many Requests`.
3. Submit a DSA Code Hint. Verify that exactly 1 `CODE_RUN` usage log is generated in the database rather than 2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enabled usage-limit enforcement for resume-generation endpoints (`latex-chat`, `latex-optimize-jd`) via middleware.
  * Updated mock interview booking to rely on middleware for usage limits, and to return `used`/`limit` in the response.
  * Adjusted behind-the-scenes usage accounting for resume generation and code review/code run activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->