### PR TITLE
fix: replace timing-unsafe API key comparison with crypto.timingSafeEqual

### DIFF
--- a/server/src/module/admin/admin.controller.ts
+++ b/server/src/module/admin/admin.controller.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from "express";
+import crypto from "crypto";
 import { validateRequestData } from "../../utils/validation.utils.js";
 import type { AdminService } from "./admin.service.js";
 import { setTokenCookie } from "../../utils/cookie.utils.js";
@@ -1008,7 +1009,12 @@ export class AdminController {
 
       const apiKey = req.headers["x-api-key"];
       const expectedKey = process.env["EXTERNAL_JOB_API_KEY"];
-      if (!expectedKey || apiKey !== expectedKey) {
+      const keyValid =
+        typeof apiKey === "string" &&
+        !!expectedKey &&
+        apiKey.length === expectedKey.length &&
+        crypto.timingSafeEqual(Buffer.from(apiKey), Buffer.from(expectedKey));
+      if (!keyValid) {
         logger.warn("[ingestExternalJob] auth failed", {
           expectedKeySet: !!expectedKey,
           receivedKeyPresent: !!apiKey,


### PR DESCRIPTION
The ingestExternalJob endpoint compared the X-API-Key header using !== which is vulnerable to timing attacks. This replaces the comparison with crypto.timingSafeEqual, using a length guard to prevent the Buffer mismatch error that timingSafeEqual throws when inputs differ in length. The same pattern is already used in email-inbound.controller.ts for webhook signature verification.

Closes #2622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for incoming API key checks on external job ingestion, using a safer comparison method.
  * Kept the same error response and logging behavior when an invalid key is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->