### PR TITLE
fix: remove duplicate .no-scrollbar CSS rule 

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -399,6 +399,3 @@ body::-webkit-scrollbar-thumb:hover {
     margin: 0.5in;
   }
 }
-/* Hide scrollbar for horizontal scroll chips */
-.no-scrollbar::-webkit-scrollbar { display: none; }
-.no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }


### PR DESCRIPTION
# Pull Request

## Description
- Removed a duplicate `.no-scrollbar rule` in `client/src/index.css`.
- The class was defined twice, once via the Tailwind `@utility no-scrollbar` block, and again as a standalone plain-CSS block with identical rules near the bottom of the file. 
- Kept the `@utility` definition and removed the redundant duplicate.

## Related Issue
Fixes #2609 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing

- Confirmed via diff that only the duplicate block was removed. 
- Ran `grep -rn "no-scrollbar" client/src/` to confirm all usages (`RepoDiscoveryPage.tsx`, `LearningPathSidebar.tsx`, `ProgramTrackerPage.tsx`) still resolve correctly against the remaining `@utility` definition. 
- Both blocks had identical property values, so no visual change occurs.

## Screenshots / Video

> No UI changes in this PR

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrollbar hiding behavior for horizontally scrollable chips, making the UI look cleaner and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->