### PR TITLE
fix(opensource): add missing heatmap index migration + include today (follow-up to #2559)

### DIFF
--- a/server/src/database/prisma/migrations/20260626120000_add_activity_heatmap_indexes/migration.sql
+++ b/server/src/database/prisma/migrations/20260626120000_add_activity_heatmap_indexes/migration.sql
@@ -1,0 +1,18 @@
+-- Activity heatmap composite indexes (issue #2302 / PR #2559)
+--
+-- These back the per-user, 90-day range scans in
+-- OpensourceService.getActivityHeatmap. PR #2559 added the matching @@index
+-- lines to schema but shipped no migration, so prod would never have created
+-- them (migrate deploy applies migration SQL, not a schema diff).
+--
+-- IF NOT EXISTS so `migrate deploy` is a no-op where an index was already
+-- created via `db push`, and still creates it on a fresh database.
+
+CREATE INDEX IF NOT EXISTS "guideProgress_userId_createdAt_idx"
+ON "guideProgress" ("userId", "createdAt");
+
+CREATE INDEX IF NOT EXISTS "repoRequest_userId_status_createdAt_idx"
+ON "repoRequest" ("userId", "status", "createdAt");
+
+CREATE INDEX IF NOT EXISTS "guideFeedback_userId_createdAt_idx"
+ON "guideFeedback" ("userId", "createdAt");

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -761,8 +761,11 @@ export class OpensourceService {
     });
   }
   async getActivityHeatmap(userId: number) {
+    // 90-day window inclusive of today: the result loop below emits 90 cells
+    // [since .. since+89], so start `since` 89 days back to land the last cell
+    // on today. Querying/displaying from the same `since` keeps them aligned.
     const since = new Date();
-    since.setDate(since.getDate() - 90);
+    since.setDate(since.getDate() - 89);
     since.setHours(0, 0, 0, 0);
 
     const [repoRequests, guideProgressRecords, guideFeedbackRecords, pullRequestRecords] = await Promise.all([


### PR DESCRIPTION
Follow-up to #2559 (activity heatmap optimization).

## 1. Missing migration
#2559 added three `@@index` lines to `base.prisma` but shipped **no migration**. In this repo prod indexes are created by `prisma migrate deploy` running committed migration SQL, not by diffing the schema, so the indexes would never be created on prod and the "optimized" queries would still full-scan (schema/DB drift).

This adds `20260626120000_add_activity_heatmap_indexes`:
- `guideProgress_userId_createdAt_idx` on `(userId, createdAt)`
- `repoRequest_userId_status_createdAt_idx` on `(userId, status, createdAt)`
- `guideFeedback_userId_createdAt_idx` on `(userId, createdAt)`

Uses `CREATE INDEX IF NOT EXISTS` so `migrate deploy` is idempotent / self-healing (matches the existing GIN-index migration convention).

## 2. Off-by-one: today excluded
`getActivityHeatmap` set `since = now − 90d` and looped 90 cells `[since … since+89]`, ending on **yesterday**. Today's records were queried (`createdAt >= since`) and bucketed but their date key was never emitted, so a user's contributions today never showed until the next day. Changed `since` to 89 days back so the 90-cell window is inclusive of today; query and display stay aligned on the same `since`.

## Notes
- `githubPullRequest` query is already covered by the existing `(connectionId, mergedAt)` index, so no index needed there.
- Not changed: `guideProgress` is one row per guide (`@@unique([userId, guideSlug])`, `createdAt` = guide start), so the `guideSteps` bucket reflects guides-started + feedback-given, not per-step completions. That's a data-model limitation, out of scope here.

## Testing
- `tsc --noEmit` clean for opensource files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)