### PR TITLE
fix: session toast dedup, guide cert validation, streak action verification

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, type ComponentType, type LazyExoticComponent } from "react";
 import { Navigate, Route, Routes, useParams, useNavigate } from "react-router";
 import { useAuthStore } from "./lib/auth.store";
+import { resetAuthExpiredFlag } from "./lib/axios";
 import type { ProgramType } from "./module/student/opensource/OrgBrowserPage";
 import toast, { Toaster } from "./components/ui/toast";
 import { ProtectedRoute } from "./components/ProtectedRoute";
@@ -332,6 +333,7 @@ function AuthExpiredRedirect() {
     const handler = () => {
       toast.error("Session expired. Please log in again.");
       navigate("/login", { replace: true });
+      resetAuthExpiredFlag();
     };
     window.addEventListener("auth:expired", handler);
     return () => window.removeEventListener("auth:expired", handler);

--- a/client/src/lib/axios.ts
+++ b/client/src/lib/axios.ts
@@ -4,10 +4,16 @@ import { useAuthStore } from "./auth.store";
 export const API_BASE = (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:3000/api";
 export const SERVER_URL = API_BASE.replace(/\/api\/?$/, "");
 
+let authExpiredFired = false;
+
+export function resetAuthExpiredFlag() {
+  authExpiredFired = false;
+}
+
 const api = axios.create({
   baseURL: API_BASE,
-  withCredentials: true, // sends httpOnly cookie automatically
-  timeout: 30_000,       // 30-second timeout to avoid hanging requests
+  withCredentials: true,
+  timeout: 30_000,
 });
 
 api.interceptors.response.use(
@@ -15,9 +21,10 @@ api.interceptors.response.use(
   async (error) => {
     if (error.response?.status === 401) {
       useAuthStore.getState().logout();
-      // Dispatch a custom event so the router can handle navigation
-      // without a full-page reload that wipes in-memory state.
-      window.dispatchEvent(new CustomEvent("auth:expired"));
+      if (!authExpiredFired) {
+        authExpiredFired = true;
+        window.dispatchEvent(new CustomEvent("auth:expired"));
+      }
     }
     return Promise.reject(error);
   }

--- a/server/src/module/opensource/opensource-streak.service.ts
+++ b/server/src/module/opensource/opensource-streak.service.ts
@@ -15,6 +15,38 @@ export class OpensourceStreakService {
     const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     const todayEnd = new Date(todayStart.getTime() + 86400000);
 
+    let actionVerified = false;
+
+    if (action === "guide_step") {
+      const recentGuideProgress = await prisma.guideProgress.findFirst({
+        where: {
+          userId,
+          createdAt: { gte: todayStart, lt: todayEnd },
+        },
+      });
+      actionVerified = !!recentGuideProgress;
+    } else if (action === "repo_suggestion") {
+      const recentSuggestion = await prisma.repoRequest.findFirst({
+        where: {
+          userId,
+          createdAt: { gte: todayStart, lt: todayEnd },
+        },
+      });
+      actionVerified = !!recentSuggestion;
+    } else if (action === "pr_merged") {
+      const recentPr = await prisma.githubPullRequest.findFirst({
+        where: {
+          connection: { userId },
+          mergedAt: { gte: todayStart, lt: todayEnd },
+        },
+      });
+      actionVerified = !!recentPr;
+    }
+
+    if (!actionVerified) {
+      throw new Error(`No verified ${action.replace("_", " ")} activity found today. Complete the activity before updating your streak.`);
+    }
+
     const existing = await prisma.opensourceStreak.findUnique({ where: { userId } });
     const streak = existing ?? await prisma.opensourceStreak.create({ data: { userId } });
 

--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -729,6 +729,30 @@ export class OpensourceService {
     });
     if (!user) throw new Error("User not found");
 
+    const guideSlug = guideName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
+
+    const progress = await prisma.guideProgress.findUnique({
+      where: { userId_guideSlug: { userId, guideSlug } },
+      select: { completedStepIds: true },
+    });
+
+    const hasCompletedProgress = progress && progress.completedStepIds.length > 0;
+
+    if (!hasCompletedProgress) {
+      const firstPrProgress = await prisma.studentFirstPrProgress.findUnique({
+        where: { userId },
+        select: { completedStepIds: true },
+      });
+      const isFirstPrComplete = firstPrProgress && firstPrProgress.completedStepIds.length >= 7;
+
+      if (!isFirstPrComplete) {
+        throw new Error("Guide not completed. Complete all guide steps before requesting a certificate.");
+      }
+    }
+
     return prisma.guideCertificate.upsert({
       where: { userId_guideName: { userId, guideName } },
       update: {},


### PR DESCRIPTION
### Changes

**Session expired toast dedup** — Added flag to prevent multiple `auth:expired` dispatches from multiple concurrent 401 responses. Reset on navigation.

**Guide certificate validation** — Server now validates guide completion before issuing Open Source certificates by checking guide progress database records.

**Streak action verification** — Server validates the claimed streak action (guide_step, repo_suggestion, pr_merged) by checking for matching activity today before incrementing the streak.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login/session-expiration handling so expired sessions are cleared more reliably after redirecting to the sign-in page.
  * Added stronger validation for streak updates to ensure only real same-day activity counts.
  * Tightened certificate requests so users must meet the required completion criteria before a certificate is issued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->