### PR TITLE
fix: restore subscriptionPlan on renew to prevent plan loss after expiration

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -327,9 +327,13 @@ export class PaymentService {
     });
     if (!payment) return;
 
+    const billing = sub.metadata["billing"] ?? "monthly";
+    const plan = billing === "yearly" ? "YEARLY" : "MONTHLY";
+
     await prisma.user.update({
       where: { id: payment.userId },
       data: {
+        subscriptionPlan: plan,
         subscriptionStatus: "ACTIVE",
         subscriptionEndDate: new Date(sub.next_billing_date),
       },


### PR DESCRIPTION
Closes #2619

When a subscription renews, renewSubscription only updates subscriptionStatus and subscriptionEndDate but does not restore subscriptionPlan. This means a YEARLY subscriber whose subscription expired would lose their plan tier on renewal. Fix reads billing from metadata (same pattern as activateSubscription) and restores the plan.