### PR TITLE
fix: log forgot-password email failures

### DIFF
--- a/server/src/module/auth/auth.service.ts
+++ b/server/src/module/auth/auth.service.ts
@@ -691,7 +691,7 @@ export class AuthService {
       to: user.email,
       subject: "Reset your InternHack password",
       html: resetPasswordEmailHtml(user.name, otp),
-    });
+    }).catch((err) => console.error("Failed to send password reset email:", err));
   }
 
   async resetPassword(email: string, otp: string, newPassword: string) {
@@ -918,4 +918,3 @@ export class AuthService {
     return data;
   }
 }
-


### PR DESCRIPTION
## Summary
- add explicit error logging when forgot-password email delivery fails
- keep the existing anti-enumeration behavior unchanged
- match the sendEmail error handling pattern already used elsewhere in auth.service.ts

Closes #2693

## Validation
- git diff --check
- npm run lint -- server/src/module/auth/auth.service.ts (fails in this checkout because eslint is not installed locally)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of password reset email delivery failures by logging errors when messages cannot be sent.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->