### PR TITLE
fix: add admin email notification to contact form (#2625)

### DIFF
--- a/server/src/module/contact/contact.routes.ts
+++ b/server/src/module/contact/contact.routes.ts
@@ -3,6 +3,9 @@ import type { Request, Response } from "express";
 import { prisma } from "../../database/db.js";
 import { contactSchema } from "./contact.validation.js";
 import { contactLimiter } from "../../middleware/rate-limit.middleware.js";
+import { sendEmail } from "../../utils/email.utils.js";
+
+const ADMIN_EMAIL = () => process.env.ADMIN_EMAIL || process.env.EMAIL_FROM || "";
 
 export const contactRouter = Router();
 
@@ -13,6 +16,21 @@ contactRouter.post("/", contactLimiter, async (req: Request, res: Response) => {
       return res.status(400).json({ message: "Validation failed", errors: parsed.error.issues });
     }
     await prisma.contactSubmission.create({ data: parsed.data });
+
+    const adminEmail = ADMIN_EMAIL();
+    if (adminEmail) {
+      const { name, email, subject, message } = parsed.data;
+      sendEmail({
+        to: adminEmail,
+        subject: `[Contact Form] ${subject}`,
+        html: `<p><strong>Name:</strong> ${name}</p>
+<p><strong>Email:</strong> ${email}</p>
+<p><strong>Subject:</strong> ${subject}</p>
+<p><strong>Message:</strong></p>
+<p>${message}</p>`,
+      }).catch((err) => console.error("Failed to send admin notification:", err));
+    }
+
     return res.status(201).json({ message: "Message sent successfully" });
   } catch {
     return res.status(500).json({ message: "Failed to send message" });


### PR DESCRIPTION
### Description

Adds an email notification to the admin/configured email address whenever a user submits the contact form.

### Changes
- Import sendEmail utility
- After saving the contact submission to the database, fire-and-forget an email with the contact details to the configured admin email
- Uses ADMIN_EMAIL env var, falling back to EMAIL_FROM

Closes #2625

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email notifications for administrators after successful contact form submissions.
  * Notifications include the submitter’s name, email address, subject, and message.

* **Bug Fixes**
  * Contact form responses are no longer interrupted if notification delivery fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->