### PR TITLE
fix: prevent email enumeration by returning identical response for all register outcomes

### DIFF
--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -35,7 +35,7 @@ export class AuthController {
       const input = req.body as z.infer<typeof registerSchema>;
 
       const data = await this.authService.register(input);
-      return res.status(201).json({ message: "Registration successful. Please verify your email to continue.", user: data.user });
+      return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });
     } catch (error) {
       if (error instanceof Error && error.message === "Email already registered") {
         return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });


### PR DESCRIPTION
Fixes #2644

Returns an identical response shape (`{ message }` without `user`) for both successful registration and duplicate email, so attackers cannot enumerate registered emails by checking for the `user` field.

This contribution is part of GSSoC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registration responses now return a consistent message-only payload, avoiding exposure of the newly created user details.
  * The “email already registered” response remains unchanged and now matches the success response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->