### PR TITLE
Fix errorMiddleware partial string matching leaking raw error messages

### DIFF
--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -159,15 +159,15 @@ export function errorMiddleware(err: Error, req: Request, res: Response, _next: 
   // Fallback: try partial matches for dynamic error messages
   const msg = err.message.toLowerCase();
   if (msg.includes("not found")) {
-    respond(req, res, 404, err.message, err);
+    respond(req, res, 404, "Resource not found", err);
     return;
   }
   if (msg.includes("already") && (msg.includes("exists") || msg.includes("registered") || msg.includes("applied"))) {
-    respond(req, res, 409, err.message, err);
+    respond(req, res, 409, "Resource already exists", err);
     return;
   }
   if (msg.includes("unauthorized") || msg.includes("not authorized")) {
-    respond(req, res, 403, err.message, err);
+    respond(req, res, 403, "Not authorized", err);
     return;
   }
 


### PR DESCRIPTION
## Summary
Replaced `err.message` with generic messages in the partial-match fallback blocks of `errorMiddleware`. The raw error is still logged server-side but no longer leaked to the client in production.

Fixes #2702

GSSoC