### PR TITLE
fix: use createdAt instead of updatedAt in contribution trend

### DIFF
--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -570,14 +570,14 @@ export class OpensourceService {
       where: {
         userId,
         status: "APPROVED",
-        updatedAt: { gte: startMonth, lt: endMonth },
+        createdAt: { gte: startMonth, lt: endMonth },
       },
-      select: { updatedAt: true },
+      select: { createdAt: true },
     });
 
     const countsByMonth = new Map<string, number>();
     for (const request of approvedRequests) {
-      const monthKey = this.getMonthKeyUTC(request.updatedAt);
+      const monthKey = this.getMonthKeyUTC(request.createdAt);
       countsByMonth.set(monthKey, (countsByMonth.get(monthKey) ?? 0) + 1);
     }
 
@@ -906,5 +906,6 @@ export class OpensourceService {
   }
 
 }
+
 
 


### PR DESCRIPTION
Fixes monthly contribution count shifting based on admin activity.

Closes #2522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monthly contribution trends now count items based on when they were originally created, providing more accurate historical reporting.
  * Trend charts and totals may shift slightly to reflect the corrected month attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->