### PR TITLE
fix: serialize subscription activation

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -1,4 +1,5 @@
 import { DodoPayments } from "dodopayments";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../database/db.js";
 import { sendEmail } from "../../utils/email.utils.js";
 import { premiumConfirmationEmailHtml } from "../../utils/email-templates.js";
@@ -256,6 +257,8 @@ export class PaymentService {
           subscriptionEndDate: endDate,
         },
       });
+    }, {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
     });
 
     // Invalidate cache after transaction succeeds


### PR DESCRIPTION
## Summary
- add Serializable isolation to the subscription activation transaction
- align the implementation with the existing comment about duplicate webhook race protection
- prevent concurrent duplicate activations from observing stale PENDING state

Closes #2695

## Validation
- git diff --check
- npm run typecheck (fails in this checkout because tsc is not installed locally)
