### PR TITLE
fix(db): backfill before dropping legacy array columns (no data loss)

### DIFF
--- a/server/src/database/prisma/migrations/20260622111111_drop_tracked_programs/migration.sql
+++ b/server/src/database/prisma/migrations/20260622111111_drop_tracked_programs/migration.sql
@@ -1,3 +1,36 @@
--- Phase 2: Clean up the dropped array column
+-- Phase 2: Backfill, then clean up the legacy array column.
+--
+-- Backfill legacy user.trackedPrograms (slug array) into the programInterest
+-- join table BEFORE dropping the column, so no tracked-program data is lost
+-- when this migration is applied on deploy. The programInterest.active /
+-- updatedAt columns this relies on are added in the preceding migration
+-- 20260622094358_add_program_interest_fields. Idempotent via ON CONFLICT.
+DO $$
+DECLARE
+  u       RECORD;
+  p       TEXT;
+  prog_id INT;
+BEGIN
+  FOR u IN
+    SELECT id, "trackedPrograms"
+    FROM "user"
+    WHERE array_length("trackedPrograms", 1) > 0
+  LOOP
+    FOREACH p IN ARRAY u."trackedPrograms"
+    LOOP
+      SELECT id INTO prog_id FROM "ossProgram" WHERE slug = p;
+      IF prog_id IS NULL THEN
+        RAISE WARNING '[SKIP] Program slug "%" not found for user %', p, u.id;
+        CONTINUE;
+      END IF;
+
+      INSERT INTO "programInterest" ("userId", "programId", "active", "createdAt", "updatedAt")
+      VALUES (u.id, prog_id, TRUE, NOW(), NOW())
+      ON CONFLICT ("userId", "programId")
+      DO UPDATE SET "active" = TRUE, "updatedAt" = NOW();
+    END LOOP;
+  END LOOP;
+END $$;
+
 DROP INDEX IF EXISTS "programInterest_userId_idx";
 ALTER TABLE "user" DROP COLUMN IF EXISTS "trackedPrograms";

--- a/server/src/database/prisma/migrations/20260622333333_drop_interview_progress_arrays/migration.sql
+++ b/server/src/database/prisma/migrations/20260622333333_drop_interview_progress_arrays/migration.sql
@@ -1,2 +1,34 @@
+-- Backfill, then drop the legacy array columns.
+--
+-- Backfill completedIds / bookmarkedIds from userInterviewProgress into the
+-- normalized UserInterviewQuestionState table BEFORE dropping them, so no
+-- progress or bookmark data is lost when this migration is applied on deploy.
+-- The target table + indexes are created in the preceding migration
+-- 20260622102727_add_interview_question_state. Idempotent via ON CONFLICT.
+
+-- completedIds -> rows marked isCompleted
+INSERT INTO "UserInterviewQuestionState" ("userId", "questionId", "isCompleted", "isBookmarked")
+SELECT uip."userId", q.qid, TRUE, FALSE
+FROM "userInterviewProgress" uip
+CROSS JOIN LATERAL unnest(uip."completedIds") AS q(qid)
+ON CONFLICT ("userId", "questionId") DO NOTHING;
+
+-- bookmarkedIds -> rows marked isBookmarked (insert any not already present)
+INSERT INTO "UserInterviewQuestionState" ("userId", "questionId", "isCompleted", "isBookmarked")
+SELECT uip."userId", q.qid, FALSE, TRUE
+FROM "userInterviewProgress" uip
+CROSS JOIN LATERAL unnest(uip."bookmarkedIds") AS q(qid)
+ON CONFLICT ("userId", "questionId") DO NOTHING;
+
+-- flip the bookmark flag on rows that already existed from completedIds
+UPDATE "UserInterviewQuestionState" uqs
+SET "isBookmarked" = TRUE,
+    "updatedAt"    = NOW()
+FROM "userInterviewProgress" uip,
+     LATERAL unnest(uip."bookmarkedIds") AS b(qid)
+WHERE uqs."userId" = uip."userId"
+  AND uqs."questionId" = b.qid
+  AND uqs."isBookmarked" = FALSE;
+
 ALTER TABLE "userInterviewProgress" DROP COLUMN IF EXISTS "bookmarkedIds";
 ALTER TABLE "userInterviewProgress" DROP COLUMN IF EXISTS "completedIds";


### PR DESCRIPTION
## Problem

Three columns are dropped by migrations already merged to main, but the data was never migrated, so a production \`migrate deploy\` would silently lose data:

- \`user.trackedPrograms\` — **747** non-null values
- \`userInterviewProgress.completedIds\` — **3** values
- \`userInterviewProgress.bookmarkedIds\` — **3** values

The backfill `.sql` scripts existed under `server/src/database/scripts/` but were **not wired into the deploy path** (`build` → `migrate-on-deploy.mjs` runs only `prisma migrate deploy`), so they would never run.

## Fix

Fold each backfill into the **top of its drop migration**, before the `DROP`:

- `20260622111111_drop_tracked_programs` → backfills `programInterest` from `user.trackedPrograms`, then drops.
- `20260622333333_drop_interview_progress_arrays` → backfills `UserInterviewQuestionState` from `completedIds`/`bookmarkedIds`, then drops.

Each backfill only depends on columns/tables created by the preceding `add_*` migration, and is idempotent (`ON CONFLICT DO NOTHING` / `DO UPDATE`).

Also fixed a latent bug in `backfill-program-interest.sql`: the `FOREACH` loop variable over a `text[]` must be `TEXT`, not `RECORD` (would error at runtime).

## Note

Do **not** use `prisma db push` for these changes against a DB with real data — it bypasses migration files (and thus the backfill). Use `migrate deploy` / `npm run db:deploy`, which is what prod runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Executed internal data restructuring operations to migrate and consolidate existing records across the system. These comprehensive updates ensure complete data preservation while reorganizing information for improved system reliability, enhanced performance, and better data consistency. The changes optimize internal data organization and prepare the platform for future scalability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->