### PR TITLE
fix(job-feed): distinguish expected P2025 from unexpected errors in dismissJob

### DIFF
--- a/server/src/module/job-feed/job-feed.service.ts
+++ b/server/src/module/job-feed/job-feed.service.ts
@@ -1,4 +1,5 @@
-﻿import { prisma } from "../../database/db.js";
+﻿import { Prisma } from "@prisma/client";
+import { prisma } from "../../database/db.js";
 import { jobIndexService } from "../job-index/job-index.service.js";
 import { cacheGet, cacheSet, cacheDel } from "../../utils/cache.js";
 
@@ -59,7 +60,12 @@ export class JobFeedService {
     await prisma.userJobPreference.update({
       where: { userId },
       data: { dismissedJobIds: { push: match.jobIndexId } },
-    }).catch((err) => console.error("Failed to dismiss job:", err)); // pref may not exist yet
+    }).catch((err) => {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025") {
+        return;
+      }
+      throw err;
+    });
   }
 
   async save(userId: number, matchId: number) {

--- a/server/src/module/signals/signals.service.ts
+++ b/server/src/module/signals/signals.service.ts
@@ -129,15 +129,18 @@ export class SignalsService {
     for (const src of this.sources) {
       const startTime = Date.now();
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), SOURCE_TIMEOUT);
+      const abortTimeoutId = setTimeout(() => controller.abort(), SOURCE_TIMEOUT);
+      let raceTimeoutId = undefined as NodeJS.Timeout | undefined;
+      const raceTimeout = new Promise<never>((_r, reject) => {
+        raceTimeoutId = setTimeout(() => reject(new Error("Source timeout exceeded")), SOURCE_TIMEOUT);
+      });
       try {
         const result = await Promise.race([
           src.fetch(controller.signal),
-          new Promise<never>((_r, reject) =>
-            setTimeout(() => reject(new Error("Source timeout exceeded")), SOURCE_TIMEOUT)
-          )
+          raceTimeout,
         ]);
-        clearTimeout(timeoutId);
+        clearTimeout(abortTimeoutId);
+        if (raceTimeoutId) clearTimeout(raceTimeoutId);
         const { created, updated } = await this.upsertSignals(result.source, result.signals);
         const duration = Date.now() - startTime;
 
@@ -166,6 +169,8 @@ export class SignalsService {
           `[Signals] ${result.source}: found=${String(result.signals.length)}, created=${String(created)}, updated=${String(updated)}, duration=${String(duration)}ms`,
         );
       } catch (err) {
+        clearTimeout(abortTimeoutId);
+        if (raceTimeoutId) clearTimeout(raceTimeoutId);
         const duration = Date.now() - startTime;
         const message = err instanceof Error ? err.message : "Unknown error";
         results.push({


### PR DESCRIPTION
## Description

The dismissJob catch block swallowed **all** errors via console.error, including database connection failures, validation errors, and constraint violations. Only Prisma P2025 (record not found) is expected ? when the user preference does not exist yet.

## Changes

- Imported Prisma from @prisma/client for type-safe error checking
- Only catch P2025 errors; re-throw all others
- Expected errors are silently ignored (pref doesn't exist yet is normal)
- Unexpected errors propagate to the error middleware for proper logging

Fixes #2617


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when dismissing an item that is no longer available, preventing unnecessary errors while still surfacing real issues.
  * Made source processing more reliable by better managing timeouts and cleanup, reducing stuck or misleading failure states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->