### PR TITLE
fix: remove incorrect CODE_RUN usage log from generateHint

### DIFF
--- a/server/src/module/dsa/dsa.service.ts
+++ b/server/src/module/dsa/dsa.service.ts
@@ -1481,10 +1481,6 @@ Return ONLY a JSON array, no markdown fences:
 
     const hint = `${baseHint}${tagContext} (level: ${level})`;
 
-    await prisma.usageLog.create({
-      data: { userId, action: "CODE_RUN" },
-    });
-
     return {
       hint,
       level,


### PR DESCRIPTION
Closes #2519

## Summary
Removes the usageLog.create call with action CODE_RUN from the generateHint method. Generating a hint is not code execution and should not consume the user's CODE_RUN daily limit. The route-level usageLimit('CODE_RUN') middleware already guards the endpoint.