### PR TITLE
fix(peer-mock-interview): consistent premium gating across cron and API (#2536)

### DIFF
--- a/server/src/middleware/premium.middleware.ts
+++ b/server/src/middleware/premium.middleware.ts
@@ -1,0 +1,47 @@
+import type { Request, Response, NextFunction } from "express";
+import { prisma } from "../database/db.js";
+import { getPlanTier } from "../config/usage-limits.js";
+
+/**
+ * Gate a route behind an active Premium subscription.
+ *
+ * Uses the canonical `getPlanTier` (the same helper the usage-limit middleware
+ * uses) so the check honours `subscriptionEndDate` instead of a bespoke
+ * plan+status check. Centralising the per-request lookup here removes the
+ * duplicated `user.findUnique` that previously sat in every controller method.
+ */
+export async function requirePremium(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  if (!req.user) {
+    res.status(401).json({ message: "Authentication required" });
+    return;
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: req.user.id },
+    select: {
+      subscriptionPlan: true,
+      subscriptionStatus: true,
+      subscriptionEndDate: true,
+    },
+  });
+
+  if (
+    !user ||
+    getPlanTier(
+      user.subscriptionPlan,
+      user.subscriptionStatus,
+      user.subscriptionEndDate,
+    ) !== "PREMIUM"
+  ) {
+    res
+      .status(403)
+      .json({ message: "Premium subscription required for peer mock interviews" });
+    return;
+  }
+
+  next();
+}

--- a/server/src/module/peer-mock-interview/peer-mock-interview.controller.ts
+++ b/server/src/module/peer-mock-interview/peer-mock-interview.controller.ts
@@ -1,35 +1,19 @@
 import type { Request, Response } from "express";
-import { prisma } from "../../database/db.js";
 import { PeerMockInterviewService } from "./peer-mock-interview.service.js";
-import { mockInterviewPreferenceSchema, mockInterviewFeedbackSchema, proposeTimeSchema, acceptTimeSchema } from "./peer-mock-interview.validation.js";
 
 const service = new PeerMockInterviewService();
 
