### PR TITLE
fix: remove hardcoded admin email fallback in error middleware and expert-session service

### DIFF
--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -4,7 +4,7 @@ import { prisma } from "../database/db.js";
 import { sendEmail } from "../utils/email.utils.js";
 import { FileUploadError } from "../lib/errors.js";
 
-const ADMIN_ALERT_EMAIL = process.env["ADMIN_ALERT_EMAIL"] ?? "mrsachinchaurasiya@gmail.com";
+const ADMIN_ALERT_EMAIL = process.env["ADMIN_ALERT_EMAIL"] ?? "";
 
 const SENSITIVE_KEYS = new Set([
   "password", "newPassword", "confirmPassword", "currentPassword",

--- a/server/src/module/expert-session/expert-session.service.ts
+++ b/server/src/module/expert-session/expert-session.service.ts
@@ -8,7 +8,7 @@ const BUSINESS_END_HOUR = 18; // last slot starts 17:30, ends 18:00 IST
 const LOOKAHEAD_DAYS = 14;
 const MIN_LEAD_HOURS = 12;
 
-const ADMIN_ALERT_EMAIL = process.env["ADMIN_ALERT_EMAIL"] ?? "mrsachinchaurasiya@gmail.com";
+const ADMIN_ALERT_EMAIL = process.env["ADMIN_ALERT_EMAIL"] ?? "";
 
 interface IstParts {
   year: number;


### PR DESCRIPTION
Fixes #2658

Removes the personal email fallback (`mrsachinchaurasiya@gmail.com`) from both `error.middleware.ts` and `expert-session.service.ts`. Both now use `process.env["ADMIN_ALERT_EMAIL"] ?? ""` so the send will fail explicitly if the env var is not set, instead of silently leaking the maintainer's email.

This contribution is part of GSSoC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated admin alert email handling to use a blank default when no email address is configured, avoiding unintended delivery to a fallback address.
  * Improved consistency in booking confirmation notifications by relying on the configured email setting only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->