### PR TITLE
fix: remove dead guestResult computation in getPublicProfile

### DIFF
--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -492,10 +492,6 @@ export class AuthService {
     const fullResult = {
       ...rest,
     };
-    // Guest-safe view: strip PII regardless of who triggered the request.
-    const { email: _email, contactNo: _contactNo, ...guestRest } = fullResult as any;
-    const guestResult = guestRest;
-
     // Authorized tier (admin): cache and return the full view under
     // the ":auth" key, which is only ever served back to authorized viewers.
     if (isVisitorAuthorized) {
@@ -506,7 +502,7 @@ export class AuthService {
     // Only the owner reaches this point (non-owner, non-authorized visitors are
     // rejected above). Return the owner's full view; never cache under the
     // shared key so it can't be served to another visitor.
-    return { profile: isOwner ? fullResult : guestResult, cacheHit: false };
+    return { profile: fullResult, cacheHit: false };
   }
 
   async verifyEmail(email: string, otp: string) {


### PR DESCRIPTION
## Description
Removes dead `guestResult` computation in `getPublicProfile()`. The `guestResult` variable was computed on every profile request (lines 496-497) but never used — non-owner/non-authorized visitors are rejected at line 482, authorized viewers return early at line 503, and the ternary at line 509 always takes the `fullResult` branch since only the owner reaches it.

**Changes:**
- Removed the `guestResult` destructure/computation (5 lines)
- Simplified return to `{ profile: fullResult, cacheHit: false }`

Fixes #2677


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated public profile responses so authenticated viewers receive the full profile data after access checks.
  * Kept admin caching behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->