### PR TITLE
fix(peer-mock-interview): harden async scheduling (follow-up to #2563)

### DIFF
--- a/client/src/module/student/mock-interview/MockInterviewPage.tsx
+++ b/client/src/module/student/mock-interview/MockInterviewPage.tsx
@@ -38,6 +38,20 @@ import type {
 
 const CALENDLY_URL = "https://calendly.com/mrsachinchaurasiya/30min";
 
+/**
+ * A meeting link is supplied by the matched peer, so treat it as untrusted:
+ * only render it as a clickable link when it is an http(s) URL. Guards against a
+ * javascript:/data: href slipping past the API validation (defense in depth).
+ */
+function isSafeHttpUrl(url: string): boolean {
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 type InterviewMode = null | "ai" | "expert" | "peer";
 
 const OPTIONS = [
@@ -1493,7 +1507,7 @@ function PeerMockInterview({ onBack }: { onBack: () => void }) {
                     {pairing.status === "SCHEDULED" && (
                       <div className="bg-lime-50 dark:bg-lime-400/10 border border-lime-200 dark:border-lime-400/20 p-3 rounded">
                         <p className="text-xs font-semibold text-lime-900 dark:text-lime-500">Scheduled for {pairing.scheduledAt && new Date(pairing.scheduledAt).toLocaleString()}</p>
-                        {pairing.meetingLink && (
+                        {pairing.meetingLink && isSafeHttpUrl(pairing.meetingLink) && (
                           <a href={pairing.meetingLink} target="_blank" rel="noreferrer" className="text-xs text-lime-600 dark:text-lime-400 underline mt-1 block">
                             Join Meeting Link
                           </a>

--- a/server/src/cron/peer-mock-interview-reminders.cron.ts
+++ b/server/src/cron/peer-mock-interview-reminders.cron.ts
@@ -47,8 +47,14 @@ const checkAndSendReminders = async () => {
       ? `Reminder: Mock Interview in 1 hour!`
       : `Reminder: Mock Interview tomorrow!`;
       
+    const scheduledLabel =
+      pairing.scheduledAt.toLocaleString("en-US", {
+        timeZone: "UTC",
+        dateStyle: "medium",
+        timeStyle: "short",
+      }) + " UTC";
     const html = `<h3>Mock Interview Reminder</h3>
-      <p>Your practice mock interview is scheduled for <strong>${pairing.scheduledAt.toLocaleString()}</strong>.</p>
+      <p>Your practice mock interview is scheduled for <strong>${scheduledLabel}</strong>.</p>
       ${pairing.meetingLink ? `<p>Meeting Link: <a href="${pairing.meetingLink}">${pairing.meetingLink}</a></p>` : "<p>No meeting link was provided. Please coordinate with your partner if you haven't already.</p>"}
       <p>Good luck!</p>`;
 

--- a/server/src/database/prisma/migrations/20260626140000_fix_peer_mock_scheduledat_nullable/migration.sql
+++ b/server/src/database/prisma/migrations/20260626140000_fix_peer_mock_scheduledat_nullable/migration.sql
@@ -1,0 +1,18 @@
+-- Corrective migration for #2563.
+--
+-- The original migration (20260625000000_add_pending_schedule_and_fields) added
+-- the new columns and the PENDING_SCHEDULE enum value, but did NOT alter the
+-- existing `scheduledAt` column (still NOT NULL DEFAULT now()) or the `status`
+-- column default. The async scheduling flow creates pairings with
+-- scheduledAt = NULL and status = PENDING_SCHEDULE, so without this the matching
+-- job hits a NOT NULL violation on prod and no pairings are created.
+--
+-- PENDING_SCHEDULE was committed in the prior migration (separate transaction),
+-- so it is safe to reference it as a column default here.
+--
+-- All statements are idempotent (DROP NOT NULL / DROP DEFAULT / SET DEFAULT are
+-- no-ops if already applied), so this is safe to re-run / self-heals drift.
+
+ALTER TABLE "peerMockInterview" ALTER COLUMN "scheduledAt" DROP NOT NULL;
+ALTER TABLE "peerMockInterview" ALTER COLUMN "scheduledAt" DROP DEFAULT;
+ALTER TABLE "peerMockInterview" ALTER COLUMN "status" SET DEFAULT 'PENDING_SCHEDULE';

--- a/server/src/module/peer-mock-interview/peer-mock-interview.routes.ts
+++ b/server/src/module/peer-mock-interview/peer-mock-interview.routes.ts
@@ -78,12 +78,13 @@ peerMockInterviewRouter.post(
   (req, res) => controller.submitRating(req, res)
 );
 
-// Propose a time for a pending mock interview
+// Propose / accept / reject a time. These are scheduling-coordination calls, not
+// interview consumption, so they intentionally do NOT go through usageLimit:
+// re-proposing after a reject must not burn the user's mock-interview quota.
 peerMockInterviewRouter.post(
   "/pairings/:id/propose-time",
   authMiddleware,
   requireRole("STUDENT"),
-  usageLimit("MOCK_INTERVIEW"),
   validateBody(proposeTimeSchema),
   (req, res) => controller.proposeTime(req, res)
 );
@@ -93,7 +94,6 @@ peerMockInterviewRouter.post(
   "/pairings/:id/accept-time",
   authMiddleware,
   requireRole("STUDENT"),
-  usageLimit("MOCK_INTERVIEW"),
   validateBody(acceptTimeSchema),
   (req, res) => controller.acceptTime(req, res)
 );
@@ -103,7 +103,6 @@ peerMockInterviewRouter.post(
   "/pairings/:id/reject-time",
   authMiddleware,
   requireRole("STUDENT"),
-  usageLimit("MOCK_INTERVIEW"),
   validateBody(z.object({})),
   (req, res) => controller.rejectTime(req, res)
 );

--- a/server/src/module/peer-mock-interview/peer-mock-interview.service.ts
+++ b/server/src/module/peer-mock-interview/peer-mock-interview.service.ts
@@ -7,6 +7,21 @@ export interface ScoredPair {
   score: number;
 }
 
+/**
+ * Format a date for emails in UTC with an explicit label. Server-side
+ * `toLocaleString()` renders in the server's timezone (UTC on Vercel) with no
+ * indication, which is ambiguous for recipients; this makes the zone explicit.
+ */
+function formatUtc(d: Date): string {
+  return (
+    d.toLocaleString("en-US", {
+      timeZone: "UTC",
+      dateStyle: "medium",
+      timeStyle: "short",
+    }) + " UTC"
+  );
+}
+
 export class PeerMockInterviewService {
   /**
    * Retrieves the peer mock interview preferences for a user.
@@ -68,12 +83,11 @@ export class PeerMockInterviewService {
           console.error("Failed to send cancellation email:", err);
         }
       }
-    } else {
-      // Run match making job in the background to pair them immediately if possible
-      this.runMatchingJob().catch(err => {
-        console.error("Failed to run background matching job on preference update:", err);
-      });
     }
+    // Note: matching runs on the scheduled match cron. We deliberately do not
+    // fire runMatchingJob() here: on Vercel serverless the function can freeze
+    // after responding, so a fire-and-forget job would not reliably finish, and
+    // running the full matching engine inline would make this endpoint slow.
 
     return preference;
   }
@@ -279,7 +293,7 @@ export class PeerMockInterviewService {
         const emailUtils = await import("../../utils/email.utils.js");
         const html = `<h3>New Time Proposed</h3>
           <p><strong>${proposer.name}</strong> has proposed a time for your upcoming practice session:</p>
-          <p><strong>${proposedTime.toLocaleString()}</strong></p>
+          <p><strong>${formatUtc(proposedTime)}</strong></p>
           <p>Please log in to your dashboard to accept or reject this proposed time.</p>`;
         await emailUtils.sendEmail({ to: partner.email, subject: "Mock Interview Time Proposed", html });
       } catch (err) {
@@ -329,7 +343,7 @@ export class PeerMockInterviewService {
 
     const emailUtils = await import("../../utils/email.utils.js");
     const html = `<h3>Mock Interview Scheduled!</h3>
-      <p>Your mock interview has been scheduled for <strong>${pairing.proposedTime.toLocaleString()}</strong>.</p>
+      <p>Your mock interview has been scheduled for <strong>${formatUtc(pairing.proposedTime)}</strong>.</p>
       ${meetingLink ? `<p>Meeting Link: <a href="${meetingLink}">${meetingLink}</a></p>` : ""}
       <p>Please mark your calendar!</p>`;
 
@@ -395,6 +409,11 @@ export class PeerMockInterviewService {
       const prefs = await prisma.peerMockInterviewPreference.findMany({
         where: {
           enabled: true,
+          user: {
+            roadmapEnrollments: {
+              some: { status: "ACTIVE" },
+            },
+          },
         },
         include: {
           user: {

--- a/server/src/module/peer-mock-interview/peer-mock-interview.validation.ts
+++ b/server/src/module/peer-mock-interview/peer-mock-interview.validation.ts
@@ -16,5 +16,16 @@ export const proposeTimeSchema = z.object({
 });
 
 export const acceptTimeSchema = z.object({
-  meetingLink: z.string().url().max(500).optional(),
+  // Restrict to http(s): z.string().url() also accepts javascript:/data: URLs,
+  // and the meeting link is rendered as an <a href> in the UI and emails, so an
+  // unrestricted scheme is a stored-XSS / phishing vector for the matched peer.
+  meetingLink: z
+    .string()
+    .url()
+    .max(500)
+    .refine(
+      (url) => /^https?:\/\//i.test(url),
+      "Meeting link must start with http:// or https://",
+    )
+    .optional(),
 });


### PR DESCRIPTION
Follow-up to #2563. Fixes the issues found in review.

## 🔴 Critical
- **Broken migration.** #2563's schema made `scheduledAt` nullable and changed the `status` default, but the migration never altered the existing column. The matching job creates rows with `scheduledAt = NULL` → **NOT NULL violation on prod**. Adds a corrective migration dropping `NOT NULL`/default on `scheduledAt` and setting the `status` default to `PENDING_SCHEDULE` (the enum value was committed in the prior migration, so this is safe). Idempotent / self-healing.
- **Stored XSS via `meetingLink`.** `z.string().url()` accepts `javascript:`/`data:` URLs and the link renders as `<a href>` in the UI and emails. Restricted to `http(s)` in the validator and guarded the client render with `isSafeHttpUrl` (defense in depth).

## 🟡 Correctness
- Removed `usageLimit("MOCK_INTERVIEW")` from propose/accept/reject — coordinating (re-proposing after a reject) must not burn interview quota. Premium is still enforced via `checkPremiumSubscription` in the controller.
- Dropped the fire-and-forget `runMatchingJob()` on preference enable: on Vercel serverless the function can freeze after responding so it wouldn't run reliably; the scheduled match cron already handles matching.
- Restored the `roadmapEnrollments: ACTIVE` filter in `runMatchingJob` that the refactor silently dropped (only actively enrolled users should match).
- Email/reminder scheduled times used `toLocaleString()` (server TZ, no label); now formatted explicitly in UTC with a label.

## Testing
- `tsc --noEmit` clean (server + client changed files), after regenerating the Prisma client for #2563's schema.
- `vitest run peer-mock-interview.test.ts` → 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)