### PR TITLE
fix: use user name instead of email in enrollment PDF welcome email

### DIFF
--- a/server/src/module/roadmap/roadmap.controller.ts
+++ b/server/src/module/roadmap/roadmap.controller.ts
@@ -176,8 +176,12 @@ export async function enroll(req: Request, res: Response, next: NextFunction) {
         enrollmentId: enrollment.id,
       });
       if (full) {
+        const u = await prisma.user.findUnique({
+          where: { id: req.user!.id },
+          select: { name: true },
+        });
         const pdfBuffer = await generateRoadmapPdf({
-          user: { name: req.user!.name },
+          user: { name: u?.name ?? req.user!.email },
           roadmap: {
             title: full.roadmap.title,
             shortDescription: full.roadmap.shortDescription,

--- a/server/src/module/roadmap/roadmap.controller.ts
+++ b/server/src/module/roadmap/roadmap.controller.ts
@@ -177,7 +177,7 @@ export async function enroll(req: Request, res: Response, next: NextFunction) {
       });
       if (full) {
         const pdfBuffer = await generateRoadmapPdf({
-          user: { name: req.user!.email },
+          user: { name: req.user!.name },
           roadmap: {
             title: full.roadmap.title,
             shortDescription: full.roadmap.shortDescription,
@@ -1429,3 +1429,4 @@ export async function getAiUsage(req: Request, res: Response, next: NextFunction
     next(err);
   }
 }
+


### PR DESCRIPTION
Fixes user name display in enrollment PDF welcome email.

Closes #2517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the welcome-email PDF to use the recipient’s name (from their profile) instead of their email address.
  * Minor end-of-file formatting adjustment with no visible behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->