### PR TITLE
fix: return updated blog view count

### DIFF
--- a/server/src/module/blog/blog.service.ts
+++ b/server/src/module/blog/blog.service.ts
@@ -101,12 +101,11 @@ export class BlogService {
       throw new Error("Post not found");
     }
 
-    await prisma.blogPost.update({
+    return prisma.blogPost.update({
       where: { id: post.id },
       data: { viewCount: { increment: 1 } },
+      include: { author: { select: authorSelect } },
     });
-
-    return { ...post, viewCount: post.viewCount + 1 };
   }
 
   async listAll(query: ListAllParams) {


### PR DESCRIPTION
## Summary
- return the updated blog post record directly from Prisma after incrementing viewCount
- ensure concurrent readers receive the authoritative database value instead of a stale pre-increment snapshot
- preserve the existing author include shape in the response

Closes #2694

## Validation
- git diff --check
- npm run typecheck (fails in this checkout because tsc is not installed locally)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blog post view-count updates for more reliable tracking.
  * Blog post details now reflect the incremented view count and include author information consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->