### PR TITLE
fix: make VERIFICATION_SECRET throw on missing env var instead of falling back to JWT_SECRET

### DIFF
--- a/server/src/utils/jwt.utils.ts
+++ b/server/src/utils/jwt.utils.ts
@@ -2,7 +2,7 @@ import jwt from "jsonwebtoken";
 import type { UserRole } from "@prisma/client";
 
 const JWT_SECRET: string = process.env["JWT_SECRET"] ?? (() => { throw new Error("JWT_SECRET environment variable is required"); })();
-const VERIFICATION_SECRET: string = process.env["VERIFICATION_SECRET"] ?? JWT_SECRET;
+const VERIFICATION_SECRET: string = process.env["VERIFICATION_SECRET"] ?? (() => { throw new Error("VERIFICATION_SECRET environment variable is required"); })();
 
 const JWT_EXPIRES_IN = "7d";
 const VERIFICATION_EXPIRES_IN = "365d";


### PR DESCRIPTION
Fixes #2659

Changes `VERIFICATION_SECRET` to throw immediately if the env var is not set, matching the `JWT_SECRET` pattern. This prevents silent token-type isolation breakage where verification tokens could be confused with auth tokens.

This contribution is part of GSSoC.