### PR TITLE
fix(db): make 20260622 migration batch idempotent so deploy self-heals drift

### DIFF
--- a/server/src/database/prisma/migrations/20260622094358_add_program_interest_fields/migration.sql
+++ b/server/src/database/prisma/migrations/20260622094358_add_program_interest_fields/migration.sql
@@ -1,16 +1,25 @@
 -- Phase 1: Safe Additive Changes Only
+--
+-- Made fully idempotent so `prisma migrate deploy` is a safe no-op on
+-- environments already advanced to this state via `db push` (prod), while
+-- still creating everything from scratch on a fresh database.
 
 -- AlterTable (Add new columns safely with defaults)
-ALTER TABLE "programInterest" 
-ADD COLUMN "active" BOOLEAN NOT NULL DEFAULT true,
-ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT NOW();
+ALTER TABLE "programInterest"
+ADD COLUMN IF NOT EXISTS "active" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT NOW();
 
 -- Create New High-Performance Indexes
-CREATE INDEX "programInterest_userId_active_idx" ON "programInterest"("userId", "active");
-CREATE INDEX "programInterest_programId_active_idx" ON "programInterest"("programId", "active");
+CREATE INDEX IF NOT EXISTS "programInterest_userId_active_idx" ON "programInterest"("userId", "active");
+CREATE INDEX IF NOT EXISTS "programInterest_programId_active_idx" ON "programInterest"("programId", "active");
 
--- Add ForeignKey Constraint
-ALTER TABLE "programInterest" ADD CONSTRAINT "programInterest_programId_fkey" FOREIGN KEY ("programId") REFERENCES "ossProgram"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- Add ForeignKey Constraint (Postgres has no ADD CONSTRAINT IF NOT EXISTS; guard it)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'programInterest_programId_fkey') THEN
+    ALTER TABLE "programInterest" ADD CONSTRAINT "programInterest_programId_fkey" FOREIGN KEY ("programId") REFERENCES "ossProgram"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
 
 -- (Keep extra indexes Prisma found if they are part of your local environment drift)
 CREATE INDEX IF NOT EXISTS "roadmapStudyBuddyPair_roadmapId_active_idx" ON "roadmapStudyBuddyPair"("roadmapId", "active");

--- a/server/src/database/prisma/migrations/20260622102727_add_interview_question_state/migration.sql
+++ b/server/src/database/prisma/migrations/20260622102727_add_interview_question_state/migration.sql
@@ -1,7 +1,11 @@
 -- Phase 1: Safe Additive Changes Only
+--
+-- Made fully idempotent so `prisma migrate deploy` is a safe no-op on
+-- environments already advanced to this state via `db push` (prod), while
+-- still creating everything from scratch on a fresh database.
 
 -- Create Table
