### PR TITLE
Fix holdSubscription setting EXPIRED instead of ON_HOLD

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -363,7 +363,7 @@ export class PaymentService {
 
     await prisma.user.update({
       where: { id: payment.userId },
-      data: { subscriptionStatus: "EXPIRED" },
+      data: { subscriptionStatus: "ON_HOLD" },
     });
     await invalidateUserTierCache(payment.userId);
   }


### PR DESCRIPTION
## Summary
Changed `subscriptionStatus: "EXPIRED"` to `subscriptionStatus: "ON_HOLD"` in the `holdSubscription` method. This was a copy-paste error from `expireSubscription` directly above it.

Fixes #2699

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription status now correctly displays **On Hold** when a subscription is placed on hold, instead of **Expired**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->