### PR TITLE
fix: use user name instead of email in enrollment PDF welcome email

### DIFF
--- a/server/src/module/roadmap/roadmap.controller.ts
+++ b/server/src/module/roadmap/roadmap.controller.ts
@@ -177,7 +177,7 @@ export async function enroll(req: Request, res: Response, next: NextFunction) {
       });
       if (full) {
         const pdfBuffer = await generateRoadmapPdf({
-          user: { name: req.user!.email },
+          user: { name: req.user!.name },
           roadmap: {
             title: full.roadmap.title,
             shortDescription: full.roadmap.shortDescription,
@@ -1429,3 +1429,4 @@ export async function getAiUsage(req: Request, res: Response, next: NextFunction
     next(err);
   }
 }
+


### PR DESCRIPTION
Closes #2517

Fixes the PDF welcome email to use req.user.name instead of req.user.email for the user name.