### PR TITLE
fix: batch HTML fixes - font preload warning and deprecated meta tag

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -17,6 +17,7 @@
     <meta name="application-name" content="InternHack" />
     <meta name="apple-mobile-web-app-title" content="InternHack" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="format-detection" content="telephone=no" />
     <meta name="google-site-verification" content="qxZRRZCLQmN6aVtKU68ePK39IIqOwC4P_RzmstGC0KA" />
@@ -133,9 +134,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://api.internhack.xyz" />
     <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
-
-    <!-- Preload primary font weight to reduce LCP FOUT -->
-    <link rel="preload" href="https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfAZ9hiJ-Ek-_EeA.woff2" as="font" type="font/woff2" crossorigin />
 
     <!-- Fonts (non-blocking) -->
     <link


### PR DESCRIPTION
### Summary

Fixes two HTML bugs:

- **#2566** - Remove unused font preload link that causes console warnings. Preconnect + async CSS loader already handles font loading.
- **#2565** - Add standard `mobile-web-app-capable` meta tag alongside deprecated `apple-mobile-web-app-capable` to eliminate deprecation warning.

Closes #2566
Closes #2565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile web app support in the initial page load, improving the experience on mobile devices.
* **Bug Fixes**
  * Removed a font preload hint, which may slightly change initial text loading behavior during page render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->