### PR TITLE
fix: prevent email enumeration by returning identical response shape for all register outcomes

### DIFF
--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -34,8 +34,8 @@ export class AuthController {
       // Body is already validated & typed by route-level validateBody(registerSchema)
       const input = req.body as z.infer<typeof registerSchema>;
 
-      const data = await this.authService.register(input);
-      return res.status(201).json({ message: "Registration successful. Please verify your email to continue.", user: data.user });
+      await this.authService.register(input);
+      return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });
     } catch (error) {
       if (error instanceof Error && error.message === "Email already registered") {
         return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });


### PR DESCRIPTION
This PR addresses #2644.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registration now returns a simpler success response without including user details.
  * Existing validation and error messages for duplicate email and server errors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->