### PR TITLE
fix: correct free-tier city filter skip/take logic to avoid zero results

### DIFF
--- a/server/src/module/company/company.service.ts
+++ b/server/src/module/company/company.service.ts
@@ -1,4 +1,4 @@
-﻿import { prisma } from "../../database/db.js";
+import { prisma } from "../../database/db.js";
 import type { Prisma } from "@prisma/client";
 import type { PlanTier } from "../../config/usage-limits.js";
 import sanitizeHtml from "sanitize-html";
@@ -102,14 +102,14 @@ export class CompanyService {
     // Free/unauthenticated users: cap at 20 when filtering by city
     const isCityLimited = !!params.city && tier === "FREE";
     const effectiveLimit = isCityLimited ? Math.min(limit, 20) : limit;
-    const effectiveSkip = isCityLimited ? Math.min(skip, 20) : skip;
+    const effectiveSkip = skip;
 
     const [companies, total] = await Promise.all([
       prisma.company.findMany({
         where,
         orderBy: { avgRating: "desc" },
-        skip: isCityLimited && effectiveSkip >= 20 ? 20 : effectiveSkip,
-        take: isCityLimited ? Math.max(0, 20 - effectiveSkip) : effectiveLimit,
+        skip: effectiveSkip,
+        take: effectiveLimit,
         select: {
           id: true,
           name: true,
@@ -293,4 +293,5 @@ export class CompanyService {
     });
   }
 }
+
 


### PR DESCRIPTION
Closes #2521

Removes the skip capping and complex take calculation for free-tier city filtering.