### PR TITLE
fix: include skipped topics in completion denominator for summarizeProgress

### DIFF
--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -1205,8 +1205,8 @@ export function summarizeProgress(
     }
   }
 
-  const totalTopics = allTopics.length - skippedTopics;
-  const hoursTotal = allTopics.reduce((sum, t) => sum + t.estimatedHours, 0) - skippedHours;
+  const totalTopics = allTopics.length;
+  const hoursTotal = allTopics.reduce((sum, t) => sum + t.estimatedHours, 0);
 
   return {
     totalTopics,
@@ -1219,3 +1219,4 @@ export function summarizeProgress(
     hoursTotal,
   };
 }
+


### PR DESCRIPTION
Closes #2524

Removes the subtraction of skippedTopics and skippedHours from the denominator in summarizeProgress.