### PR TITLE
fix: add standard mobile-web-app-capable meta tag alongside deprecate…

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -16,6 +16,7 @@
     <meta name="theme-color" content="#030712" />
     <meta name="application-name" content="InternHack" />
     <meta name="apple-mobile-web-app-title" content="InternHack" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="format-detection" content="telephone=no" />


### PR DESCRIPTION
Fixes #2565

Adds the standard `mobile-web-app-capable` meta tag alongside the existing (deprecated) `apple-mobile-web-app-capable` tag in `client/index.html`, resolving the browser console deprecation warning.

The Apple-specific tag is retained for Safari/iOS compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled mobile web-app support for compatible non-Apple mobile devices, improving the app’s installable, app-like experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->