### PR TITLE
fix: return 409 for duplicate email registration (#2644)

### DIFF
--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -38,7 +38,7 @@ export class AuthController {
       return res.status(201).json({ message: "Registration successful. Please verify your email to continue.", user: data.user });
     } catch (error) {
       if (error instanceof Error && error.message === "Email already registered") {
-        return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });
+        return res.status(409).json({ message: "Email already registered" });
       }
       console.error(error);
       return res.status(500).json({ message: "Internal Server Error" });


### PR DESCRIPTION
### Description

Fixes email enumeration vulnerability in the register endpoint.

### Changes
- Changed status code from 201 to 409 for duplicate email registration
- Returns error message instead of pretending success

Before: returned 201 with success message (inconsistent - no user field) -> leaks email existence
After: returns 409 Conflict with proper error message

Closes #2644

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Registration attempts using an already registered email now return a **409 Conflict** response instead of appearing successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->