### PR TITLE
fix: add periodic eviction and size cap to in-memory cache

### DIFF
--- a/server/src/utils/cache.ts
+++ b/server/src/utils/cache.ts
@@ -4,6 +4,18 @@ interface CacheEntry {
 }
 
 const store = new Map<string, CacheEntry>();
+const MAX_ENTRIES = 10_000;
+const SWEEP_INTERVAL_MS = 60_000;
+
+function sweepExpired(): void {
+  const now = Date.now();
+  for (const [key, entry] of store) {
+    if (now > entry.exp) store.delete(key);
+  }
+}
+
+const sweepTimer = setInterval(sweepExpired, SWEEP_INTERVAL_MS);
+if (sweepTimer.unref) sweepTimer.unref();
 
 export async function cacheGet<T>(key: string): Promise<T | null> {
   const entry = store.get(key);
@@ -15,6 +27,10 @@ export async function cacheGet<T>(key: string): Promise<T | null> {
 }
 
 export async function cacheSet(key: string, value: unknown, ttlSeconds: number): Promise<void> {
+  if (store.size >= MAX_ENTRIES && !store.has(key)) {
+    sweepExpired();
+    if (store.size >= MAX_ENTRIES) return;
+  }
   store.set(key, { val: JSON.stringify(value), exp: Date.now() + ttlSeconds * 1000 });
 }
 


### PR DESCRIPTION
The cache Map grew without bound since expired entries were only removed on cacheGet for that specific key. This adds a 60-second periodic sweep that evicts expired entries (setInterval with unref so it doesn't block process exit), and a 10,000 entry cap with pre-set eviction so cacheSet does not grow past the limit.\n\nCloses #2623

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic cleanup for expired cached entries.
  * Improved cache limits so new entries are rejected when the cache is full, helping prevent unbounded growth and stale data buildup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->