-CREATE TABLE "UserInterviewQuestionState" (
+CREATE TABLE IF NOT EXISTS "UserInterviewQuestionState" (
     "id" SERIAL NOT NULL,
     "userId" INTEGER NOT NULL,
     "questionId" TEXT NOT NULL,
@@ -14,16 +18,21 @@ CREATE TABLE "UserInterviewQuestionState" (
 );
 
 -- Create Indexes
-CREATE INDEX "UserInterviewQuestionState_userId_idx" ON "UserInterviewQuestionState"("userId");
-CREATE INDEX "UserInterviewQuestionState_questionId_idx" ON "UserInterviewQuestionState"("questionId");
-CREATE INDEX "UserInterviewQuestionState_userId_questionId_isCompleted_idx" ON "UserInterviewQuestionState"("userId", "questionId", "isCompleted");
-CREATE INDEX "UserInterviewQuestionState_userId_questionId_isBookmarked_idx" ON "UserInterviewQuestionState"("userId", "questionId", "isBookmarked");
-CREATE UNIQUE INDEX "UserInterviewQuestionState_userId_questionId_key" ON "UserInterviewQuestionState"("userId", "questionId");
+CREATE INDEX IF NOT EXISTS "UserInterviewQuestionState_userId_idx" ON "UserInterviewQuestionState"("userId");
+CREATE INDEX IF NOT EXISTS "UserInterviewQuestionState_questionId_idx" ON "UserInterviewQuestionState"("questionId");
+CREATE INDEX IF NOT EXISTS "UserInterviewQuestionState_userId_questionId_isCompleted_idx" ON "UserInterviewQuestionState"("userId", "questionId", "isCompleted");
+CREATE INDEX IF NOT EXISTS "UserInterviewQuestionState_userId_questionId_isBookmarked_idx" ON "UserInterviewQuestionState"("userId", "questionId", "isBookmarked");
+CREATE UNIQUE INDEX IF NOT EXISTS "UserInterviewQuestionState_userId_questionId_key" ON "UserInterviewQuestionState"("userId", "questionId");
 
 -- Sync tracking indexes found from environment drift
 CREATE INDEX IF NOT EXISTS "roadmapStudyBuddyPair_roadmapId_active_idx" ON "roadmapStudyBuddyPair"("roadmapId", "active");
 CREATE INDEX IF NOT EXISTS "roadmapStudyBuddyPair_roadmapId_active_studentAId_idx" ON "roadmapStudyBuddyPair"("roadmapId", "active", "studentAId");
 CREATE INDEX IF NOT EXISTS "roadmapStudyBuddyPair_roadmapId_active_studentBId_idx" ON "roadmapStudyBuddyPair"("roadmapId", "active", "studentBId");
 
--- Add ForeignKey
-ALTER TABLE "UserInterviewQuestionState" ADD CONSTRAINT "UserInterviewQuestionState_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- Add ForeignKey (Postgres has no ADD CONSTRAINT IF NOT EXISTS; guard it)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'UserInterviewQuestionState_userId_fkey') THEN
+    ALTER TABLE "UserInterviewQuestionState" ADD CONSTRAINT "UserInterviewQuestionState_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/server/src/database/prisma/migrations/20260622111111_drop_tracked_programs/migration.sql
+++ b/server/src/database/prisma/migrations/20260622111111_drop_tracked_programs/migration.sql
@@ -2,34 +2,29 @@
 --
 -- Backfill legacy user.trackedPrograms (slug array) into the programInterest
 -- join table BEFORE dropping the column, so no tracked-program data is lost
--- when this migration is applied on deploy. The programInterest.active /
--- updatedAt columns this relies on are added in the preceding migration
--- 20260622094358_add_program_interest_fields. Idempotent via ON CONFLICT.
+-- when this migration runs on a fresh/non-prod database. The programInterest
+-- active / updatedAt columns this relies on are added in the preceding
+-- migration 20260622094358_add_program_interest_fields.
+--
+-- Guarded on column existence so it is a no-op on environments already
+-- advanced via `db push` (prod), where "trackedPrograms" is already dropped;
+-- without the guard the backfill would throw `column does not exist` and fail
+-- the deploy. Idempotent via ON CONFLICT; unknown slugs are skipped (the inner
+-- JOIN drops them) to avoid violating the programId foreign key.
 DO $$
-DECLARE
-  u       RECORD;
-  p       TEXT;
-  prog_id INT;
 BEGIN
-  FOR u IN
-    SELECT id, "trackedPrograms"
-    FROM "user"
-    WHERE array_length("trackedPrograms", 1) > 0
-  LOOP
-    FOREACH p IN ARRAY u."trackedPrograms"
-    LOOP
-      SELECT id INTO prog_id FROM "ossProgram" WHERE slug = p;
-      IF prog_id IS NULL THEN
-        RAISE WARNING '[SKIP] Program slug "%" not found for user %', p, u.id;
-        CONTINUE;
-      END IF;
-
-      INSERT INTO "programInterest" ("userId", "programId", "active", "createdAt", "updatedAt")
-      VALUES (u.id, prog_id, TRUE, NOW(), NOW())
-      ON CONFLICT ("userId", "programId")
-      DO UPDATE SET "active" = TRUE, "updatedAt" = NOW();
-    END LOOP;
-  END LOOP;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'user' AND column_name = 'trackedPrograms'
+  ) THEN
+    INSERT INTO "programInterest" ("userId", "programId", "active", "createdAt", "updatedAt")
+    SELECT u.id, p.id, TRUE, NOW(), NOW()
+    FROM "user" u
+    CROSS JOIN LATERAL unnest(u."trackedPrograms") AS s(slug)
+    JOIN "ossProgram" p ON p.slug = s.slug
+    ON CONFLICT ("userId", "programId")
+    DO UPDATE SET "active" = TRUE, "updatedAt" = NOW();
+  END IF;
 END $$;
 
 DROP INDEX IF EXISTS "programInterest_userId_idx";

--- a/server/src/database/prisma/migrations/20260622111540_add_opensource_tags_gin_index/migration.sql
+++ b/server/src/database/prisma/migrations/20260622111540_add_opensource_tags_gin_index/migration.sql
@@ -1,2 +1,4 @@
 -- CreateIndex
-CREATE INDEX "opensourceRepo_tags_idx" ON "opensourceRepo" USING GIN ("tags");
+-- IF NOT EXISTS so `migrate deploy` is a no-op where the GIN index was already
+-- created via `db push` (prod), and still creates it on a fresh database.
+CREATE INDEX IF NOT EXISTS "opensourceRepo_tags_idx" ON "opensourceRepo" USING GIN ("tags");

--- a/server/src/database/prisma/migrations/20260622333333_drop_interview_progress_arrays/migration.sql
+++ b/server/src/database/prisma/migrations/20260622333333_drop_interview_progress_arrays/migration.sql
@@ -2,33 +2,46 @@
 --
 -- Backfill completedIds / bookmarkedIds from userInterviewProgress into the
 -- normalized UserInterviewQuestionState table BEFORE dropping them, so no
--- progress or bookmark data is lost when this migration is applied on deploy.
--- The target table + indexes are created in the preceding migration
--- 20260622102727_add_interview_question_state. Idempotent via ON CONFLICT.
+-- progress or bookmark data is lost when this migration runs on a fresh/non-prod
+-- database. The target table + indexes are created in the preceding migration
+-- 20260622102727_add_interview_question_state.
+--
+-- Guarded on column existence so it is a no-op on environments already advanced
+-- via `db push` (prod), where these columns are already dropped; without the
+-- guard the unnest() would throw `column does not exist` and fail the deploy.
+-- Idempotent via ON CONFLICT.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'userInterviewProgress'
+      AND column_name IN ('completedIds', 'bookmarkedIds')
+  ) THEN
+    -- completedIds -> rows marked isCompleted
+    INSERT INTO "UserInterviewQuestionState" ("userId", "questionId", "isCompleted", "isBookmarked")
+    SELECT uip."userId", q.qid, TRUE, FALSE
+    FROM "userInterviewProgress" uip
+    CROSS JOIN LATERAL unnest(uip."completedIds") AS q(qid)
+    ON CONFLICT ("userId", "questionId") DO NOTHING;
 
