### PR TITLE
fix: replace Math.random() with crypto.randomInt for OTP generation

### DIFF
--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -77,7 +77,7 @@ function buildAuthUser(user: AuthUser): AuthUser {
 
 /** Generate a 6-digit OTP with its hash and expiry timestamp. */
 async function generateOtp() {
-  const otp = Math.floor(100000 + Math.random() * 900000).toString();
+  const otp = crypto.randomInt(100000, 1000000).toString();
   const hashedOtp = await hashPassword(otp);
   const expiresAt = new Date(Date.now() + OTP_TTL_MS);
   return { otp, hashedOtp, expiresAt };


### PR DESCRIPTION
This PR addresses #2643.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved one-time password generation to use a more secure random source, making OTPs less predictable.
  - OTP hashing, expiry, and delivery behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->