### PR TITLE
fix(skill-test): make incremental proctor log authoritative for scoring (follow-up to #2531)

### DIFF
--- a/server/src/__tests__/calendar.utils.test.ts
+++ b/server/src/__tests__/calendar.utils.test.ts
@@ -6,7 +6,7 @@ describe("calendar.utils", () => {
     it("should generate a valid ICS calendar event", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "test-event-123",
         title: "Team Meeting",
@@ -29,7 +29,7 @@ describe("calendar.utils", () => {
     it("should format dates correctly in ICS format", () => {
       const start = new Date("2024-06-25T10:00:00.000Z");
       const end = new Date("2024-06-25T11:00:00.000Z");
-      
+
       const ics = generateICS({
         uid: "date-test",
         title: "Date Test",
@@ -46,7 +46,7 @@ describe("calendar.utils", () => {
     it("should include location when provided", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "location-test",
         title: "Conference",
@@ -62,7 +62,7 @@ describe("calendar.utils", () => {
     it("should not include location line when not provided", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "no-location-test",
         title: "Virtual Meeting",
@@ -77,7 +77,7 @@ describe("calendar.utils", () => {
     it("should escape special characters in title", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "escape-test",
         title: "Meeting; Important, Review\\Update",
@@ -93,7 +93,7 @@ describe("calendar.utils", () => {
     it("should escape special characters in description", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "escape-desc-test",
         title: "Meeting",
@@ -103,13 +103,15 @@ describe("calendar.utils", () => {
       });
 
       // Newlines, semicolons, commas, and backslashes should be escaped
-      expect(ics).toContain("DESCRIPTION:Line 1\\nLine 2\\; with semicolon\\, and comma\\\\backslash");
+      expect(ics).toContain(
+        "DESCRIPTION:Line 1\\nLine 2\\; with semicolon\\, and comma\\\\backslash",
+      );
     });
 
     it("should escape special characters in location", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "escape-location-test",
         title: "Meeting",
@@ -119,13 +121,15 @@ describe("calendar.utils", () => {
         location: "Room A; Building B, Floor 3\\Wing C",
       });
 
-      expect(ics).toContain("LOCATION:Room A\\; Building B\\, Floor 3\\\\Wing C");
+      expect(ics).toContain(
+        "LOCATION:Room A\\; Building B\\, Floor 3\\\\Wing C",
+      );
     });
 
     it("should use CRLF line endings", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "crlf-test",
         title: "Test",
@@ -142,7 +146,7 @@ describe("calendar.utils", () => {
     it("should include DTSTAMP with current timestamp", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "timestamp-test",
         title: "Test",
@@ -158,7 +162,7 @@ describe("calendar.utils", () => {
     it("should handle events spanning multiple days", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-27T18:00:00Z");
-      
+
       const ics = generateICS({
         uid: "multi-day-test",
         title: "Conference",
@@ -174,7 +178,7 @@ describe("calendar.utils", () => {
     it("should handle empty strings in title and description", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics = generateICS({
         uid: "empty-test",
         title: "",
@@ -192,7 +196,7 @@ describe("calendar.utils", () => {
     it("should generate unique UIDs with @internhack.xyz domain", () => {
       const start = new Date("2024-06-25T10:00:00Z");
       const end = new Date("2024-06-25T11:00:00Z");
-      
+
       const ics1 = generateICS({
         uid: "event-1",
         title: "Event 1",

--- a/server/src/__tests__/crypto.utils.test.ts
+++ b/server/src/__tests__/crypto.utils.test.ts
@@ -3,7 +3,8 @@ import { encrypt, decrypt } from "../utils/crypto.utils.js";
 
 describe("crypto.utils", () => {
   const originalEnv = process.env.APP_PASSWORD_ENCRYPTION_KEY;
-  const validKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  const validKey =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
   beforeAll(() => {
     process.env.APP_PASSWORD_ENCRYPTION_KEY = validKey;
@@ -30,7 +31,7 @@ describe("crypto.utils", () => {
 
       // Each encryption should produce a unique ciphertext due to random IV
       expect(encrypted1).not.toBe(encrypted2);
-      
+
       // But both should decrypt to the same plaintext
       expect(decrypt(encrypted1)).toBe(plaintext);
       expect(decrypt(encrypted2)).toBe(plaintext);
@@ -73,9 +74,9 @@ describe("crypto.utils", () => {
 
       const parts = encrypted.split(":");
       expect(parts.length).toBe(3);
-      
+
       // Each part should be valid base64
-      parts.forEach(part => {
+      parts.forEach((part) => {
         expect(part).toMatch(/^[A-Za-z0-9+/]+=*$/);
       });
     });
@@ -84,7 +85,9 @@ describe("crypto.utils", () => {
       const originalKey = process.env.APP_PASSWORD_ENCRYPTION_KEY;
       delete process.env.APP_PASSWORD_ENCRYPTION_KEY;
 
-      expect(() => encrypt("test")).toThrow("APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string");
+      expect(() => encrypt("test")).toThrow(
+        "APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string",
+      );
 
       process.env.APP_PASSWORD_ENCRYPTION_KEY = originalKey;
     });
@@ -93,7 +96,9 @@ describe("crypto.utils", () => {
       const originalKey = process.env.APP_PASSWORD_ENCRYPTION_KEY;
       process.env.APP_PASSWORD_ENCRYPTION_KEY = "tooshort";
 
-      expect(() => encrypt("test")).toThrow("APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string");
+      expect(() => encrypt("test")).toThrow(
+        "APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string",
+      );
 
       process.env.APP_PASSWORD_ENCRYPTION_KEY = originalKey;
     });
@@ -112,12 +117,12 @@ describe("crypto.utils", () => {
       // Test with minimal non-empty content since empty strings have a known limitation
       const plaintext = " "; // Single space
       const encrypted = encrypt(plaintext);
-      
+
       // Verify encrypted format is valid
       const parts = encrypted.split(":");
       expect(parts.length).toBe(3);
       expect(parts[2]).toBeTruthy(); // Ciphertext should exist for non-empty input
-      
+
       const decrypted = decrypt(encrypted);
       expect(decrypted).toBe(plaintext);
     });
@@ -131,20 +136,24 @@ describe("crypto.utils", () => {
     });
 
     it("should throw error for invalid encrypted format (missing parts)", () => {
-      expect(() => decrypt("invalid")).toThrow("Invalid encrypted value format");
-      expect(() => decrypt("part1:part2")).toThrow("Invalid encrypted value format");
+      expect(() => decrypt("invalid")).toThrow(
+        "Invalid encrypted value format",
+      );
+      expect(() => decrypt("part1:part2")).toThrow(
+        "Invalid encrypted value format",
+      );
       expect(() => decrypt("")).toThrow("Invalid encrypted value format");
     });
 
     it("should throw error for tampered ciphertext", () => {
       const plaintext = "original data with enough content";
       const encrypted = encrypt(plaintext);
-      
+
       // Tamper with the ciphertext part by flipping a bit in the middle
       const parts = encrypted.split(":");
       const cipherBuffer = Buffer.from(parts[2]!, "base64");
       if (cipherBuffer.length > 0) {
-        cipherBuffer[0] = cipherBuffer[0]! ^ 0xFF; // Flip all bits in first byte
+        cipherBuffer[0] = cipherBuffer[0]! ^ 0xff; // Flip all bits in first byte
         parts[2] = cipherBuffer.toString("base64");
         const tampered = parts.join(":");
         expect(() => decrypt(tampered)).toThrow();
@@ -154,11 +163,11 @@ describe("crypto.utils", () => {
     it("should throw error for tampered authentication tag", () => {
       const plaintext = "secure data";
       const encrypted = encrypt(plaintext);
-      
+
       // Tamper with the auth tag by flipping bits
       const parts = encrypted.split(":");
       const tagBuffer = Buffer.from(parts[1]!, "base64");
-      tagBuffer[0] = tagBuffer[0]! ^ 0xFF; // Flip all bits in first byte
+      tagBuffer[0] = tagBuffer[0]! ^ 0xff; // Flip all bits in first byte
       parts[1] = tagBuffer.toString("base64");
       const tampered = parts.join(":");
 
@@ -168,11 +177,11 @@ describe("crypto.utils", () => {
     it("should throw error for tampered IV", () => {
       const plaintext = "protected data";
       const encrypted = encrypt(plaintext);
-      
+
       // Tamper with the IV by flipping bits
       const parts = encrypted.split(":");
       const ivBuffer = Buffer.from(parts[0]!, "base64");
-      ivBuffer[0] = ivBuffer[0]! ^ 0xFF; // Flip all bits in first byte
+      ivBuffer[0] = ivBuffer[0]! ^ 0xff; // Flip all bits in first byte
       parts[0] = ivBuffer.toString("base64");
       const tampered = parts.join(":");
 
@@ -182,11 +191,13 @@ describe("crypto.utils", () => {
     it("should throw error when decryption key is missing", () => {
       const plaintext = "test";
       const encrypted = encrypt(plaintext);
-      
+
       const originalKey = process.env.APP_PASSWORD_ENCRYPTION_KEY;
       delete process.env.APP_PASSWORD_ENCRYPTION_KEY;
 
-      expect(() => decrypt(encrypted)).toThrow("APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string");
+      expect(() => decrypt(encrypted)).toThrow(
+        "APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string",
+      );
 
       process.env.APP_PASSWORD_ENCRYPTION_KEY = originalKey;
     });
@@ -194,10 +205,11 @@ describe("crypto.utils", () => {
     it("should throw error when decryption key is wrong", () => {
       const plaintext = "secret";
       const encrypted = encrypt(plaintext);
-      
+
       const originalKey = process.env.APP_PASSWORD_ENCRYPTION_KEY;
       // Use a different valid key
-      process.env.APP_PASSWORD_ENCRYPTION_KEY = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+      process.env.APP_PASSWORD_ENCRYPTION_KEY =
+        "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
 
       expect(() => decrypt(encrypted)).toThrow();
 
@@ -213,11 +225,11 @@ describe("crypto.utils", () => {
     it("should use AES-256-GCM (authenticated encryption)", () => {
       const plaintext = "test data";
       const encrypted = encrypt(plaintext);
-      
+
       // AES-256-GCM provides both confidentiality and authenticity
       // Any tampering should be detected
       const parts = encrypted.split(":");
-      
+
       // Verify we have all three parts (IV, auth tag, ciphertext)
       expect(parts.length).toBe(3);
       expect(parts[0]).toBeTruthy(); // IV
@@ -228,10 +240,10 @@ describe("crypto.utils", () => {
     it("should use 16-byte (128-bit) IV", () => {
       const plaintext = "test";
       const encrypted = encrypt(plaintext);
-      
+
       const ivBase64 = encrypted.split(":")[0]!;
       const ivBuffer = Buffer.from(ivBase64, "base64");
-      
+
       // IV should be 16 bytes for AES-GCM
       expect(ivBuffer.length).toBe(16);
     });
@@ -239,25 +251,27 @@ describe("crypto.utils", () => {
     it("should use 16-byte (128-bit) authentication tag", () => {
       const plaintext = "test";
       const encrypted = encrypt(plaintext);
-      
+
       const authTagBase64 = encrypted.split(":")[1]!;
       const authTagBuffer = Buffer.from(authTagBase64, "base64");
-      
+
       // Auth tag should be 16 bytes
       expect(authTagBuffer.length).toBe(16);
     });
 
     it("should require 32-byte (256-bit) encryption key", () => {
       const originalKey = process.env.APP_PASSWORD_ENCRYPTION_KEY;
-      
+
       // Test with 64 hex characters (32 bytes)
       process.env.APP_PASSWORD_ENCRYPTION_KEY = "a".repeat(64);
       expect(() => encrypt("test")).not.toThrow();
-      
+
       // Test with wrong length
       process.env.APP_PASSWORD_ENCRYPTION_KEY = "a".repeat(63);
-      expect(() => encrypt("test")).toThrow("APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string");
-      
+      expect(() => encrypt("test")).toThrow(
+        "APP_PASSWORD_ENCRYPTION_KEY must be a 64-char hex string",
+      );
+
       process.env.APP_PASSWORD_ENCRYPTION_KEY = originalKey;
     });
   });
@@ -276,7 +290,7 @@ describe("crypto.utils", () => {
         "password123!@#",
       ];
 
-      testCases.forEach(plaintext => {
+      testCases.forEach((plaintext) => {
         const encrypted = encrypt(plaintext);
         const decrypted = decrypt(encrypted);
         expect(decrypted).toBe(plaintext);
@@ -285,13 +299,13 @@ describe("crypto.utils", () => {
 
     it("should handle multiple encrypt/decrypt cycles", () => {
       let data = "original data";
-      
+
       // Encrypt and decrypt multiple times
       for (let i = 0; i < 5; i++) {
         const encrypted = encrypt(data);
         data = decrypt(encrypted);
       }
-      
+
       expect(data).toBe("original data");
     });
   });

--- a/server/src/__tests__/skill-test.service.test.ts
+++ b/server/src/__tests__/skill-test.service.test.ts
@@ -12,6 +12,13 @@ vi.mock("../database/db.js", () => ({
     skillTest: {
       findUnique: vi.fn(),
     },
+    skillTestAttempt: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    verifiedSkill: {
+      upsert: vi.fn(),
+    },
     // $transaction receives a callback; we invoke it with a fake tx object
     // that exposes the two methods the service actually calls.
     $transaction: vi.fn((cb: any) =>
@@ -27,6 +34,7 @@ vi.mock("../utils/cache.js", () => ({
   cacheGet: vi.fn(),
   cacheSet: vi.fn(),
   cacheDel: vi.fn(),
+  cacheDelPattern: vi.fn(),
 }));
 
 const service = new SkillTestService();
@@ -118,5 +126,60 @@ describe("SkillTestService.logProctorEvents", () => {
       JSON.stringify(newEvents),
       99
     );
+  });
+});
+
+describe("SkillTestService.submitTest proctoring integrity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves server-side incrementalEvents and scores from them, ignoring under-reported client counts", async () => {
+    // Test with one question the student answers correctly.
+    vi.mocked(prisma.skillTest.findUnique).mockResolvedValue({
+      id: 10,
+      passThreshold: 70,
+      timeLimitSecs: 3600,
+      skillName: "react",
+      questions: [{ id: 1, correctIndex: 0, explanation: null }],
+    } as any);
+
+    // The open session already holds tamper-resistant events appended during the test.
+    const serverEvents = [
+      { type: "tab_switch", timestamp: "2024-01-01T10:01:00.000Z" },
+      { type: "devtools", timestamp: "2024-01-01T10:02:00.000Z", detail: "F12" },
+      { type: "camera_track_ended", timestamp: "2024-01-01T10:03:00.000Z" },
+    ];
+    vi.mocked(prisma.skillTestAttempt.findFirst).mockResolvedValue({
+      id: 99,
+      startedAt: new Date(Date.now() - 600 * 1000), // 10 mins ago, not expired
+      answers: [{ questionId: 1 }],
+      proctorLog: { incrementalEvents: serverEvents },
+    } as any);
+
+    vi.mocked(prisma.skillTestAttempt.update).mockResolvedValue({ id: 99 } as any);
+
+    // Client tries to under-report: claims a clean run.
+    const clientProctorLog = { tabSwitches: 0, devtoolsAttempts: 0, cameraEnabled: true };
+
+    const result = await service.submitTest(
+      10,
+      2,
+      [{ questionId: 1, selectedIndex: 0 }],
+      clientProctorLog,
+    );
+
+    expect(result.score).toBe(100); // answered correctly
+
+    const updateArg = vi.mocked(prisma.skillTestAttempt.update).mock.calls[0]![0] as any;
+    // Score derived from the server log: 100 - 15 (tab) - 25 (devtools) - 20 (camera) = 40
+    expect(updateArg.data.proctoringScore).toBe(40);
+    // Below the 60 minimum → fails despite a perfect quiz score
+    expect(updateArg.data.passed).toBe(false);
+    expect(result.passed).toBe(false);
+    // The incremental events survive submit instead of being clobbered.
+    expect(updateArg.data.proctorLog.incrementalEvents).toHaveLength(3);
+    // Passing branch never runs, so no verified skill is written.
+    expect(prisma.verifiedSkill.upsert).not.toHaveBeenCalled();
   });
 });

--- a/server/src/module/skill-test/skill-test.service.ts
+++ b/server/src/module/skill-test/skill-test.service.ts
@@ -278,9 +278,22 @@ export class SkillTestService {
         ? Math.round((correctCount / totalQuestions) * 100)
         : 0;
 
-    // Calculate proctoring integrity score
-    const proctoringScore = this.calculateProctoringScore(proctorLog);
-    const autoTerminated = !!(proctorLog && (proctorLog as any).terminated);
+    // Merge the server-side incremental proctor log (appended during the test via
+    // /proctor-logs) into the client-submitted summary. The incremental events are
+    // the tamper-resistant record; the client payload can be under-reported, so we
+    // must not let submit clobber them.
+    const existingEvents = (session.proctorLog as Record<string, unknown> | null)?.[
+      "incrementalEvents"
+    ];
+    const serverEvents = Array.isArray(existingEvents) ? existingEvents : [];
+    const mergedProctorLog: Record<string, unknown> | undefined =
+      proctorLog || serverEvents.length > 0
+        ? { ...(proctorLog ?? {}), incrementalEvents: serverEvents }
+        : undefined;
+
+    // Calculate proctoring integrity score from the merged (server-authoritative) log
+    const proctoringScore = this.calculateProctoringScore(mergedProctorLog);
+    const autoTerminated = !!(mergedProctorLog && (mergedProctorLog as any).terminated);
 
     const PROCTOR_MINIMUM = 60;
     const passed = score >= test.passThreshold && proctoringScore >= PROCTOR_MINIMUM;
@@ -292,7 +305,7 @@ export class SkillTestService {
         score,
         passed,
         answers: gradedAnswers,
-        proctorLog: (proctorLog as Prisma.InputJsonValue | null) ?? Prisma.DbNull,
+        proctorLog: (mergedProctorLog as Prisma.InputJsonValue | null) ?? Prisma.DbNull,
         proctoringScore,
         autoTerminated,
         completedAt: new Date(),
@@ -526,17 +539,62 @@ export class SkillTestService {
   ): number {
     if (!proctorLog) return 100;
     const log = proctorLog as any;
+
+    // Prefer the server-side, tamper-resistant incremental event log when present;
+    // fall back to the client-reported aggregate counts for older/partial sessions
+    // (e.g. a client that never flushed any incremental events).
+    const events: { type?: string }[] = Array.isArray(log.incrementalEvents)
+      ? log.incrementalEvents
+      : [];
+
+    let tabSwitches: number;
+    let focusLosses: number;
+    let fullscreenExits: number;
+    let devtoolsAttempts: number;
+    let copyPasteAttempts: number;
+    let rightClickAttempts: number;
+    let faceViolations: number;
+    let cameraDropped = log.cameraEnabled === false;
+
+    if (events.length > 0) {
+      tabSwitches = focusLosses = fullscreenExits = 0;
+      devtoolsAttempts = copyPasteAttempts = rightClickAttempts = faceViolations = 0;
+      for (const e of events) {
+        switch (e.type) {
+          case "tab_switch": tabSwitches++; break;
+          case "focus_loss": focusLosses++; break;
+          case "fullscreen_exit": fullscreenExits++; break;
+          case "devtools": devtoolsAttempts++; break;
+          case "copy_paste": copyPasteAttempts++; break;
+          case "right_click": rightClickAttempts++; break;
+          case "face_violation": faceViolations++; break;
+          case "camera_track_ended":
+          case "camera_track_muted": cameraDropped = true; break;
+        }
+      }
+    } else {
+      tabSwitches = log.tabSwitches ?? 0;
+      focusLosses = log.focusLosses ?? 0;
+      fullscreenExits = log.fullscreenExits ?? 0;
+      devtoolsAttempts = log.devtoolsAttempts ?? 0;
+      copyPasteAttempts = log.copyPasteAttempts ?? 0;
+      rightClickAttempts = log.rightClickAttempts ?? 0;
+      faceViolations = Array.isArray(log.faceViolations)
+        ? log.faceViolations.length
+        : 0;
+    }
+
     let s = 100;
-    s -= (log.tabSwitches ?? 0) * 15;
-    s -= (log.focusLosses ?? 0) * 5;
-    s -= (log.fullscreenExits ?? 0) * 20;
-    s -= (log.devtoolsAttempts ?? 0) * 25;
-    s -= (log.copyPasteAttempts ?? 0) * 10;
-    s -= (log.rightClickAttempts ?? 0) * 3;
-    s -=
-      (Array.isArray(log.faceViolations) ? log.faceViolations.length : 0) * 10;
+    s -= tabSwitches * 15;
+    s -= focusLosses * 5;
+    s -= fullscreenExits * 20;
+    s -= devtoolsAttempts * 25;
+    s -= copyPasteAttempts * 10;
+    s -= rightClickAttempts * 3;
+    s -= faceViolations * 10;
     if (log.terminated) s -= 30;
-    if (log.cameraEnabled === false) s -= 20;
+    // Camera dropped mid-test (hardware unplug / permission revoke) or never enabled.
+    if (cameraDropped) s -= 20;
     return Math.max(0, s);
   }
 


### PR DESCRIPTION
Follow-up to #2531 (incremental proctoring logs).

## Problem
#2531 added `/proctor-logs` syncing into `proctorLog.incrementalEvents`, but the data was never used:
- `submitTest` fully **replaced** `proctorLog` with the client payload, clobbering the server-appended `incrementalEvents`.
- `calculateProctoringScore` only read the **client-reported** aggregate counts.

So the feature was write-only and the anti-tamper goal of #2400 was unmet: a student could under-report violations in the submit payload and the trustworthy server-side record was discarded.

## Fix
- `submitTest` now **merges** the server-side `incrementalEvents` into the stored `proctorLog` instead of overwriting them.
- `calculateProctoringScore` derives violation counts from the tamper-resistant `incrementalEvents` when present, falling back to client aggregates for older/partial sessions.
- Camera track drops (`camera_track_ended`/`camera_track_muted`) now count toward the proctoring penalty, matching the PR description (without changing the live no-instant-terminate behavior).
- Added a `submitTest` test asserting events survive submit and that scoring ignores under-reported client counts.

## Testing
- `npx vitest run src/__tests__/skill-test.service.test.ts` → 6 passed.
- Server typecheck clean for skill-test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved submission handling so proctoring checks use server-preserved event history, making integrity scores more accurate and harder to bypass.
  * Ensured saved proctoring details are kept intact during test submission instead of being overwritten by client data.
  * Updated related tests to cover the revised proctoring and crypto behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->