--- completedIds -> rows marked isCompleted
-INSERT INTO "UserInterviewQuestionState" ("userId", "questionId", "isCompleted", "isBookmarked")
-SELECT uip."userId", q.qid, TRUE, FALSE
-FROM "userInterviewProgress" uip
-CROSS JOIN LATERAL unnest(uip."completedIds") AS q(qid)
-ON CONFLICT ("userId", "questionId") DO NOTHING;
+    -- bookmarkedIds -> rows marked isBookmarked (insert any not already present)
+    INSERT INTO "UserInterviewQuestionState" ("userId", "questionId", "isCompleted", "isBookmarked")
+    SELECT uip."userId", q.qid, FALSE, TRUE
+    FROM "userInterviewProgress" uip
+    CROSS JOIN LATERAL unnest(uip."bookmarkedIds") AS q(qid)
+    ON CONFLICT ("userId", "questionId") DO NOTHING;
 
--- bookmarkedIds -> rows marked isBookmarked (insert any not already present)
-INSERT INTO "UserInterviewQuestionState" ("userId", "questionId", "isCompleted", "isBookmarked")
-SELECT uip."userId", q.qid, FALSE, TRUE
-FROM "userInterviewProgress" uip
-CROSS JOIN LATERAL unnest(uip."bookmarkedIds") AS q(qid)
-ON CONFLICT ("userId", "questionId") DO NOTHING;
-
--- flip the bookmark flag on rows that already existed from completedIds
-UPDATE "UserInterviewQuestionState" uqs
-SET "isBookmarked" = TRUE,
-    "updatedAt"    = NOW()
-FROM "userInterviewProgress" uip,
-     LATERAL unnest(uip."bookmarkedIds") AS b(qid)
-WHERE uqs."userId" = uip."userId"
-  AND uqs."questionId" = b.qid
-  AND uqs."isBookmarked" = FALSE;
+    -- flip the bookmark flag on rows that already existed from completedIds
+    UPDATE "UserInterviewQuestionState" uqs
+    SET "isBookmarked" = TRUE,
+        "updatedAt"    = NOW()
+    FROM "userInterviewProgress" uip,
+         LATERAL unnest(uip."bookmarkedIds") AS b(qid)
+    WHERE uqs."userId" = uip."userId"
+      AND uqs."questionId" = b.qid
+      AND uqs."isBookmarked" = FALSE;
+  END IF;
+END $$;
 
 ALTER TABLE "userInterviewProgress" DROP COLUMN IF EXISTS "bookmarkedIds";
 ALTER TABLE "userInterviewProgress" DROP COLUMN IF EXISTS "completedIds";


