### PR TITLE
Fix client crash on duplicate-email registration — data.user is undefined

### DIFF
--- a/client/src/module/auth/RegisterPage.tsx
+++ b/client/src/module/auth/RegisterPage.tsx
@@ -266,7 +266,7 @@ export default function RegisterPage() {
     try {
       const payload: Record<string, string> = { name: form.name, email: form.email, password: form.password };
       const { data } = await api.post("/auth/register", payload);
-      if (!data.user.isVerified) {
+      if (data.user && !data.user.isVerified) {
         navigate(`/verify-email?email=${encodeURIComponent(form.email)}`);
       } else {
         login(data.user);


### PR DESCRIPTION
## Summary
Added a null guard on the client side in `RegisterPage.tsx` for `data.user` before accessing `data.user.isVerified`. When the server catches "Email already registered", it returns a response without the `user` property, causing a `TypeError` on the client.

Fixes #2703

GSSoC