### PR TITLE
fix: replace non-null assertions with explicit user id guard in notes controller

### DIFF
--- a/server/src/module/notes/notes.controller.ts
+++ b/server/src/module/notes/notes.controller.ts
@@ -6,7 +6,9 @@ export class NotesController {
 
   async getNotes(req: Request, res: Response, next: NextFunction) {
     try {
-      const notes = await this.notesService.getNotes(req.user!.id, req.query as any);
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: "Unauthorized" });
+      const notes = await this.notesService.getNotes(userId, req.query as any);
       res.json({ notes });
     } catch (err) {
       next(err);
@@ -15,9 +17,11 @@ export class NotesController {
 
   async getNote(req: Request, res: Response, next: NextFunction) {
     try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: "Unauthorized" });
       const { contentType, contentId } = req.params;
       const note = await this.notesService.getNote(
-        req.user!.id,
+        userId,
         contentType as any,
         contentId as string
       );
@@ -29,10 +33,12 @@ export class NotesController {
 
   async saveNote(req: Request, res: Response, next: NextFunction) {
     try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: "Unauthorized" });
       const { contentType, contentId } = req.params;
       const { note } = req.body;
       const saved = await this.notesService.saveNote(
-        req.user!.id,
+        userId,
         contentType as any,
         contentId as string,
         note
@@ -45,9 +51,11 @@ export class NotesController {
 
   async deleteNote(req: Request, res: Response, next: NextFunction) {
     try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: "Unauthorized" });
       const { contentType, contentId } = req.params;
       const result = await this.notesService.deleteNote(
-        req.user!.id,
+        userId,
         contentType as any,
         contentId as string
       );


### PR DESCRIPTION
Closes #2618

Replaces req.user!.id non-null assertions (4 occurrences) with optional chaining and an explicit 401 guard, preventing runtime crashes if req.user is somehow missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notes actions now return a clear `401 Unauthorized` response when no authenticated user is present.
  * Viewing, saving, and deleting notes now consistently require a valid signed-in session, preventing unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->