### PR TITLE
Fix escapeHtml missing single-quote escaping in email-inbound controller

### DIFF
--- a/server/src/module/email-inbound/email-inbound.controller.ts
+++ b/server/src/module/email-inbound/email-inbound.controller.ts
@@ -138,5 +138,6 @@ function escapeHtml(str: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
 }


### PR DESCRIPTION
## Summary
Added single-quote escaping (`&#x27;`) to the `escapeHtml` function in both `email-inbound.controller.ts` and `email-templates.ts`. Without this, user-controlled values with `'` characters could break out of HTML attributes.

Fixes #2700

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML safety when forwarding emails by escaping single quotation marks in email content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->