### PR TITLE
fix: sync selectedYear when availableYears changes (#2662)

### DIFF
--- a/client/src/components/OssContributionHeatmap.tsx
+++ b/client/src/components/OssContributionHeatmap.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ActivityCalendar } from "react-activity-calendar";
 import api from "../lib/axios";
@@ -57,6 +57,10 @@ export const OssContributionHeatmap = React.memo(function OssContributionHeatmap
   }, [data]);
 
   const [selectedYear, setSelectedYear] = useState<number>(availableYears[0] ?? new Date().getFullYear());
+
+  useEffect(() => {
+    setSelectedYear(availableYears[0] ?? new Date().getFullYear());
+  }, [availableYears]);
 
   const heatmapData = useMemo(() => {
     if (!data || data.length === 0) return null;


### PR DESCRIPTION
### Description

Fixes stale selectedYear state in the contribution heatmap component. When data loads asynchronously, availableYears changes after initial render, but selectedYear remained at the initial value (current year), which could be outside the available years set, resulting in an empty heatmap.

### Changes
- Added useEffect to sync selectedYear when availableYears changes

Closes #2662

GSSoC