### PR TITLE
fix: clear dangling setTimeout after Promise.race in scraper timeout handler

### DIFF
--- a/server/src/module/scraper/scraper.service.ts
+++ b/server/src/module/scraper/scraper.service.ts
@@ -91,13 +91,13 @@ export class ScraperService {
     for (const scraper of this.scrapers) {
       const startTime = Date.now();
 
+      let timer: ReturnType<typeof setTimeout> | undefined;
       try {
-        let timer: ReturnType<typeof setTimeout>;
         const timeoutPromise = new Promise<never>((_resolve, reject) => {
           timer = setTimeout(() => reject(new Error("Scraper timeout exceeded")), SCRAPER_TIMEOUT);
         });
         const result = await Promise.race([scraper.scrape(), timeoutPromise]);
-        clearTimeout(timer!);
+        clearTimeout(timer);
         const { created, updated } = await this.upsertJobs(result.source, result.jobs);
 
         const duration = Date.now() - startTime;
@@ -128,7 +128,7 @@ export class ScraperService {
           `[Scraper] ${result.source}: found=${String(result.jobs.length)}, created=${String(created)}, updated=${String(updated)}, duration=${String(duration)}ms`
         );
       } catch (err) {
-        clearTimeout(timer!);
+        if (timer) clearTimeout(timer);
         const duration = Date.now() - startTime;
         const errorMsg = err instanceof Error ? err.message : "Unknown error";
 

--- a/server/src/module/scraper/scraper.service.ts
+++ b/server/src/module/scraper/scraper.service.ts
@@ -92,10 +92,12 @@ export class ScraperService {
       const startTime = Date.now();
 
       try {
-        const timeoutPromise = new Promise<never>((_resolve, reject) =>
-          setTimeout(() => reject(new Error("Scraper timeout exceeded")), SCRAPER_TIMEOUT),
-        );
+        let timer: ReturnType<typeof setTimeout>;
+        const timeoutPromise = new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error("Scraper timeout exceeded")), SCRAPER_TIMEOUT);
+        });
         const result = await Promise.race([scraper.scrape(), timeoutPromise]);
+        clearTimeout(timer!);
         const { created, updated } = await this.upsertJobs(result.source, result.jobs);
 
         const duration = Date.now() - startTime;
@@ -126,6 +128,7 @@ export class ScraperService {
           `[Scraper] ${result.source}: found=${String(result.jobs.length)}, created=${String(created)}, updated=${String(updated)}, duration=${String(duration)}ms`
         );
       } catch (err) {
+        clearTimeout(timer!);
         const duration = Date.now() - startTime;
         const errorMsg = err instanceof Error ? err.message : "Unknown error";
 


### PR DESCRIPTION
Closes #2615

When scraper.scrape() wins the Promise.race, the timeoutPromise's setTimeout remains active for the full 5-minute SCRAPER_TIMEOUT, keeping the event loop open. This stores the timer reference and clears it after the race completes (or on error).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scraper timeout handling by reliably stopping long-running scraping tasks.
  * Ensured timeout timers are cleared after both successful runs and failures, reducing the chance of lingering timers or duplicate timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->