### PR TITLE
fix: log mock interview fallback when Gemini is unavailable

### DIFF
--- a/server/src/module/student/student.service.ts
+++ b/server/src/module/student/student.service.ts
@@ -3,7 +3,10 @@ import { Prisma } from "@prisma/client";
 import { sendEmail } from "../../utils/email.utils.js";
 import { buildUnsubscribeUrl } from "../../utils/unsubscribe.utils.js";
 import { milestoneEmailHtml } from "../../utils/email-templates.js";
+import { createLogger } from "../../utils/logger.js";
 import { GoogleGenerativeAI } from "@google/generative-ai";
+
+const logger = createLogger("StudentService");
 
 interface MockInterviewTranscriptEntry {
   question: string;
@@ -29,6 +32,7 @@ export class StudentService {
     const apiKey = process.env.GEMINI_API_KEY;
 
     if (!apiKey) {
+      logger.warn("GEMINI_API_KEY not configured, falling back to generic mock interview feedback");
       return { feedback: fallbackFeedback, fallbackUsed: true };
     }
 


### PR DESCRIPTION
## Summary
- add a structured warning when mock interview feedback falls back because `GEMINI_API_KEY` is missing
- keep the existing fallback response behavior unchanged while making the degraded path observable

Closes #2635

## Validation
- git diff --check
- inspected touched fallback path in `server/src/module/student/student.service.ts`