### PR TITLE
fix: remove overly strict title substring match in findDuplicateRoadmap

### DIFF
--- a/server/src/__tests__/roadmap.service.test.ts
+++ b/server/src/__tests__/roadmap.service.test.ts
@@ -6,6 +6,7 @@ import {
   updateTopicProgress,
   recomputePace,
   getEnrollmentAnalyticsBatchForUser,
+  findDuplicateRoadmap,
 } from "../module/roadmap/roadmap.service.js";
 import { prisma } from "../database/db.js";
 import { invalidateRecommendations } from "../module/recommendation/recommendation.service.js";
@@ -19,7 +20,7 @@ import type { EnrollInput } from "../module/roadmap/roadmap.validation.js";
 // `tx.roadmapEnrollment.create` resolve against the same configurable mocks.
 vi.mock("../database/db.js", () => ({
   prisma: {
-    roadmap: { findFirst: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
+    roadmap: { findFirst: vi.fn(), findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn() },
     roadmapEnrollment: {
       findFirst: vi.fn(),
       findUnique: vi.fn(),
@@ -804,5 +805,92 @@ describe("getEnrollmentAnalyticsBatchForUser", () => {
     expect(
       prisma.roadmapEnrollment.findMany,
     ).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── findDuplicateRoadmap ──────────────────────────────────────────────────────
+
+describe("findDuplicateRoadmap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const makeRoadmap = (title: string) => ({
+    id: 1,
+    title,
+    slug: "ai-test",
+    ownerUserId: USER_ID,
+    isAiGenerated: true,
+    updatedAt: new Date(),
+  } as any);
+
+  it("returns null for empty goal", async () => {
+    await expect(findDuplicateRoadmap("", USER_ID)).resolves.toBeNull();
+  });
+
+  it("returns null for goal with only stop words", async () => {
+    await expect(findDuplicateRoadmap("want to learn how for", USER_ID)).resolves.toBeNull();
+  });
+
+  it("returns null when no roadmaps exist at all", async () => {
+    vi.mocked(prisma.roadmap.findMany).mockResolvedValue([]);
+    const result = await findDuplicateRoadmap("machine learning", USER_ID);
+    expect(result).toBeNull();
+    expect(prisma.roadmap.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a roadmap when title contains all keywords", async () => {
+    vi.mocked(prisma.roadmap.findMany).mockResolvedValue([
+      makeRoadmap("Machine Learning Roadmap"),
+    ]);
+    const result = await findDuplicateRoadmap("i want to learn machine learning", USER_ID);
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Machine Learning Roadmap");
+  });
+
+  it("returns a roadmap when title contains enough keywords to exceed threshold", async () => {
+    vi.mocked(prisma.roadmap.findMany).mockResolvedValue([
+      makeRoadmap("Data Science with Python"),
+    ]);
+    const result = await findDuplicateRoadmap("learn data science python for beginners", USER_ID);
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Data Science with Python");
+  });
+
+  it("returns null when keyword overlap is below threshold", async () => {
+    vi.mocked(prisma.roadmap.findMany).mockResolvedValue([
+      makeRoadmap("Advanced Quantum Computing"),
+    ]);
+    const result = await findDuplicateRoadmap("learn web development with react", USER_ID);
+    expect(result).toBeNull();
+  });
+
+  it("selects the best-matching roadmap from multiple candidates", async () => {
+    vi.mocked(prisma.roadmap.findMany).mockResolvedValue([
+      makeRoadmap("React for Beginners"),
+      makeRoadmap("Full Stack Web Development"),
+      makeRoadmap("DevOps with Docker and Kubernetes"),
+    ]);
+    const result = await findDuplicateRoadmap("learn react web development full stack", USER_ID);
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe("Full Stack Web Development");
+  });
+
+  it("passes correct prisma query parameters", async () => {
+    vi.mocked(prisma.roadmap.findMany).mockResolvedValue([]);
+    await findDuplicateRoadmap("learn python data science", USER_ID);
+    expect(prisma.roadmap.findMany).toHaveBeenCalledWith({
+      where: {
+        ownerUserId: USER_ID,
+        isAiGenerated: true,
+        slug: { startsWith: "ai-" },
+        OR: [
+          { title: { contains: "python", mode: "insensitive" } },
+          { title: { contains: "data", mode: "insensitive" } },
+          { title: { contains: "science", mode: "insensitive" } },
+        ],
+      },
+      orderBy: { updatedAt: "desc" },
+    });
   });
 });

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -13,6 +13,22 @@ interface WeeklyPlanWeek {
   topicSlugs: string[];
   totalHours: number;
 }
+const STOP_WORDS = new Set([
+  "want", "learn", "how", "for", "the", "and", "get", "become",
+  "need", "use", "can", "know", "like", "just", "all", "any",
+  "are", "but", "not", "out", "new", "way", "its", "has",
+  "was", "had", "his", "her", "she", "him", "who", "why",
+  "yes", "maybe", "also", "every", "able", "make", "take",
+  "some", "such", "than", "that", "them", "then", "they",
+  "this", "will", "with", "have", "from", "which", "were",
+  "study", "about", "what", "being", "done", "each", "else",
+  "over", "should", "into", "more", "much", "must", "only",
+  "other", "same", "well", "does", "doing", "would", "could",
+  "most", "still", "thing", "things", "help",
+]);
+
+const SIMILARITY_THRESHOLD = 0.3;
+
 export async function findDuplicateRoadmap(
   goalDescription: string,
   userId: number,
@@ -20,29 +36,41 @@ export async function findDuplicateRoadmap(
   const normalizedGoal = goalDescription.toLowerCase().trim();
   if (!normalizedGoal) return null;
 
-  // Simple keyword-based similarity: extract significant words
   const keywords = normalizedGoal
     .split(/\s+/)
-    .filter((w) => w.length >= 3 && !["want", "learn", "how", "for", "the", "and"].includes(w));
+    .filter((w) => w.length >= 3 && !STOP_WORDS.has(w));
 
   if (keywords.length === 0) return null;
 
-  // We'll search for roadmaps where the title contains at least one of the major keywords
-  // and then we can do a secondary check if needed, or just let the user Decide.
-  // For now, let's find the most recent one that matches.
-  return prisma.roadmap.findFirst({
+  const candidates = await prisma.roadmap.findMany({
     where: {
       ownerUserId: userId,
       isAiGenerated: true,
-      slug: {
-        startsWith: "ai-",
-      },
+      slug: { startsWith: "ai-" },
       OR: keywords.map(kw => ({
         title: { contains: kw, mode: 'insensitive' }
-      }))
+      })),
     },
-    orderBy: { updatedAt: 'desc' }
+    orderBy: { updatedAt: 'desc' },
   });
+
+  if (candidates.length === 0) return null;
+
+  let bestMatch: typeof candidates[0] | null = null;
+  let bestScore = 0;
+
+  for (const roadmap of candidates) {
+    const title = roadmap.title.toLowerCase();
+    const matchCount = keywords.filter(kw => title.includes(kw)).length;
+    const score = matchCount / keywords.length;
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestMatch = roadmap;
+    }
+  }
+
+  return bestScore >= SIMILARITY_THRESHOLD ? bestMatch : null;
 }
 export interface EnrolledRoadmap {
   enrollment: Prisma.roadmapEnrollmentGetPayload<{

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -37,10 +37,6 @@ export async function findDuplicateRoadmap(
       slug: {
         startsWith: "ai-",
       },
-      title: {
-        contains: normalizedGoal.slice(0, 30),
-        mode: "insensitive",
-      },
       OR: keywords.map(kw => ({
         title: { contains: kw, mode: 'insensitive' }
       }))
@@ -1219,3 +1215,4 @@ export function summarizeProgress(
     hoursTotal,
   };
 }
+


### PR DESCRIPTION
Closes #2518

## Problem
indDuplicateRoadmap used the first 30 chars of the users full goal description as a Prisma title contains filter. No roadmap title would ever contain a substring like a sentence fragment, so duplicate detection was effectively always broken.

## Changes

### roadmap.service.ts
- Removed the broken normalizedGoal.slice(0, 30) title substring match
- Added a comprehensive stop-words list (60+ words) for better keyword extraction
- Replaced single findFirst with findMany + in-memory scoring
- Extracted STOP_WORDS and SIMILARITY_THRESHOLD constants

### roadmap.service.test.ts
Added 7 test cases covering empty goal, stop-words-only, no roadmaps, all-keyword match, threshold match, below-threshold, multi-candidate selection, and Prisma query verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate roadmap detection to better identify similar roadmap goals.
  * Added stronger matching so results are more accurate when goals are short, vague, or include common stop words.
  * Duplicate suggestions now choose the best match from multiple candidates only when similarity is high enough.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->