### PR TITLE
fix: add Zod validation for guideName in issueCertificate

### DIFF
--- a/server/src/module/opensource/opensource.controller.ts
+++ b/server/src/module/opensource/opensource.controller.ts
@@ -12,6 +12,7 @@ import {
   bookmarkBodySchema,
   bulkMigrateBookmarksSchema,
   guideFeedbackSchema,
+  issueCertificateSchema,
 } from "./opensource.validation.js";
 import { parsePagination } from "../../utils/pagination.utils.js";
 
@@ -382,12 +383,12 @@ export class OpensourceController {
 
   async issueCertificate(req: Request, res: Response, next: NextFunction) {
     try {
-      const { guideName } = req.body;
-      if (!guideName) {
-        res.status(400).json({ message: "guideName is required" });
+      const parsed = issueCertificateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ message: "Validation failed", errors: parsed.error.flatten().fieldErrors });
         return;
       }
-      const certificate = await service.issueCertificate(req.user!.id, guideName);
+      const certificate = await service.issueCertificate(req.user!.id, parsed.data.guideName);
       res.status(201).json({ certificate });
     } catch (err) {
       next(err);

--- a/server/src/module/opensource/opensource.validation.ts
+++ b/server/src/module/opensource/opensource.validation.ts
@@ -131,3 +131,7 @@ export const bulkMigrateBookmarksSchema = z.object({
     .min(1, "At least one repoId is required")
     .max(500, "Cannot migrate more than 500 bookmarks at once"),
 });
+
+export const issueCertificateSchema = z.object({
+  guideName: z.string().min(1, "guideName is required"),
+});


### PR DESCRIPTION
Closes #2520

## Summary
Replaces the manual truthiness check for guideName with proper Zod schema validation (issueCertificateSchema), consistent with all other controller methods in the same file.