### PR TITLE
Fix lazyWithRetry global hasReloaded flag breaking retry for all routes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,14 +11,14 @@ import ScrollProgressBar from "./components/common/ScrollProgressBar";
 import ScrollToTop from "./components/common/ScrollToTop";
 const ContributorsPage = lazyWithRetry(() => import("./module/contributors/ContributorsPage"));
 
-let hasReloaded = false;
+const retryState = new Map<() => Promise<{ default: ComponentType<unknown> }>, boolean>();
 
 function lazyWithRetry<T extends ComponentType<unknown>>(factory: () => Promise<{ default: T }>): LazyExoticComponent<T> {
   return lazy(
     () =>
       factory().catch((err: unknown) => {
-        if (!hasReloaded) {
-          hasReloaded = true;
+        if (!retryState.get(factory)) {
+          retryState.set(factory, true);
           window.location.reload();
           return new Promise<never>(() => { });
         }


### PR DESCRIPTION
## Summary
Changed the module-scoped `hasReloaded` boolean to a per-factory `Map` so a chunk-load failure on one lazy route doesn't prevent retry for other lazy routes. Each import factory now tracks its own retry state.

Fixes #2701

GSSoC