### PR TITLE
perf: add database indexes on dsaProblemReport foreign keys to prevent full table scans

### DIFF
--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -629,6 +629,9 @@ model dsaProblemReport {
   problemId Int
   problem   dsaProblem @relation(fields: [problemId], references: [id], onDelete: Cascade)
   user      user       @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([problemId])
 }
 
 model studentDsaProgress {


### PR DESCRIPTION
Fixes #2660

Adds `@@index([userId])` and `@@index([problemId])` on `dsaProblemReport` to prevent full table scans when querying reports by user or problem. The `contactSubmission` model already has `@@index([createdAt])`.

This contribution is part of GSSoC.