### PR TITLE
fix: align default AWS region in upload validation with controller (ap-south-1)

### DIFF
--- a/server/src/module/upload/upload.validation.ts
+++ b/server/src/module/upload/upload.validation.ts
@@ -4,7 +4,7 @@ import type { Request, Response, NextFunction } from "express";
 // Helper function to validate S3 URLs from authorized bucket
 const validateS3Url = (url: string): boolean => {
   const allowedBucket = process.env.AWS_S3_BUCKET || "internhack-uploads";
-  const region = process.env.AWS_REGION || "us-east-1";
+  const region = process.env.AWS_REGION || "ap-south-1";
 
   // Check if URL is from authorized S3 bucket
   const validPatterns = [


### PR DESCRIPTION
This PR addresses #2646.