### PR TITLE
fix(signals): clear both timeouts to prevent timer leaks and unhandled rejections

### DIFF
--- a/server/src/module/signals/signals.service.ts
+++ b/server/src/module/signals/signals.service.ts
@@ -129,15 +129,18 @@ export class SignalsService {
     for (const src of this.sources) {
       const startTime = Date.now();
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), SOURCE_TIMEOUT);
+      const abortTimeoutId = setTimeout(() => controller.abort(), SOURCE_TIMEOUT);
+      let raceTimeoutId = undefined as NodeJS.Timeout | undefined;
+      const raceTimeout = new Promise<never>((_r, reject) => {
+        raceTimeoutId = setTimeout(() => reject(new Error("Source timeout exceeded")), SOURCE_TIMEOUT);
+      });
       try {
         const result = await Promise.race([
           src.fetch(controller.signal),
-          new Promise<never>((_r, reject) =>
-            setTimeout(() => reject(new Error("Source timeout exceeded")), SOURCE_TIMEOUT)
-          )
+          raceTimeout,
         ]);
-        clearTimeout(timeoutId);
+        clearTimeout(abortTimeoutId);
+        if (raceTimeoutId) clearTimeout(raceTimeoutId);
         const { created, updated } = await this.upsertSignals(result.source, result.signals);
         const duration = Date.now() - startTime;
 
@@ -166,6 +169,8 @@ export class SignalsService {
           `[Signals] ${result.source}: found=${String(result.signals.length)}, created=${String(created)}, updated=${String(updated)}, duration=${String(duration)}ms`,
         );
       } catch (err) {
+        clearTimeout(abortTimeoutId);
+        if (raceTimeoutId) clearTimeout(raceTimeoutId);
         const duration = Date.now() - startTime;
         const message = err instanceof Error ? err.message : "Unknown error";
         results.push({


### PR DESCRIPTION
## Description

The source ingest created TWO independent timeouts that both fire at SOURCE_TIMEOUT:
1. controller.abort() via setTimeout ? hard-aborts the fetch
2. A race-rejection setTimeout ? rejects the race with 'Source timeout exceeded'

Only timeout #1 was cleared. Timeout #2 was never cleared. In both success and failure scenarios, the second timeout fires on an already-settled Promise, causing an unhandledPromiseRejection.

With 4 signal sources per ingest cycle (every 6 hours), this leaked 4 timer handles + 4 unhandled rejections per run.

## Changes

- Named both timeout IDs: bortTimeoutId and aceTimeoutId
- Cleared both timeouts on both success and error paths
- The aceTimeoutId is declared as let so it's accessible in catch

Fixes #2616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source ingestion timeout handling to reduce hangs and make timeouts fail more consistently.
  * Ingestion jobs now clean up timeout timers more reliably, which helps prevent lingering background activity after success or failure.
  * Failed sources now produce clearer timeout-related errors and more consistent logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->