### PR TITLE
fix: use user name instead of email in enrollment PDF welcome email

### DIFF
--- a/server/src/module/roadmap/roadmap.controller.ts
+++ b/server/src/module/roadmap/roadmap.controller.ts
@@ -176,7 +176,7 @@ export async function enroll(req: Request, res: Response, next: NextFunction) {
       });
       if (full) {
         const pdfBuffer = await generateRoadmapPdf({
-          user: { name: req.user!.email },
+          user: { name: req.user!.name },
           roadmap: {
             title: full.roadmap.title,
             shortDescription: full.roadmap.shortDescription,


### PR DESCRIPTION
Closes #2517

## Summary
Changes the PDF welcome email to use req.user.name instead of req.user.email for the user name displayed in the generated roadmap PDF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect user information being included in welcome email and PDF documents generated during enrollment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->