### PR TITLE
fix: include skipped topics in completion denominator for summarizeProgress

### DIFF
--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -1054,8 +1054,8 @@ export function summarizeProgress(
     }
   }
 
-  const totalTopics = allTopics.length - skippedTopics;
-  const hoursTotal = allTopics.reduce((sum, t) => sum + t.estimatedHours, 0) - skippedHours;
+  const totalTopics = allTopics.length;
+  const hoursTotal = allTopics.reduce((sum, t) => sum + t.estimatedHours, 0);
 
   return {
     totalTopics,


### PR DESCRIPTION
Closes #2524

## Summary
Removes the subtraction of skippedTopics and skippedHours from the denominator in summarizeProgress. Previously, skipping half the topics and completing the rest would show 100% completion, allowing users to bypass the certificate requirement without actually completing all topics.