### PR TITLE
fix: use createdAt instead of updatedAt in contribution trend calculation

### DIFF
--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -570,14 +570,14 @@ export class OpensourceService {
       where: {
         userId,
         status: "APPROVED",
-        updatedAt: { gte: startMonth, lt: endMonth },
+        createdAt: { gte: startMonth, lt: endMonth },
       },
-      select: { updatedAt: true },
+      select: { createdAt: true },
     });
 
     const countsByMonth = new Map<string, number>();
     for (const request of approvedRequests) {
-      const monthKey = this.getMonthKeyUTC(request.updatedAt);
+      const monthKey = this.getMonthKeyUTC(request.createdAt);
       countsByMonth.set(monthKey, (countsByMonth.get(monthKey) ?? 0) + 1);
     }
 
@@ -821,5 +821,6 @@ export class OpensourceService {
   }
 
 }
+
 
 


### PR DESCRIPTION
Closes #2522

Changes three references from updatedAt to createdAt in getStudentContributionTrend.