### PR TITLE
fix(job-index): add console.error logging to semanticSearch catch block

### DIFF
--- a/server/src/module/job-index/job-index.service.ts
+++ b/server/src/module/job-index/job-index.service.ts
@@ -339,8 +339,8 @@ export class JobIndexService {
         limit,
       );
       return jobs;
-    } catch {
-      // pgvector / embedding column not set up yet, fall back to empty
+    } catch (err) {
+      console.error("[JobIndex] semanticSearch failed:", err);
       return [];
     }
   }


### PR DESCRIPTION
Add console.error logging to semanticSearch catch block so operators can see database failures.

Fixes #2667


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search error handling so failures are now logged before returning no results, making issues easier to diagnose.
  * Search behavior still returns an empty result when an error occurs, preserving the existing user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->