### PR TITLE
fix: wire Zod validation schemas into upload routes

### DIFF
--- a/server/src/module/upload/upload.routes.ts
+++ b/server/src/module/upload/upload.routes.ts
@@ -6,6 +6,10 @@ import {
   validateBody,
   presignRequestSchema,
   guestPresignRequestSchema,
+  uploadProfilePicSchema,
+  uploadCoverImageSchema,
+  uploadResumeSchema,
+  deleteResumeSchema,
 } from "./upload.validation.js";
 
 const uploadController = new UploadController();
@@ -46,7 +50,7 @@ uploadRouter.post(
   (req, res) => uploadController.getPresignedUrl(req, res),
 );
 
-uploadRouter.post("/profile-pic", (req, res) => uploadController.uploadProfilePic(req, res));
-uploadRouter.post("/cover-image", (req, res) => uploadController.uploadCoverImage(req, res));
-uploadRouter.post("/profile-resume", (req, res) => uploadController.uploadProfileResume(req, res));
-uploadRouter.delete("/profile-resume", (req, res) => uploadController.deleteProfileResume(req, res));
+uploadRouter.post("/profile-pic", validateBody(uploadProfilePicSchema), (req, res) => uploadController.uploadProfilePic(req, res));
+uploadRouter.post("/cover-image", validateBody(uploadCoverImageSchema), (req, res) => uploadController.uploadCoverImage(req, res));
+uploadRouter.post("/profile-resume", validateBody(uploadResumeSchema), (req, res) => uploadController.uploadProfileResume(req, res));
+uploadRouter.delete("/profile-resume", validateBody(deleteResumeSchema), (req, res) => uploadController.deleteProfileResume(req, res));


### PR DESCRIPTION
## Description
Four Zod validation schemas defined in `upload.validation.ts` were never wired into the routes. This PR imports them and adds `validateBody(schema)` middleware to the 4 upload routes, consistent with every other module in the codebase.

**Schemas wired:**
- `uploadProfilePicSchema` → `POST /profile-pic`
- `uploadCoverImageSchema` → `POST /cover-image`
- `uploadResumeSchema` → `POST /profile-resume`
- `deleteResumeSchema` → `DELETE /profile-resume`

Fixes #2678


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added request validation for profile upload actions, including profile picture, cover image, profile resume, and resume deletion.
  * Users will now receive clearer feedback when required upload details are missing or invalid before the request is processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->