### PR DESCRIPTION
Follow-up to #2533 (which is already merged and cannot be reopened).

## Why

I reviewed #2533 against the **live prod DB**. The intent (backfill before dropping legacy arrays) is right, but the reality on prod breaks it:

| Fact | Value |
|---|---|
| Latest applied migration on prod | `20260620_add_opensource_repo_composite_indexes` |
| All five `20260622*` migrations | **pending** (not in `_prisma_migrations`) |
| `user.trackedPrograms`, `userInterviewProgress.completedIds`/`bookmarkedIds` | **already dropped** |
| `programInterest.active`, `programInterest`/`UISQ` indexes + FKs, `UserInterviewQuestionState`, GIN `opensourceRepo_tags_idx` | **already exist** |

Prod was `db push`'d to the final state without recording the migrations. So on the next prod deploy, `prisma migrate deploy` would:
1. Fail on the **first add-migration** (`ADD COLUMN "active"` / `CREATE TABLE` with no `IF NOT EXISTS` → "already exists"), and
2. If it got further, the #2533 backfills would throw `column "trackedPrograms"/"completedIds" does not exist`,

leaving a stuck failed migration (the exact situation the 2026-06-23 baseline repair just cleaned up).

## What this PR does

Makes the whole `20260622*` batch idempotent so `migrate deploy` is a safe no-op where prod already matches, while still building from scratch + backfilling on a fresh DB:

- **add_program_interest_fields** — `ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, FK guarded via `pg_constraint`.
- **add_interview_question_state** — `CREATE TABLE/INDEX IF NOT EXISTS`, FK guarded.
- **add_opensource_tags_gin_index** — `CREATE INDEX IF NOT EXISTS`.
- **drop_tracked_programs** — backfill guarded on column existence; PL/pgSQL loop rewritten as set-based `INSERT … SELECT … JOIN "ossProgram"` (matches the project's "bulk operations belong in SQL" rule; unknown slugs dropped by the join, avoiding FK violations).
- **drop_interview_progress_arrays** — backfills guarded on column existence.

## Verification

Ran the full batch against **prod inside a transaction and rolled back** — all five execute clean as no-ops, nothing changed. So the next production deploy will record them as applied and self-heal the drift; no manual `prisma migrate resolve` needed.

> Note: legacy data is already gone on prod (source columns dropped, `programInterest`/`UISQ` both 0 rows), so nothing is recoverable there. The backfill only benefits fresh/non-prod databases. This PR's goal is to stop the batch from breaking deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced database migration safety with conditional logic to prevent deployment errors when migrations are reapplied.
  * Improved reliability of data migration processes with safer backfill operations.
  * Optimized database updates to reduce schema-related conflicts during system deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->