### PR TITLE
style(server): fix trailing whitespace in merged util tests

### DIFF
--- a/server/src/__tests__/calendar.utils.test.ts
+++ b/server/src/__tests__/calendar.utils.test.ts
@@ -6,7 +6,7 @@ describe("calendar.utils", () => {
     it("should generate a valid ICS calendar event", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "test-event-123",
         title: "Team Meeting",
@@ -29,7 +29,7 @@ describe("calendar.utils", () => {
     it("should format dates correctly in ICS format", () => {
       const start = new Date("2024-06-25T10:00:00.000Z");
       const end = new Date("2024-06-25T11:00:00.000Z");
-      
+
       const ics = generateICS({
         uid: "date-test",
         title: "Date Test",
@@ -46,7 +46,7 @@ describe("calendar.utils", () => {
     it("should include location when provided", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "location-test",
         title: "Conference",
@@ -62,7 +62,7 @@ describe("calendar.utils", () => {
     it("should not include location line when not provided", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "no-location-test",
         title: "Virtual Meeting",
@@ -77,7 +77,7 @@ describe("calendar.utils", () => {
     it("should escape special characters in title", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "escape-test",
         title: "Meeting; Important, Review\\Update",
@@ -93,7 +93,7 @@ describe("calendar.utils", () => {
     it("should escape special characters in description", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "escape-desc-test",
         title: "Meeting",
@@ -103,13 +103,15 @@ describe("calendar.utils", () => {
       });
 
       // Newlines, semicolons, commas, and backslashes should be escaped
-      expect(ics).toContain("DESCRIPTION:Line 1\\nLine 2\\; with semicolon\\, and comma\\\\backslash");
+      expect(ics).toContain(
+        "DESCRIPTION:Line 1\\nLine 2\\; with semicolon\\, and comma\\\\backslash",
+      );
     });
 
     it("should escape special characters in location", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "escape-location-test",
         title: "Meeting",
@@ -119,13 +121,15 @@ describe("calendar.utils", () => {
         location: "Room A; Building B, Floor 3\\Wing C",
       });
 
-      expect(ics).toContain("LOCATION:Room A\\; Building B\\, Floor 3\\\\Wing C");
+      expect(ics).toContain(
+        "LOCATION:Room A\\; Building B\\, Floor 3\\\\Wing C",
+      );
     });
 
     it("should use CRLF line endings", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "crlf-test",
         title: "Test",
@@ -142,7 +146,7 @@ describe("calendar.utils", () => {
     it("should include DTSTAMP with current timestamp", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "timestamp-test",
         title: "Test",
@@ -158,7 +162,7 @@ describe("calendar.utils", () => {
     it("should handle events spanning multiple days", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-27T18:00:00Z");
-      
+
       const ics = generateICS({
         uid: "multi-day-test",
         title: "Conference",
@@ -174,7 +178,7 @@ describe("calendar.utils", () => {
     it("should handle empty strings in title and description", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "empty-test",
         title: "",
@@ -192,7 +196,7 @@ describe("calendar.utils", () => {
     it("should generate unique UIDs with @internhack.xyz domain", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics1 = generateICS({
         uid: "event-1",
         title: "Event 1",

--- a/server/src/__tests__/crypto.utils.test.ts
+++ b/server/src/__tests__/crypto.utils.test.ts
@@ -3,7 +3,8 @@ import { encrypt, decrypt } from "../utils/crypto.utils.js";
 
 describe("crypto.utils", () => {
   const originalEnv = process.env.APP_PASSWORD_ENCRYPTION_KEY;
-  const validKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  const validKey =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
   beforeAll(() => {
     process.env.APP_PASSWORD_ENCRYPTION_KEY = validKey;
@@ -30,7 +31,7 @@ describe("crypto.utils", () => {
 
       // Each encryption should produce a unique ciphertext due to random IV
       expect(encrypted1).not.toBe(encrypted2);
-      
+
       // But both should decrypt to the same plaintext
       expect(decrypt(encrypted1)).toBe(plaintext);
       expect(decrypt(encrypted2)).toBe(plaintext);
@@ -73,9 +74,9 @@ describe("crypto.utils", () => {
 
       const parts = encrypted.split(":");
       expect(parts.length).toBe(3);
-      
+
       // Each part should be valid base64
-      parts.forEach(part => {
+      parts.forEach((part) => {
         expect(part).toMatch(/^[A-Za-z0-9+/]+=*$/);
       });
     });
@@ -84,7 +85,9 @@ describe("crypto.utils", () => {
       const originalKey = process.env.APP_PASSWORD_ENCRYPTION_KEY;
       delete process.env.APP_PASSWORD_ENCRYPTION_KEY;
 
-      expect(() => encrypt("test")).toThrow("APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string");
+      expect(() => encrypt("test")).toThrow(
+        "APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string",
+      );
 
       process.env.APP_PASSWORD_ENCRYPTION_KEY = originalKey;
     });
@@ -93,7 +96,9 @@ describe("crypto.utils", () => {
       const originalKey = process.env.APP_PASSWORD_ENCRYPTION_KEY;
       process.env.APP_PASSWORD_ENCRYPTION_KEY = "tooshort";
 
-      expect(() => encrypt("test")).toThrow("APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string");
+      expect(() => encrypt("test")).toThrow(
+        "APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string",
+      );
 
       process.env.APP_PASSWORD_ENCRYPTION_KEY = originalKey;
     });
@@ -112,12 +117,12 @@ describe("crypto.utils", () => {
       // Test with minimal non-empty content since empty strings have a known limitation
       const plaintext = " "; // Single space
       const encrypted = encrypt(plaintext);
-      
+
       // Verify encrypted format is valid
       const parts = encrypted.split(":");
       expect(parts.length).toBe(3);
       expect(parts[2]).toBeTruthy(); // Ciphertext should exist for non-empty input
-      
+
       const decrypted = decrypt(encrypted);
       expect(decrypted).toBe(plaintext);
     });
@@ -131,20 +136,24 @@ describe("crypto.utils", () => {
     });
 
     it("should throw error for invalid encrypted format (missing parts)", () => {
-      expect(() => decrypt("invalid")).toThrow("Invalid encrypted value format");
-      expect(() => decrypt("part1:part2")).toThrow("Invalid encrypted value format");
+      expect(() => decrypt("invalid")).toThrow(
+        "Invalid encrypted value format",
+      );
+      expect(() => decrypt("part1:part2")).toThrow(
+        "Invalid encrypted value format",
+      );
       expect(() => decrypt("")).toThrow("Invalid encrypted value format");
     });
 
     it("should throw error for tampered ciphertext", () => {
       const plaintext = "original data with enough content";
       const encrypted = encrypt(plaintext);
-      
+
       // Tamper with the ciphertext part by flipping a bit in the middle
       const parts = encrypted.split(":");
       const cipherBuffer = Buffer.from(parts[2]!, "base64");
       if (cipherBuffer.length > 0) {
-        cipherBuffer[0] = cipherBuffer[0]! ^ 0xFF; // Flip all bits in first byte
+        cipherBuffer[0] = cipherBuffer[0]! ^ 0xff; // Flip all bits in first byte
         parts[2] = cipherBuffer.toString("base64");
         const tampered = parts.join(":");
         expect(() => decrypt(tampered)).toThrow();
@@ -154,11 +163,11 @@ describe("crypto.utils", () => {
     it("should throw error for tampered authentication tag", () => {
       const plaintext = "secure data";
       const encrypted = encrypt(plaintext);
-      
+
       // Tamper with the auth tag by flipping bits
       const parts = encrypted.split(":");
       const tagBuffer = Buffer.from(parts[1]!, "base64");
-      tagBuffer[0] = tagBuffer[0]! ^ 0xFF; // Flip all bits in first byte
+      tagBuffer[0] = tagBuffer[0]! ^ 0xff; // Flip all bits in first byte
       parts[1] = tagBuffer.toString("base64");
       const tampered = parts.join(":");
 
@@ -168,11 +177,11 @@ describe("crypto.utils", () => {
     it("should throw error for tampered IV", () => {
       const plaintext = "protected data";
       const encrypted = encrypt(plaintext);
-      
+
       // Tamper with the IV by flipping bits
       const parts = encrypted.split(":");
       const ivBuffer = Buffer.from(parts[0]!, "base64");
-      ivBuffer[0] = ivBuffer[0]! ^ 0xFF; // Flip all bits in first byte
+      ivBuffer[0] = ivBuffer[0]! ^ 0xff; // Flip all bits in first byte
       parts[0] = ivBuffer.toString("base64");
       const tampered = parts.join(":");
 
@@ -182,11 +191,13 @@ describe("crypto.utils", () => {
     it("should throw error when decryption key is missing", () => {
       const plaintext = "test";
       const encrypted = encrypt(plaintext);
-      
+
       const originalKey = process.env.APP_PASSWORD_ENCRYPTION_KEY;
       delete process.env.APP_PASSWORD_ENCRYPTION_KEY;
 
-      expect(() => decrypt(encrypted)).toThrow("APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string");
+      expect(() => decrypt(encrypted)).toThrow(
+        "APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string",
+      );
 
       process.env.APP_PASSWORD_ENCRYPTION_KEY = originalKey;
     });
@@ -194,10 +205,11 @@ describe("crypto.utils", () => {
     it("should throw error when decryption key is wrong", () => {
       const plaintext = "secret";
       const encrypted = encrypt(plaintext);
-      
+
       const originalKey = process.env.APP_PASSWORD_ENCRYPTION_KEY;
       // Use a different valid key
-      process.env.APP_PASSWORD_ENCRYPTION_KEY = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+      process.env.APP_PASSWORD_ENCRYPTION_KEY =
+        "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
 
       expect(() => decrypt(encrypted)).toThrow();
 
@@ -213,11 +225,11 @@ describe("crypto.utils", () => {
     it("should use AES-256-GCM (authenticated encryption)", () => {
       const plaintext = "test data";
       const encrypted = encrypt(plaintext);
-      
+
       // AES-256-GCM provides both confidentiality and authenticity
       // Any tampering should be detected
       const parts = encrypted.split(":");
-      
+
       // Verify we have all three parts (IV, auth tag, ciphertext)
       expect(parts.length).toBe(3);
       expect(parts[0]).toBeTruthy(); // IV
@@ -228,10 +240,10 @@ describe("crypto.utils", () => {
     it("should use 16-byte (128-bit) IV", () => {
       const plaintext = "test";
       const encrypted = encrypt(plaintext);
-      
+
       const ivBase64 = encrypted.split(":")[0]!;
       const ivBuffer = Buffer.from(ivBase64, "base64");
-      
+
       // IV should be 16 bytes for AES-GCM
       expect(ivBuffer.length).toBe(16);
     });
@@ -239,25 +251,27 @@ describe("crypto.utils", () => {
     it("should use 16-byte (128-bit) authentication tag", () => {
       const plaintext = "test";
       const encrypted = encrypt(plaintext);
-      
+
       const authTagBase64 = encrypted.split(":")[1]!;
       const authTagBuffer = Buffer.from(authTagBase64, "base64");
-      
+
       // Auth tag should be 16 bytes
       expect(authTagBuffer.length).toBe(16);
     });
 
     it("should require 32-byte (256-bit) encryption key", () => {
       const originalKey = process.env.APP_PASSWORD_ENCRYPTION_KEY;
-      
+
       // Test with 64 hex characters (32 bytes)
       process.env.APP_PASSWORD_ENCRYPTION_KEY = "a".repeat(64);
       expect(() => encrypt("test")).not.toThrow();
-      
+
       // Test with wrong length
       process.env.APP_PASSWORD_ENCRYPTION_KEY = "a".repeat(63);
-      expect(() => encrypt("test")).toThrow("APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string");
-      
+      expect(() => encrypt("test")).toThrow(
+        "APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string",
+      );
+
       process.env.APP_PASSWORD_ENCRYPTION_KEY = originalKey;
     });
   });
@@ -276,7 +290,7 @@ describe("crypto.utils", () => {
         "password123!@#",
       ];
 
-      testCases.forEach(plaintext => {
+      testCases.forEach((plaintext) => {
         const encrypted = encrypt(plaintext);
         const decrypted = decrypt(encrypted);
         expect(decrypted).toBe(plaintext);
@@ -285,13 +299,13 @@ describe("crypto.utils", () => {
 
     it("should handle multiple encrypt/decrypt cycles", () => {
       let data = "original data";
-      
+
       // Encrypt and decrypt multiple times
       for (let i = 0; i < 5; i++) {
         const encrypted = encrypt(data);
         data = decrypt(encrypted);
       }
-      
+
       expect(data).toBe("original data");
     });
   });


### PR DESCRIPTION
Cleans trailing whitespace on blank lines in the two test files merged via #2568 and #2570 (flagged in review). Ran `prettier --write`; no behavior change, both suites still pass (36/36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Cleaned up formatting and readability in calendar utility tests, including multi-line expectation assertions.
  * Reformatted crypto utility tests for consistency, with clearer multi-line assertions and spacing updates.
  * No test behavior or coverage was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->