### PR TITLE
fix: send admin email notification on contact form submission

### DIFF
--- a/server/src/module/contact/contact.routes.ts
+++ b/server/src/module/contact/contact.routes.ts
@@ -3,6 +3,9 @@ import type { Request, Response } from "express";
 import { prisma } from "../../database/db.js";
 import { contactSchema } from "./contact.validation.js";
 import { contactLimiter } from "../../middleware/rate-limit.middleware.js";
+import { sendEmail } from "../../utils/email.utils.js";
+
+const ADMIN_ALERT_EMAIL = process.env["ADMIN_ALERT_EMAIL"] ?? "mrsachinchaurasiya@gmail.com";
 
 export const contactRouter = Router();
 
@@ -13,6 +16,15 @@ contactRouter.post("/", contactLimiter, async (req: Request, res: Response) => {
       return res.status(400).json({ message: "Validation failed", errors: parsed.error.issues });
     }
     await prisma.contactSubmission.create({ data: parsed.data });
+    sendEmail({
+      to: ADMIN_ALERT_EMAIL,
+      subject: `New contact form submission: ${parsed.data.subject}`,
+      html: `<p><strong>Name:</strong> ${parsed.data.name}</p>
+<p><strong>Email:</strong> ${parsed.data.email}</p>
+<p><strong>Subject:</strong> ${parsed.data.subject}</p>
+<p><strong>Message:</strong></p>
+<p>${parsed.data.message}</p>`,
+    });
     return res.status(201).json({ message: "Message sent successfully" });
   } catch {
     return res.status(500).json({ message: "Failed to send message" });


### PR DESCRIPTION
Contact form submissions were silently stored in the database with no notification to the site admin. This adds a sendEmail call to the admin alert address after a successful submission, using the existing sendEmail utility which gracefully degrades in dev when RESEND_API_KEY is not set.\n\nCloses #2625