+// Premium gating + body validation are handled by route middleware
+// (requirePremium + validateBody), so these handlers assume an authenticated
+// premium STUDENT and an already-parsed req.body.
 export class PeerMockInterviewController {
-  private async checkPremiumSubscription(userId: number): Promise<boolean> {
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { subscriptionPlan: true, subscriptionStatus: true },
-    });
-    return !!(
-      user &&
-      (user.subscriptionPlan === "MONTHLY" || user.subscriptionPlan === "YEARLY") &&
-      user.subscriptionStatus === "ACTIVE"
-    );
-  }
-
   async getPreference(req: Request, res: Response) {
     try {
       if (!req.user) {
         res.status(401).json({ message: "Authentication required" });
         return;
       }
-      if (!await this.checkPremiumSubscription(req.user.id)) {
-        res.status(403).json({ message: "Premium subscription required for peer mock interviews" });
-        return;
-      }
-      const userId = req.user.id;
-      const pref = await service.getPreference(userId);
+      const pref = await service.getPreference(req.user.id);
       res.json(pref);
     } catch (err: any) {
       res.status(err.status || 500).json({ message: err.message || "Failed to fetch preferences" });
@@ -42,19 +26,8 @@ export class PeerMockInterviewController {
         res.status(401).json({ message: "Authentication required" });
         return;
       }
-      if (!await this.checkPremiumSubscription(req.user.id)) {
-        res.status(403).json({ message: "Premium subscription required for peer mock interviews" });
-        return;
-      }
-      const userId = req.user.id;
-      const parsed = mockInterviewPreferenceSchema.safeParse(req.body);
-      if (!parsed.success) {
-        res.status(400).json({ message: "Invalid preferences input", errors: parsed.error.format() });
-        return;
-      }
-
-      const { topic, availability, enabled } = parsed.data;
-      const pref = await service.upsertPreference(userId, topic, availability, enabled);
+      const { topic, availability, enabled } = req.body;
+      const pref = await service.upsertPreference(req.user.id, topic, availability, enabled);
       res.json(pref);
     } catch (err: any) {
       res.status(err.status || 500).json({ message: err.message || "Failed to update preferences" });
@@ -67,12 +40,7 @@ export class PeerMockInterviewController {
         res.status(401).json({ message: "Authentication required" });
         return;
       }
-      if (!await this.checkPremiumSubscription(req.user.id)) {
-        res.status(403).json({ message: "Premium subscription required for peer mock interviews" });
-        return;
-      }
-      const userId = req.user.id;
-      const pairing = await service.getUpcomingPairing(userId);
+      const pairing = await service.getUpcomingPairing(req.user.id);
       res.json(pairing);
     } catch (err: any) {
       res.status(err.status || 500).json({ message: err.message || "Failed to fetch upcoming pairing" });
@@ -85,18 +53,12 @@ export class PeerMockInterviewController {
         res.status(401).json({ message: "Authentication required" });
         return;
       }
-      if (!await this.checkPremiumSubscription(req.user.id)) {
-        res.status(403).json({ message: "Premium subscription required for peer mock interviews" });
-        return;
-      }
-      const userId = req.user.id;
       const pairingId = parseInt(String(req.params["id"] || ""), 10);
       if (isNaN(pairingId)) {
         res.status(400).json({ message: "Invalid pairing ID" });
         return;
       }
-
-      const pairing = await service.getPairingDetails(userId, pairingId);
+      const pairing = await service.getPairingDetails(req.user.id, pairingId);
       res.json(pairing);
     } catch (err: any) {
       res.status(err.status || 500).json({ message: err.message || "Failed to fetch pairing details" });
@@ -109,18 +71,12 @@ export class PeerMockInterviewController {
         res.status(401).json({ message: "Authentication required" });
         return;
       }
-      if (!await this.checkPremiumSubscription(req.user.id)) {
-        res.status(403).json({ message: "Premium subscription required for peer mock interviews" });
-        return;
-      }
-      const userId = req.user.id;
       const pairingId = parseInt(String(req.params["id"] || ""), 10);
       if (isNaN(pairingId)) {
         res.status(400).json({ message: "Invalid pairing ID" });
         return;
       }
-
-      const updated = await service.markCompleted(userId, pairingId);
+      const updated = await service.markCompleted(req.user.id, pairingId);
       res.json({ message: "Mock interview marked completed", pairing: updated });
     } catch (err: any) {
       res.status(err.status || 500).json({ message: err.message || "Failed to complete pairing" });
@@ -133,55 +89,32 @@ export class PeerMockInterviewController {
         res.status(401).json({ message: "Authentication required" });
         return;
       }
-      if (!await this.checkPremiumSubscription(req.user.id)) {
-        res.status(403).json({ message: "Premium subscription required for peer mock interviews" });
-        return;
-      }
-      const userId = req.user.id;
       const pairingId = parseInt(String(req.params["id"] || ""), 10);
       if (isNaN(pairingId)) {
         res.status(400).json({ message: "Invalid pairing ID" });
         return;
       }
-
-      const parsed = mockInterviewFeedbackSchema.safeParse(req.body);
-      if (!parsed.success) {
-        res.status(400).json({ message: "Invalid feedback input", errors: parsed.error.format() });
-        return;
-      }
-
-      const { rating, feedback } = parsed.data;
-      const updated = await service.submitRating(userId, pairingId, rating, feedback);
+      const { rating, feedback } = req.body;
+      const updated = await service.submitRating(req.user.id, pairingId, rating, feedback);
       res.json({ message: "Feedback submitted successfully", pairing: updated });
     } catch (err: any) {
       res.status(err.status || 500).json({ message: err.message || "Failed to submit feedback" });
     }
   }
