### PR TITLE
fix(opensource): add console.error logging to empty email catch blocks

### DIFF
--- a/server/src/module/opensource/opensource.service.ts
+++ b/server/src/module/opensource/opensource.service.ts
@@ -393,8 +393,8 @@ export class OpensourceService {
           request.owner,
         ),
       });
-    } catch {
-      /* email failure is non-blocking */
+      } catch (err) {
+      console.error("Failed to send repo request email:", err);
     }
     return request;
   }
@@ -474,8 +474,8 @@ export class OpensourceService {
           request.owner,
         ),
       });
-    } catch {
-      /* email failure is non-blocking */
+      } catch (err) {
+      console.error("Failed to send repo approval email:", err);
     }
 
     // Invalidate language list — new repo may introduce a new language


### PR DESCRIPTION
Add console.error logging to two empty email catch blocks that silently swallowed send failures.

Fixes #2668
