### PR TITLE
fix: remove overly strict title substring match in findDuplicateRoadmap

### DIFF
--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -37,10 +37,6 @@ export async function findDuplicateRoadmap(
       slug: {
         startsWith: "ai-",
       },
-      title: {
-        contains: normalizedGoal.slice(0, 30),
-        mode: "insensitive",
-      },
       OR: keywords.map(kw => ({
         title: { contains: kw, mode: 'insensitive' }
       }))


### PR DESCRIPTION
Closes #2518

## Summary
Removes the title contains condition that checked if the roadmap title contained the first 30 characters of the full goal description. Roadmap titles are short and never contain long substrings of the goal text, making this condition effectively prevent any duplicate match. The keyword-based OR clause already provides meaningful duplicate detection.