### PR TITLE
fix: scope hardcoded tech keyword filter to adzuna source only

### DIFF
--- a/server/src/module/scraper/scraper.service.ts
+++ b/server/src/module/scraper/scraper.service.ts
@@ -259,20 +259,32 @@ export class ScraperService {
     // so users only see tech roles even before the 48h expiry sweep clears
     // them. Other sources (linkedin, arbeitnow) are tech-focused already.  
   const conditions: Prisma.scrapedJobWhereInput[] = [
-  {
-    OR: [
-      { title: { contains: "developer", mode: "insensitive" } },
-      { title: { contains: "engineer", mode: "insensitive" } },
-      { title: { contains: "software", mode: "insensitive" } },
-      { title: { contains: "frontend", mode: "insensitive" } },
-      { title: { contains: "backend", mode: "insensitive" } },
-      { title: { contains: "full stack", mode: "insensitive" } },
-      { title: { contains: "python", mode: "insensitive" } },
-      { title: { contains: "java", mode: "insensitive" } },
-      { title: { contains: "react", mode: "insensitive" } }, 
-    ],
-  },
-];
+    {
+      OR: [
+        // Non-adzuna sources (linkedin, arbeitnow) are already tech-focused.
+        { source: { not: "adzuna" } },
+        // Legacy adzuna rows may contain non-tech categories — filter to IT.
+        {
+          AND: [
+            { source: "adzuna" },
+            {
+              OR: [
+                { title: { contains: "developer", mode: "insensitive" } },
+                { title: { contains: "engineer", mode: "insensitive" } },
+                { title: { contains: "software", mode: "insensitive" } },
+                { title: { contains: "frontend", mode: "insensitive" } },
+                { title: { contains: "backend", mode: "insensitive" } },
+                { title: { contains: "full stack", mode: "insensitive" } },
+                { title: { contains: "python", mode: "insensitive" } },
+                { title: { contains: "java", mode: "insensitive" } },
+                { title: { contains: "react", mode: "insensitive" } },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ];
    
 
     if (query.search) {


### PR DESCRIPTION
## Description
The hardcoded tech keyword filter (lines 261-275) was applied globally to ALL scraped jobs, ANDed with any user search. This caused searches like "data scientist", "devops", "sde", "intern", etc. to return zero results even when matching ACTIVE rows existed.

**Fix:** Scope the tech keyword filter to only affect `adzuna` source rows. Non-adzuna sources (linkedin, arbeitnow) were already tech-focused per the original comment, so they bypass the filter entirely.

The condition now reads: "either the row is not from adzuna, OR (it is from adzuna AND its title matches one of the tech keywords)". This preserves the original intent (excluding legacy non-tech adzuna rows before the 48h expiry sweep) without silently breaking user searches or hiding non-keyword tech titles from other sources.

Fixes #2675
