### PR TITLE
fix: harden LaTeX compilation and supporting file handling

### DIFF
--- a/server/src/module/latex/latex.service.ts
+++ b/server/src/module/latex/latex.service.ts
@@ -7,6 +7,21 @@ import crypto from "crypto";
 const COMPILE_TIMEOUT = 30_000; // 30 seconds
 const ONLINE_API = "https://latex.ytotech.com/builds/sync";
 
+const MAX_SOURCE_SIZE = 500 * 1024; // 500 KB
+const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB per supporting file
+const MAX_TOTAL_SIZE = 10 * 1024 * 1024; // 10 MB total
+
+const SAFE_FILENAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$/;
+const ALLOWED_EXTENSIONS = new Set([".sty", ".cls", ".bib", ".bst", ".png", ".jpg", ".jpeg", ".eps"]);
+
+const DANGEROUS_PATTERNS: RegExp[] = [
+  /\\write18/,
+  /\\immediate\s*\\write18/,
+  /\\input\s*\{\s*\|/,
+  /\\openin/,
+  /\\catcode.*\\active/,
+  /\\csname\s*shellescape/i,
+];
 export interface SupportingFile {
   filename: string;
   content: string;
@@ -14,8 +29,59 @@ export interface SupportingFile {
 
 export class LatexService {
   private pdflatexAvailable: boolean | null = null;
+private validateFilename(filename: string): void {
+    if (!SAFE_FILENAME_REGEX.test(filename)) {
+      throw new Error(`Invalid supporting file name: "${filename}"`);
+    }
+    const ext = path.extname(filename).toLowerCase();
+    if (!ALLOWED_EXTENSIONS.has(ext)) {
+      throw new Error(`Unsupported file type: "${filename}"`);
+    }
+    const resolved = path.join(os.tmpdir(), filename);
+    if (path.dirname(resolved) !== path.normalize(os.tmpdir())) {
+      throw new Error(`Invalid file path: "${filename}"`);
+    }
+  }
 
+  private validateSupportingFiles(supportingFiles: SupportingFile[]): void {
+    const seen = new Set<string>();
+    let totalSize = 0;
+
+    for (const sf of supportingFiles) {
+      this.validateFilename(sf.filename);
+
+      if (seen.has(sf.filename)) {
+        throw new Error(`Duplicate supporting file name: "${sf.filename}"`);
+      }
+      seen.add(sf.filename);
+
+      const size = Buffer.byteLength(sf.content, "utf-8");
+      if (size > MAX_FILE_SIZE) {
+        throw new Error(`Supporting file "${sf.filename}" exceeds the 2 MB size limit`);
+      }
+      totalSize += size;
+    }
+
+    if (totalSize > MAX_TOTAL_SIZE) {
+      throw new Error("Total size of supporting files exceeds the 10 MB limit");
+    }
+  }
+
+  private validateSource(source: string): void {
+    const size = Buffer.byteLength(source, "utf-8");
+    if (size > MAX_SOURCE_SIZE) {
+      throw new Error("LaTeX source exceeds the 500 KB size limit");
+    }
+
+    for (const pattern of DANGEROUS_PATTERNS) {
+      if (pattern.test(source)) {
+        throw new Error("LaTeX source contains a disallowed command");
+      }
+    }
+  }
   async compile(source: string, supportingFiles: SupportingFile[] = []): Promise<Buffer> {
+    this.validateSource(source);
+    this.validateSupportingFiles(supportingFiles);
     // Try local pdflatex first (if not already known to be missing)
     if (this.pdflatexAvailable !== false) {
       try {


### PR DESCRIPTION
# Pull Request

## Description
Describe your changes.

## Related Issue
Fixes #2604

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
Explain how you tested it.

## Screenshots / Video

> **REQUIRED for any UI change.** PRs that modify visible UI (layout, components, styles, pages) will be rejected without this.

<!-- Add a screenshot or screen recording below. Drag and drop images/GIFs here, or paste a video link. -->

_No UI changes in this PR_ (delete this line if you are making UI changes)

## Checklist
- [ ] Code follows project guidelines
- [ ] No new compile/type errors
- [ ] Tested manually (include steps above)
- [ ] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [ ] **Screenshot or video attached for every UI change** (PR will be rejected if missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LaTeX compilation now rejects unsafe source content before running, helping prevent failed or risky submissions.
  * Supporting files are validated more strictly, including filename rules, allowed file types, duplicate names, and size limits.
  * Large uploads are now blocked earlier, with limits applied to the main LaTeX source, each file, and the total attachment bundle.
  * Validation is enforced consistently across both local and online compilation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->