### PR TITLE
fix: return 409 for duplicate email registration

### DIFF
--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -38,7 +38,7 @@ export class AuthController {
       return res.status(201).json({ message: "Registration successful. Please verify your email to continue.", user: data.user });
     } catch (error) {
       if (error instanceof Error && error.message === "Email already registered") {
-        return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });
+        return res.status(409).json({ message: error.message });
       }
       console.error(error);
       return res.status(500).json({ message: "Internal Server Error" });


### PR DESCRIPTION
## Summary
- return HTTP 409 when registration uses an already registered email
- keep the response body aligned with the actual error instead of reporting a successful creation

Closes #2634

## Validation
- git diff --check
- inspected controller diff in `server/src/module/auth/auth.controller.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registration now returns a more appropriate **409 Conflict** when an email is already registered.
  * Error responses now show the specific message returned by the system instead of a generic success message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->