+
   async proposeTime(req: Request, res: Response) {
     try {
       if (!req.user) {
         res.status(401).json({ message: "Authentication required" });
         return;
       }
-      if (!await this.checkPremiumSubscription(req.user.id)) {
-        res.status(403).json({ message: "Premium subscription required for peer mock interviews" });
-        return;
-      }
-      const userId = req.user.id;
       const pairingId = parseInt(String(req.params["id"] || ""), 10);
       if (isNaN(pairingId)) {
         res.status(400).json({ message: "Invalid pairing ID" });
         return;
       }
-
-      const parsed = proposeTimeSchema.safeParse(req.body);
-      if (!parsed.success) {
-        res.status(400).json({ message: "Invalid time proposal input", errors: parsed.error.format() });
-        return;
-      }
-
-      const { proposedTime } = parsed.data;
-      const updated = await service.proposeTime(userId, pairingId, proposedTime);
+      const { proposedTime } = req.body;
+      const updated = await service.proposeTime(req.user.id, pairingId, proposedTime);
       res.json({ message: "Time proposed successfully", pairing: updated });
     } catch (err: any) {
       res.status(err.status || 500).json({ message: err.message || "Failed to propose time" });
@@ -194,25 +127,13 @@ export class PeerMockInterviewController {
         res.status(401).json({ message: "Authentication required" });
         return;
       }
-      if (!await this.checkPremiumSubscription(req.user.id)) {
-        res.status(403).json({ message: "Premium subscription required for peer mock interviews" });
-        return;
-      }
-      const userId = req.user.id;
       const pairingId = parseInt(String(req.params["id"] || ""), 10);
       if (isNaN(pairingId)) {
         res.status(400).json({ message: "Invalid pairing ID" });
         return;
       }
-
-      const parsed = acceptTimeSchema.safeParse(req.body);
-      if (!parsed.success) {
-        res.status(400).json({ message: "Invalid acceptance input", errors: parsed.error.format() });
-        return;
-      }
-
-      const { meetingLink } = parsed.data;
-      const updated = await service.acceptTime(userId, pairingId, meetingLink);
+      const { meetingLink } = req.body;
+      const updated = await service.acceptTime(req.user.id, pairingId, meetingLink);
       res.json({ message: "Time accepted successfully", pairing: updated });
     } catch (err: any) {
       res.status(err.status || 500).json({ message: err.message || "Failed to accept time" });
@@ -225,18 +146,12 @@ export class PeerMockInterviewController {
         res.status(401).json({ message: "Authentication required" });
         return;
       }
-      if (!await this.checkPremiumSubscription(req.user.id)) {
-        res.status(403).json({ message: "Premium subscription required for peer mock interviews" });
-        return;
-      }
-      const userId = req.user.id;
       const pairingId = parseInt(String(req.params["id"] || ""), 10);
       if (isNaN(pairingId)) {
         res.status(400).json({ message: "Invalid pairing ID" });
         return;
       }
-
-      const updated = await service.rejectTime(userId, pairingId);
+      const updated = await service.rejectTime(req.user.id, pairingId);
       res.json({ message: "Time rejected successfully", pairing: updated });
     } catch (err: any) {
       res.status(err.status || 500).json({ message: err.message || "Failed to reject time" });

--- a/server/src/module/peer-mock-interview/peer-mock-interview.routes.ts
+++ b/server/src/module/peer-mock-interview/peer-mock-interview.routes.ts
@@ -1,32 +1,29 @@
 import { Router } from "express";
+import { z } from "zod";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
 import { requireRole } from "../../middleware/role.middleware.js";
+import { requirePremium } from "../../middleware/premium.middleware.js";
 import { usageLimit } from "../../middleware/usage-limit.middleware.js";
+import { validateBody } from "../../middleware/validation.middleware.js";
 import { PeerMockInterviewController } from "./peer-mock-interview.controller.js";
 import { mockInterviewPreferenceSchema, mockInterviewFeedbackSchema, proposeTimeSchema, acceptTimeSchema } from "./peer-mock-interview.validation.js";
-import { z } from "zod";
-import type { Request, Response, NextFunction } from "express";
 
 const controller = new PeerMockInterviewController();
 
 export const peerMockInterviewRouter = Router();
 
-function validateBody(schema: z.Schema) {
-  return (req: Request, res: Response, next: NextFunction) => {
-    const parsed = schema.safeParse(req.body);
-    if (!parsed.success) {
-      res.status(400).json({ message: "Validation failed", errors: parsed.error.format() });
-      return;
-    }
-    next();
-  };
-}
+// Every route requires an authenticated STUDENT with an active Premium
+// subscription. requirePremium centralises the subscription lookup (via the
+// canonical getPlanTier) so the controllers no longer repeat it, and the shared
+// validateBody attaches parsed/transformed input to req.body so controllers do
+// not re-parse.
 
 // Retrieve user's mock interview preferences
 peerMockInterviewRouter.get(
   "/preferences",
   authMiddleware,
   requireRole("STUDENT"),
+  requirePremium,
   usageLimit("MOCK_INTERVIEW"),
   (req, res) => controller.getPreference(req, res)
 );
@@ -36,6 +33,7 @@ peerMockInterviewRouter.post(
   "/preferences",
   authMiddleware,
   requireRole("STUDENT"),
+  requirePremium,
   usageLimit("MOCK_INTERVIEW"),
   validateBody(mockInterviewPreferenceSchema),
   (req, res) => controller.upsertPreference(req, res)
@@ -46,6 +44,7 @@ peerMockInterviewRouter.get(
   "/pairings/upcoming",
   authMiddleware,
   requireRole("STUDENT"),
+  requirePremium,
   usageLimit("MOCK_INTERVIEW"),
   (req, res) => controller.getUpcomingPairing(req, res)
 );
@@ -55,6 +54,7 @@ peerMockInterviewRouter.get(
   "/pairings/:id",
   authMiddleware,
   requireRole("STUDENT"),
+  requirePremium,
   usageLimit("MOCK_INTERVIEW"),
   (req, res) => controller.getPairingDetails(req, res)
 );
@@ -64,6 +64,7 @@ peerMockInterviewRouter.post(
   "/pairings/:id/complete",
   authMiddleware,
   requireRole("STUDENT"),
+  requirePremium,
   usageLimit("MOCK_INTERVIEW"),
   (req, res) => controller.markCompleted(req, res)
 );
@@ -73,6 +74,7 @@ peerMockInterviewRouter.post(
   "/pairings/:id/rate",
   authMiddleware,
   requireRole("STUDENT"),
+  requirePremium,
   usageLimit("MOCK_INTERVIEW"),
   validateBody(mockInterviewFeedbackSchema),
   (req, res) => controller.submitRating(req, res)
@@ -85,6 +87,7 @@ peerMockInterviewRouter.post(
   "/pairings/:id/propose-time",
   authMiddleware,
   requireRole("STUDENT"),
+  requirePremium,
   validateBody(proposeTimeSchema),
   (req, res) => controller.proposeTime(req, res)
 );
@@ -94,6 +97,7 @@ peerMockInterviewRouter.post(
   "/pairings/:id/accept-time",
   authMiddleware,
   requireRole("STUDENT"),
+  requirePremium,
   validateBody(acceptTimeSchema),
   (req, res) => controller.acceptTime(req, res)
 );
@@ -103,6 +107,7 @@ peerMockInterviewRouter.post(
   "/pairings/:id/reject-time",
   authMiddleware,
   requireRole("STUDENT"),
+  requirePremium,
   validateBody(z.object({})),
   (req, res) => controller.rejectTime(req, res)
 );

--- a/server/src/module/peer-mock-interview/peer-mock-interview.service.ts
+++ b/server/src/module/peer-mock-interview/peer-mock-interview.service.ts
@@ -405,11 +405,22 @@ export class PeerMockInterviewService {
   async runMatchingJob() {
     const { withAdvisoryLock } = await import("../../utils/cron-lock.js");
     const result = await withAdvisoryLock("peer_mock_interview_match_service", async () => {
-      // 1. Get all active preferences
+      // 1. Get active preferences for actively-enrolled PREMIUM users only.
+      // The candidate pool must match what the API gates on (requirePremium /
+      // getPlanTier), otherwise a lapsed user gets matched by the cron and then
+      // hits 403 viewing their own pairing. This mirrors getPlanTier's PREMIUM
+      // condition at the query level (plan in {MONTHLY,YEARLY} + ACTIVE + not
+      // past subscriptionEndDate).
       const prefs = await prisma.peerMockInterviewPreference.findMany({
         where: {
           enabled: true,
           user: {
+            subscriptionStatus: "ACTIVE",
+            subscriptionPlan: { in: ["MONTHLY", "YEARLY"] },
+            OR: [
+              { subscriptionEndDate: null },
+              { subscriptionEndDate: { gt: new Date() } },
+            ],
             roadmapEnrollments: {
               some: { status: "ACTIVE" },
             },


### PR DESCRIPTION
Fixes #2536.

## Problem
- The matching cron (`runMatchingJob`) gated only on `enabled` preference + active enrollment, so a user who **lapsed from premium after opting in still got matched**, then hit `403` on every peer-mock API call and could never view their own pairing.
- The API's inline `checkPremiumSubscription` used a bespoke `plan ∈ {MONTHLY,YEARLY} && status===ACTIVE` test that **ignored `subscriptionEndDate`**, unlike the canonical `getPlanTier` used by `usageLimit`.
- The premium lookup was duplicated as a `user.findUnique` in all 9 controller methods, and body validation ran twice (route `validateBody` + controller `safeParse`).

## Fix
- New `requirePremium` middleware using `getPlanTier` (honours `subscriptionEndDate`), applied to every peer-mock route. Removes the duplicated lookup + bespoke check from the controller.
- Cron candidate pool now filters to active-enrolled **PREMIUM** users, mirroring `getPlanTier`'s PREMIUM condition at the query level — so cron and API gate on the same tier.
- Routes now use the shared `validateBody` (which attaches the parsed/transformed body); dropped the redundant controller-side `safeParse`.

## Testing
- `tsc --noEmit` clean for changed files.
- `vitest run peer-mock-interview.test.ts` → 12 passed.

Note: `usageLimit("MOCK_INTERVIEW")` on the read endpoints is left as-is (out of scope here); it consuming quota on GETs is a separate pre-existing concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)