### PR TITLE
fix: sync OssContributionHeatmap selectedYear with availableYears after data loads

### DIFF
--- a/client/src/components/OssContributionHeatmap.tsx
+++ b/client/src/components/OssContributionHeatmap.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ActivityCalendar } from "react-activity-calendar";
 import api from "../lib/axios";
@@ -57,6 +57,10 @@ export const OssContributionHeatmap = React.memo(function OssContributionHeatmap
   }, [data]);
 
   const [selectedYear, setSelectedYear] = useState<number>(availableYears[0] ?? new Date().getFullYear());
+
+  useEffect(() => {
+    setSelectedYear((prev) => (availableYears.includes(prev) ? prev : (availableYears[0] ?? new Date().getFullYear())));
+  }, [availableYears]);
 
   const heatmapData = useMemo(() => {
     if (!data || data.length === 0) return null;


### PR DESCRIPTION
Fixes #2662

Adds a `useEffect` to update `selectedYear` when `availableYears` changes (i.e. after the async query completes). Previously `selectedYear` was initialized once on mount with the fallback `availableYears[0]` (current year), and never updated when real data arrived — causing the heatmap to show empty for years outside the data range.

This contribution is part of GSSoC.