### PR TITLE
fix: log admin opensource cache invalidation failures

### DIFF
--- a/server/src/module/admin/admin-opensource.service.ts
+++ b/server/src/module/admin/admin-opensource.service.ts
@@ -1,7 +1,10 @@
 import { prisma } from "../../database/db.js";
 import { cacheDel } from "../../utils/cache.js";
+import { createLogger } from "../../utils/logger.js";
 import { LANGUAGES_CACHE_KEY } from "../opensource/opensource.service.js";
 import type { Prisma } from "@prisma/client";
+
+const logger = createLogger("AdminOpensourceService");
 
 export class AdminOpensourceService {
   async listRepos(query: {
@@ -124,7 +127,9 @@ export class AdminOpensourceService {
         hacktoberfest: input.hacktoberfest ?? false,
       },
     });
-    cacheDel(LANGUAGES_CACHE_KEY).catch(() => {});
+    cacheDel(LANGUAGES_CACHE_KEY).catch((error) => {
+      logger.error("Failed to clear languages cache after repo creation", error);
+    });
     return repo;
   }
 
@@ -172,7 +177,11 @@ export class AdminOpensourceService {
       data.hacktoberfest = input["hacktoberfest"] as boolean;
 
     const updated = await prisma.opensourceRepo.update({ where: { id: repoId }, data });
-    if (languageChanged) cacheDel(LANGUAGES_CACHE_KEY).catch(() => {});
+    if (languageChanged) {
+      cacheDel(LANGUAGES_CACHE_KEY).catch((error) => {
+        logger.error("Failed to clear languages cache after repo update", error, { repoId });
+      });
+    }
     return updated;
   }
 
@@ -182,7 +191,9 @@ export class AdminOpensourceService {
     });
     if (!repo) throw new Error("Repository not found");
     const result = await prisma.opensourceRepo.delete({ where: { id: repoId } });
-    cacheDel(LANGUAGES_CACHE_KEY).catch(() => {});
+    cacheDel(LANGUAGES_CACHE_KEY).catch((error) => {
+      logger.error("Failed to clear languages cache after repo deletion", error, { repoId });
+    });
     return result;
   }
 


### PR DESCRIPTION
## Summary
- replace silent `cacheDel(...).catch(() => {})` handlers with structured logger calls
- preserve the existing non-blocking cache invalidation flow while surfacing failures for diagnosis

Closes #2638

## Validation
- git diff --check
- inspected touched cache invalidation paths in `server/src/module/admin/admin-opensource.service.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of repository language updates by logging cache refresh failures instead of failing silently.
  * Cache cleanup continues to run after create, update, and delete actions, with better error visibility when refreshes do not complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->