### PR TITLE
fix: add 30s request timeout to resend.batch.send() to prevent hanging workers

### DIFF
--- a/server/src/utils/email.utils.ts
+++ b/server/src/utils/email.utils.ts
@@ -148,7 +148,12 @@ export async function sendEmailBatch(
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      const result = await resend.batch.send(payload);
+      const result = await Promise.race([
+        resend.batch.send(payload),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("Resend batch.send timed out after 30s")), 30_000)
+        ),
+      ]);
       if (result.error) {
         const status = (result.error as { statusCode?: number }).statusCode;
         if (status === 429 && attempt < maxRetries) {


### PR DESCRIPTION
Fixes #2661

Wraps the `resend.batch.send(payload)` call with an AbortController-based 30-second timeout using a Promise.race pattern. If the request hangs longer than 30s, it throws a timeout error that triggers the existing retry logic. This prevents cron/serverless workers from blocking indefinitely on an unresponsive Resend API.

This contribution is part of GSSoC.