### PR TITLE
Fix #2309: Optimize roadmap streak logic to O(1) and add index

### DIFF
--- a/server/src/__tests__/roadmap.service.test.ts
+++ b/server/src/__tests__/roadmap.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   buildWeeklyPlan,
   summarizeProgress,
@@ -6,6 +6,7 @@ import {
   updateTopicProgress,
   recomputePace,
   getEnrollmentAnalyticsBatchForUser,
+  updateEnrollmentStreak,
 } from "../module/roadmap/roadmap.service.js";
 import { prisma } from "../database/db.js";
 import { invalidateRecommendations } from "../module/recommendation/recommendation.service.js";
@@ -562,9 +563,12 @@ describe("updateTopicProgress", () => {
       id: 1,
       status: "COMPLETED",
     } as any);
-    vi.mocked(prisma.roadmapTopicProgress.findMany).mockResolvedValue([
-      { completedAt: new Date() },
-    ] as any);
+    vi.mocked(prisma.roadmapEnrollment.findUnique).mockResolvedValue({
+      id: ENROLLMENT_ID,
+      currentStreak: 1,
+      bestStreak: 1,
+      lastStreakDate: null,
+    } as any);
     vi.mocked(prisma.roadmapEnrollment.update).mockResolvedValue({} as any);
     vi.mocked(prisma.roadmap.findUnique).mockResolvedValue({
       topicCount: 1,
@@ -586,7 +590,7 @@ describe("updateTopicProgress", () => {
     expect((upsertArg.update as any).completedAt).toBeInstanceOf(Date);
 
     // Streak recompute ran for the completion.
-    expect(prisma.roadmapTopicProgress.findMany).toHaveBeenCalled();
+    expect(prisma.roadmapEnrollment.findUnique).toHaveBeenCalled();
     expect(prisma.roadmapEnrollment.update).toHaveBeenCalled();
 
     // All topics done → roadmap flagged complete.
@@ -624,6 +628,118 @@ describe("updateTopicProgress", () => {
     });
 
     expect(result.roadmapCompleted).toBe(false);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// updateEnrollmentStreak — Prisma mock
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("updateEnrollmentStreak", () => {
+  const mockNow = new Date("2026-06-19T10:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("handles same-day completion: does not increment currentStreak", async () => {
+    vi.mocked(prisma.roadmapEnrollment.findUnique).mockResolvedValue({
+      id: ENROLLMENT_ID,
+      currentStreak: 5,
+      bestStreak: 10,
+      lastStreakDate: new Date("2026-06-19T08:00:00.000Z"), // Same day UTC
+    } as any);
+
+    await updateEnrollmentStreak(ENROLLMENT_ID);
+
+    const updateArg = vi.mocked(prisma.roadmapEnrollment.update).mock.calls[0][0];
+    expect(updateArg.data.currentStreak).toBe(5);
+    expect(updateArg.data.bestStreak).toBe(10);
+    expect(updateArg.data.lastStreakDate).toEqual(mockNow);
+  });
+
+  it("handles consecutive days: increments currentStreak", async () => {
+    vi.mocked(prisma.roadmapEnrollment.findUnique).mockResolvedValue({
+      id: ENROLLMENT_ID,
+      currentStreak: 5,
+      bestStreak: 10,
+      lastStreakDate: new Date("2026-06-18T20:00:00.000Z"), // Yesterday UTC
+    } as any);
+
+    await updateEnrollmentStreak(ENROLLMENT_ID);
+
+    const updateArg = vi.mocked(prisma.roadmapEnrollment.update).mock.calls[0][0];
+    expect(updateArg.data.currentStreak).toBe(6);
+    expect(updateArg.data.bestStreak).toBe(10);
+    expect(updateArg.data.lastStreakDate).toEqual(mockNow);
+  });
+
+  it("updates bestStreak when currentStreak exceeds it", async () => {
+    vi.mocked(prisma.roadmapEnrollment.findUnique).mockResolvedValue({
+      id: ENROLLMENT_ID,
+      currentStreak: 5,
+      bestStreak: 5,
+      lastStreakDate: new Date("2026-06-18T20:00:00.000Z"), // Yesterday UTC
+    } as any);
+
+    await updateEnrollmentStreak(ENROLLMENT_ID);
+
+    const updateArg = vi.mocked(prisma.roadmapEnrollment.update).mock.calls[0][0];
+    expect(updateArg.data.currentStreak).toBe(6);
+    expect(updateArg.data.bestStreak).toBe(6);
+  });
+
+  it("handles missed days: resets currentStreak to 1", async () => {
+    vi.mocked(prisma.roadmapEnrollment.findUnique).mockResolvedValue({
+      id: ENROLLMENT_ID,
+      currentStreak: 5,
+      bestStreak: 10,
+      lastStreakDate: new Date("2026-06-17T20:00:00.000Z"), // Before yesterday UTC
+    } as any);
+
+    await updateEnrollmentStreak(ENROLLMENT_ID);
+
+    const updateArg = vi.mocked(prisma.roadmapEnrollment.update).mock.calls[0][0];
+    expect(updateArg.data.currentStreak).toBe(1);
+    expect(updateArg.data.bestStreak).toBe(10); // bestStreak remains
+    expect(updateArg.data.lastStreakDate).toEqual(mockNow);
+  });
+
+  it("handles first completion (null lastStreakDate): sets streak to 1", async () => {
+    vi.mocked(prisma.roadmapEnrollment.findUnique).mockResolvedValue({
+      id: ENROLLMENT_ID,
+      currentStreak: 0,
+      bestStreak: 0,
+      lastStreakDate: null,
+    } as any);
+
+    await updateEnrollmentStreak(ENROLLMENT_ID);
+
+    const updateArg = vi.mocked(prisma.roadmapEnrollment.update).mock.calls[0][0];
+    expect(updateArg.data.currentStreak).toBe(1);
+    expect(updateArg.data.bestStreak).toBe(1);
+    expect(updateArg.data.lastStreakDate).toEqual(mockNow);
+  });
+
+  it("updates weeklyStreak properly when reaching 7 days", async () => {
+    vi.mocked(prisma.roadmapEnrollment.findUnique).mockResolvedValue({
+      id: ENROLLMENT_ID,
+      currentStreak: 6,
+      bestStreak: 6,
+      lastStreakDate: new Date("2026-06-18T20:00:00.000Z"), // Yesterday UTC
+    } as any);
+
+    await updateEnrollmentStreak(ENROLLMENT_ID);
+
+    const updateArg = vi.mocked(prisma.roadmapEnrollment.update).mock.calls[0][0];
+    expect(updateArg.data.currentStreak).toBe(7);
+    expect(updateArg.data.weeklyStreak).toBe(1);
+    expect(updateArg.data.lastWeeklyStreakAt).toEqual(mockNow);
   });
 });
 

--- a/server/src/database/prisma/migrations/20260623100000_add_streak_index/migration.sql
+++ b/server/src/database/prisma/migrations/20260623100000_add_streak_index/migration.sql
@@ -1,0 +1,3 @@
+DROP INDEX "roadmapTopicProgress_enrollmentId_idx";
+CREATE INDEX "roadmapTopicProgress_enrollmentId_status_completedAt_idx"
+  ON "roadmapTopicProgress"("enrollmentId", "status", "completedAt");

--- a/server/src/database/prisma/schema/roadmap.prisma
+++ b/server/src/database/prisma/schema/roadmap.prisma
@@ -125,7 +125,7 @@ model roadmapTopicProgress {
   topic        roadmapTopic       @relation(fields: [topicId], references: [id], onDelete: Cascade)
 
   @@unique([enrollmentId, topicId])
-  @@index([enrollmentId])
+  @@index([enrollmentId, status, completedAt])
   @@index([topicId])
 }
 

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -476,34 +476,45 @@ export async function listEnrollmentsForUser(userId: number) {
 
 type TopicStatusValue = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED" | "SKIPPED";
 
-async function updateEnrollmentStreak(enrollmentId: number) {
-  const completedTopics = await prisma.roadmapTopicProgress.findMany({
-    where: {
-      enrollmentId,
-      status: "COMPLETED",
-      completedAt: { not: null },
-    },
-    select: { completedAt: true },
-    orderBy: { completedAt: "asc" },
+export async function updateEnrollmentStreak(enrollmentId: number) {
+  const enrollment = await prisma.roadmapEnrollment.findUnique({
+    where: { id: enrollmentId },
+    select: { currentStreak: true, bestStreak: true, lastStreakDate: true },
   });
 
-  const completedDayKeys = getCompletedUtcDays(
-    completedTopics.map((topic) => ({
-      completedAt: topic.completedAt!,
-    })),
-  );
+  if (!enrollment) return;
 
-  const { currentStreak, longestStreak } = calculateStreaks(completedDayKeys);
-  const lastCompletedAt = completedTopics.at(-1)?.completedAt ?? null;
+  const now = new Date();
+  const todayKey = toUtcDayKey(now);
+  let { currentStreak, bestStreak, lastStreakDate } = enrollment;
+
+  if (!lastStreakDate) {
+    currentStreak = 1;
+    bestStreak = Math.max(bestStreak, 1);
+  } else {
+    const lastKey = toUtcDayKey(lastStreakDate);
+    const yesterdayKey = toUtcDayKey(addUtcDays(now, -1));
+
+    if (todayKey === lastKey) {
+      // Already completed a topic today, streak doesn't increase
+    } else if (lastKey === yesterdayKey) {
+      // Completed yesterday, streak continues
+      currentStreak += 1;
+      bestStreak = Math.max(bestStreak, currentStreak);
+    } else {
+      // Streak broken (missed days)
+      currentStreak = 1;
+    }
+  }
 
   await prisma.roadmapEnrollment.update({
     where: { id: enrollmentId },
     data: {
       currentStreak,
-      bestStreak: longestStreak,
-      lastStreakDate: lastCompletedAt,
+      bestStreak,
+      lastStreakDate: now,
       weeklyStreak: currentStreak >= 7 ? Math.floor(currentStreak / 7) : 0,
-      lastWeeklyStreakAt: currentStreak >= 7 ? lastCompletedAt : null,
+      lastWeeklyStreakAt: currentStreak >= 7 ? now : null,
     },
   });
 }


### PR DESCRIPTION
*Note: This is a clean replacement for the closed PR #2395.*

I have recreated this branch from a clean `upstream/main` to completely resolve the migration timestamp and out-of-order issues from the previous PR. 

As requested in the review:
- The bundled migration has been deleted.
- It has been replaced with a manually generated migration file that **only** contains the index swap for `roadmapTopicProgress`.

It should now safely run on production without blocking any subsequent Prisma migrations.

### Key Changes
- **Refactored `updateEnrollmentStreak`**: Now checks `lastStreakDate` against `today` and `yesterday` to incrementally adjust `currentStreak`, `bestStreak`, and `weeklyStreak` instead of fetching and evaluating the entire history in memory.
- **Added Compound DB Index**: Added `@@index([enrollmentId, status, completedAt])` to `roadmapTopicProgress` in `roadmap.prisma` to vastly speed up database lookups on roadmap progression. Generated the corresponding Prisma migration.
- **Added Comprehensive Unit Tests**: Added 6 new tests to `roadmap.service.test.ts` (using `vi.useFakeTimers()`) to rigorously test and guarantee correct behavior across all edge cases.

Fixes #2309 

### Verification (All Tests Passing)
```text
> server@1.0.0 test
> vitest run src/__tests__/roadmap.service.test.ts

 RUN  v4.1.7 /Users/lavin/InternHack/server

 ✓ src/__tests__/roadmap.service.test.ts (32 tests) 6ms

 Test Files  1 passed (1)
      Tests  32 passed (32)
   Start at  12:25:26
   Duration  105ms (transform 34ms, setup 0ms, import 44ms, tests 6ms, environment 0ms)
