### PR TITLE
fix: add isNaN check after parseInt in opensource activity route

### DIFF
--- a/server/src/module/opensource/opensource.routes.ts
+++ b/server/src/module/opensource/opensource.routes.ts
@@ -53,6 +53,10 @@ opensourceRouter.get("/activity", authMiddleware, async (req, res, next) => {
     const queryStudentId = req.query.studentId as string | undefined;
     const userId = queryStudentId ? parseInt(queryStudentId, 10) : req.user!.id;
 
+    if (queryStudentId && isNaN(userId)) {
+      return res.status(400).json({ success: false, error: "Invalid studentId parameter" });
+    }
+
     if (queryStudentId && req.user!.role === "STUDENT" && userId !== req.user!.id) {
       return res.status(403).json({ success: false, error: "Cannot view other student's activity" });
     }


### PR DESCRIPTION
Closes #2523

## Summary
Adds an isNaN check after parseInt for the studentId query parameter. Previously, passing an invalid parameter like studentId=abc would produce NaN, causing a false 403 or a failed Prisma query.