### PR TITLE
fix: close TOCTOU race condition in bookSession (double-booking) #2691

### DIFF
--- a/server/src/__tests__/expert-session.service.test.ts
+++ b/server/src/__tests__/expert-session.service.test.ts
@@ -17,9 +17,10 @@ vi.mock("../database/db.js", () => ({
       delete: vi.fn(),
       deleteMany: vi.fn(),
     },
-    // Default: run the callback with the same mocked client as its `tx`,
-    // matching the "tx === prisma" shape most tests rely on. The concurrency
-    // test below overrides this with a stateful in-memory DB instead.
+    // No default implementation here — each describe block below wires its
+    // own $transaction behavior in beforeEach (or per-test for the
+    // concurrency suite), since "tx === prisma" vs. a stateful in-memory DB
+    // are both valid depending on what's being tested.
     $transaction: vi.fn(),
   },
 }));

--- a/server/src/__tests__/expert-session.service.test.ts
+++ b/server/src/__tests__/expert-session.service.test.ts
@@ -17,6 +17,10 @@ vi.mock("../database/db.js", () => ({
       delete: vi.fn(),
       deleteMany: vi.fn(),
     },
+    // Default: run the callback with the same mocked client as its `tx`,
+    // matching the "tx === prisma" shape most tests rely on. The concurrency
+    // test below overrides this with a stateful in-memory DB instead.
+    $transaction: vi.fn(),
   },
 }));
 
@@ -116,6 +120,7 @@ describe("ExpertSessionService booking lifecycle", () => {
     vi.clearAllMocks();
     vi.mocked(prisma.expertAvailabilityBlock.findMany).mockResolvedValue([]);
     vi.mocked(prisma.expertSession.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.$transaction).mockImplementation((fn: any) => fn(prisma));
     service = new ExpertSessionService();
   });
 
@@ -187,5 +192,110 @@ describe("ExpertSessionService booking lifecycle", () => {
     await service.cancelPendingBooking("dodo_session_789");
 
     expect(prisma.expertSession.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe("ExpertSessionService.bookSession concurrency (regression for #2691)", () => {
+  // Real Postgres Serializable transactions guarantee that of two concurrent
+  // transactions touching the same row, exactly one commits and the other
+  // gets aborted with a serialization failure. This in-memory double
+  // reproduces that guarantee (transaction bodies run one at a time, and
+  // `create` enforces the same "one active session per scheduledAt" rule as
+  // the partial unique index added in
+  // 20260712000000_add_expert_session_slot_unique_index) so we can drive a
+  // genuine two-requests-race-for-one-slot scenario without a real database.
+  function makeInMemoryDb() {
+    const sessions: { scheduledAt: Date; status: string }[] = [];
+    let queue: Promise<unknown> = Promise.resolve();
+
+    const client = {
+      expertAvailabilityBlock: { findMany: vi.fn().mockResolvedValue([]) },
+      expertSession: {
+        findMany: vi.fn(async ({ where }: any) => {
+          return sessions
+            .filter(
+              (s) =>
+                s.status === "SCHEDULED" &&
+                s.scheduledAt.getTime() >= where.scheduledAt.gte.getTime() &&
+                s.scheduledAt.getTime() <= where.scheduledAt.lte.getTime(),
+            )
+            .map((s) => ({ scheduledAt: s.scheduledAt }));
+        }),
+        create: vi.fn(async ({ data }: any) => {
+          const clash = sessions.some(
+            (s) =>
+              s.scheduledAt.getTime() === data.scheduledAt.getTime() &&
+              (s.status === "PENDING_PAYMENT" || s.status === "SCHEDULED"),
+          );
+          if (clash) {
+            throw Object.assign(new Error("Unique constraint failed on the fields: (`scheduledAt`)"), {
+              code: "P2002",
+            });
+          }
+          const record = { id: sessions.length + 1, ...data };
+          sessions.push(record);
+          return record;
+        }),
+      },
+      $transaction: vi.fn((fn: any) => {
+        // Chain each transaction body onto the previous one so bodies never
+        // interleave — this is what Serializable isolation buys you for two
+        // transactions racing to write the same row.
+        const run = queue.then(() => fn(client));
+        queue = run.catch(() => {});
+        return run;
+      }),
+    };
+
+    return { client, sessions };
+  }
+
+  it("lets only one of two concurrent bookings for the same slot succeed", async () => {
+    const { client } = makeInMemoryDb();
+    vi.mocked(prisma.$transaction).mockImplementation(client.$transaction as any);
+    vi.mocked(prisma.expertAvailabilityBlock.findMany).mockImplementation(
+      client.expertAvailabilityBlock.findMany as any,
+    );
+    vi.mocked(prisma.expertSession.findMany).mockImplementation(client.expertSession.findMany as any);
+    vi.mocked(prisma.expertSession.create).mockImplementation(client.expertSession.create as any);
+
+    const service = new ExpertSessionService();
+    const [slot] = await service.getAvailableSlots(REFERENCE_NOW);
+
+    const results = await Promise.allSettled([
+      service.bookSession(1, { scheduledAt: slot!, focusAreas: ["System Design"] }, REFERENCE_NOW),
+      service.bookSession(2, { scheduledAt: slot!, focusAreas: ["DSA"] }, REFERENCE_NOW),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({
+      status: 409,
+      message: "This slot has just been booked. Please choose another available slot.",
+    });
+    expect(client.expertSession.create).toHaveBeenCalledTimes(2); // one succeeds, one hits the unique index
+  });
+
+  it("lets two concurrent bookings for different slots both succeed", async () => {
+    const { client } = makeInMemoryDb();
+    vi.mocked(prisma.$transaction).mockImplementation(client.$transaction as any);
+    vi.mocked(prisma.expertAvailabilityBlock.findMany).mockImplementation(
+      client.expertAvailabilityBlock.findMany as any,
+    );
+    vi.mocked(prisma.expertSession.findMany).mockImplementation(client.expertSession.findMany as any);
+    vi.mocked(prisma.expertSession.create).mockImplementation(client.expertSession.create as any);
+
+    const service = new ExpertSessionService();
+    const slots = await service.getAvailableSlots(REFERENCE_NOW);
+
+    const results = await Promise.allSettled([
+      service.bookSession(1, { scheduledAt: slots[0]!, focusAreas: [] }, REFERENCE_NOW),
+      service.bookSession(2, { scheduledAt: slots[1]!, focusAreas: [] }, REFERENCE_NOW),
+    ]);
+
+    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
   });
 });

--- a/server/src/__tests__/expert-session.service.test.ts
+++ b/server/src/__tests__/expert-session.service.test.ts
@@ -104,13 +104,25 @@ describe("ExpertSessionService.getAvailableSlots", () => {
     expect(sameDaySlots.some((s) => istTime(s) === "12:00")).toBe(true);
   });
 
-  it("excludes a slot already booked by a SCHEDULED session", async () => {
+ it("excludes a slot already booked by a SCHEDULED session", async () => {
     const all = await service.getAvailableSlots(REFERENCE_NOW);
     const target = all[0]!;
     vi.mocked(prisma.expertSession.findMany).mockResolvedValue([{ scheduledAt: target }] as any);
 
     const filtered = await service.getAvailableSlots(REFERENCE_NOW);
     expect(filtered.some((s) => s.getTime() === target.getTime())).toBe(false);
+  });
+
+  it("queries for SCHEDULED sessions plus only recent (non-stale) PENDING_PAYMENT holds", async () => {
+    await service.getAvailableSlots(REFERENCE_NOW);
+
+    const call = vi.mocked(prisma.expertSession.findMany).mock.calls[0]![0] as any;
+    expect(call.where.OR).toEqual([
+      { status: "SCHEDULED" },
+      { status: "PENDING_PAYMENT", createdAt: { gte: expect.any(Date) } },
+    ]);
+    const cutoff = call.where.OR[1].createdAt.gte as Date;
+    expect(REFERENCE_NOW.getTime() - cutoff.getTime()).toBe(15 * 60 * 1000);
   });
 });
 
@@ -206,7 +218,7 @@ describe("ExpertSessionService.bookSession concurrency (regression for #2691)", 
   // 20260712000000_add_expert_session_slot_unique_index) so we can drive a
   // genuine two-requests-race-for-one-slot scenario without a real database.
   function makeInMemoryDb() {
-    const sessions: { scheduledAt: Date; status: string }[] = [];
+    const sessions: { scheduledAt: Date; status: string; createdAt: Date }[] = [];
     let queue: Promise<unknown> = Promise.resolve();
 
     const client = {
@@ -222,6 +234,20 @@ describe("ExpertSessionService.bookSession concurrency (regression for #2691)", 
             )
             .map((s) => ({ scheduledAt: s.scheduledAt }));
         }),
+        deleteMany: vi.fn(async ({ where }: any) => {
+          const before = sessions.length;
+          for (let i = sessions.length - 1; i >= 0; i--) {
+            const s = sessions[i]!;
+            if (
+              s.scheduledAt.getTime() === where.scheduledAt.getTime() &&
+              s.status === where.status &&
+              s.createdAt.getTime() < where.createdAt.lt.getTime()
+            ) {
+              sessions.splice(i, 1);
+            }
+          }
+          return { count: before - sessions.length };
+        }),
         create: vi.fn(async ({ data }: any) => {
           const clash = sessions.some(
             (s) =>
@@ -233,7 +259,7 @@ describe("ExpertSessionService.bookSession concurrency (regression for #2691)", 
               code: "P2002",
             });
           }
-          const record = { id: sessions.length + 1, ...data };
+          const record = { id: sessions.length + 1, createdAt: new Date(), ...data };
           sessions.push(record);
           return record;
         }),
@@ -298,5 +324,34 @@ describe("ExpertSessionService.bookSession concurrency (regression for #2691)", 
     ]);
 
     expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+  });
+
+  it("reclaims a slot whose only holder is a stale (TTL-expired) PENDING_PAYMENT hold", async () => {
+    const { client, sessions } = makeInMemoryDb();
+    vi.mocked(prisma.$transaction).mockImplementation(client.$transaction as any);
+    vi.mocked(prisma.expertAvailabilityBlock.findMany).mockImplementation(
+      client.expertAvailabilityBlock.findMany as any,
+    );
+    vi.mocked(prisma.expertSession.findMany).mockImplementation(client.expertSession.findMany as any);
+    vi.mocked(prisma.expertSession.deleteMany).mockImplementation(client.expertSession.deleteMany as any);
+    vi.mocked(prisma.expertSession.create).mockImplementation(client.expertSession.create as any);
+
+    const service = new ExpertSessionService();
+    const [slot] = await service.getAvailableSlots(REFERENCE_NOW);
+
+    sessions.push({
+      scheduledAt: slot!,
+      status: "PENDING_PAYMENT",
+      createdAt: new Date(REFERENCE_NOW.getTime() - 20 * 60 * 1000),
+    });
+
+    const result = await service.bookSession(1, { scheduledAt: slot!, focusAreas: [] }, REFERENCE_NOW);
+
+    expect(result).toBeTruthy();
+    expect(client.expertSession.deleteMany).toHaveBeenCalled();
+    const activeForSlot = sessions.filter(
+      (s) => s.scheduledAt.getTime() === slot!.getTime() && s.status === "PENDING_PAYMENT",
+    );
+    expect(activeForSlot).toHaveLength(1);
   });
 });

--- a/server/src/__tests__/expert-session.service.test.ts
+++ b/server/src/__tests__/expert-session.service.test.ts
@@ -217,7 +217,7 @@ describe("ExpertSessionService.bookSession concurrency (regression for #2691)", 
   // the partial unique index added in
   // 20260712000000_add_expert_session_slot_unique_index) so we can drive a
   // genuine two-requests-race-for-one-slot scenario without a real database.
-  function makeInMemoryDb() {
+  function makeInMemoryDb(now: Date) {
     const sessions: { scheduledAt: Date; status: string; createdAt: Date }[] = [];
     let queue: Promise<unknown> = Promise.resolve();
 
@@ -259,7 +259,7 @@ describe("ExpertSessionService.bookSession concurrency (regression for #2691)", 
               code: "P2002",
             });
           }
-          const record = { id: sessions.length + 1, createdAt: new Date(), ...data };
+          const record = { id: sessions.length + 1, createdAt: now, ...data };
           sessions.push(record);
           return record;
         }),
@@ -278,7 +278,7 @@ describe("ExpertSessionService.bookSession concurrency (regression for #2691)", 
   }
 
   it("lets only one of two concurrent bookings for the same slot succeed", async () => {
-    const { client } = makeInMemoryDb();
+    const { client } = makeInMemoryDb(REFERENCE_NOW);;
     vi.mocked(prisma.$transaction).mockImplementation(client.$transaction as any);
     vi.mocked(prisma.expertAvailabilityBlock.findMany).mockImplementation(
       client.expertAvailabilityBlock.findMany as any,
@@ -307,7 +307,7 @@ describe("ExpertSessionService.bookSession concurrency (regression for #2691)", 
   });
 
   it("lets two concurrent bookings for different slots both succeed", async () => {
-    const { client } = makeInMemoryDb();
+    const { client } = makeInMemoryDb(REFERENCE_NOW);
     vi.mocked(prisma.$transaction).mockImplementation(client.$transaction as any);
     vi.mocked(prisma.expertAvailabilityBlock.findMany).mockImplementation(
       client.expertAvailabilityBlock.findMany as any,
@@ -327,7 +327,7 @@ describe("ExpertSessionService.bookSession concurrency (regression for #2691)", 
   });
 
   it("reclaims a slot whose only holder is a stale (TTL-expired) PENDING_PAYMENT hold", async () => {
-    const { client, sessions } = makeInMemoryDb();
+    const { client, sessions } = makeInMemoryDb(REFERENCE_NOW);
     vi.mocked(prisma.$transaction).mockImplementation(client.$transaction as any);
     vi.mocked(prisma.expertAvailabilityBlock.findMany).mockImplementation(
       client.expertAvailabilityBlock.findMany as any,

--- a/server/src/database/prisma/migrations/20260712000000_add_expert_session_slot_unique_index/migration.sql
+++ b/server/src/database/prisma/migrations/20260712000000_add_expert_session_slot_unique_index/migration.sql
@@ -1,0 +1,12 @@
+-- Prevent double-booking the same expert-session slot at the database level.
+-- Only one "active" (PENDING_PAYMENT or SCHEDULED) session may exist per
+-- scheduledAt at a time. CANCELLED/COMPLETED rows are excluded so a freed
+-- or historical slot can be rebooked without hitting this constraint.
+--
+-- This is a backstop for expertSession.service.ts#bookSession, which already
+-- runs its availability check + create inside a Serializable transaction.
+-- Belt and suspenders: if that transaction is ever bypassed, this index is
+-- what actually stops the double booking from being written.
+CREATE UNIQUE INDEX IF NOT EXISTS "expertSession_scheduledAt_active_idx"
+ON "expertSession"("scheduledAt")
+WHERE "status" IN ('PENDING_PAYMENT', 'SCHEDULED');

--- a/server/src/database/prisma/schema/roadmap.prisma
+++ b/server/src/database/prisma/schema/roadmap.prisma
@@ -319,6 +319,12 @@ model expertAvailabilityBlock {
   @@index([date])
 }
 
+// NOTE: a partial unique index on (scheduledAt) WHERE status IN
+// ('PENDING_PAYMENT', 'SCHEDULED') is added via migration
+// 20260712000000_add_expert_session_slot_unique_index. Prisma's schema DSL
+// can't express a filtered unique constraint, so it isn't declared with
+// @@unique here — see expert-session.service.ts#bookSession for the
+// Serializable-transaction check that backs it up.
 model expertSession {
   id              Int                 @id @default(autoincrement())
   userId          Int

--- a/server/src/module/expert-session/expert-session.service.ts
+++ b/server/src/module/expert-session/expert-session.service.ts
@@ -12,6 +12,10 @@ const BUSINESS_START_HOUR = 10; // 10:00 IST
 const BUSINESS_END_HOUR = 18; // last slot starts 17:30, ends 18:00 IST
 const LOOKAHEAD_DAYS = 14;
 const MIN_LEAD_HOURS = 12;
+// How long a PENDING_PAYMENT hold blocks a slot's availability before it's
+// treated as abandoned. Checkout sessions are expected to complete or fail
+// within a couple minutes; this is deliberately generous.
+const PENDING_HOLD_TTL_MINUTES = 15;
 
 const ADMIN_ALERT_EMAIL = process.env["ADMIN_ALERT_EMAIL"] ?? "";
 
@@ -83,15 +87,28 @@ export class ExpertSessionService {
     const candidates = generateSlotCandidates(now).filter((slot) => slot >= minTime);
     if (candidates.length === 0) return [];
 
-    const rangeStart = candidates[0]!;
+   const rangeStart = candidates[0]!;
     const rangeEnd = candidates[candidates.length - 1]!;
+    // A PENDING_PAYMENT row is an active hold on a slot, so it should make
+    // that slot look unavailable too — not just SCHEDULED ones. But there's
+    // no cleanup job for abandoned checkouts (user closes the tab, no
+    // success/failure webhook ever fires), so an unbounded hold could
+    // permanently lock a slot. Cap how long a pending hold blocks
+    // availability; past that, treat it as abandoned and let the slot show
+    // as free again. The partial unique index still protects against a
+    // genuinely-concurrent double booking even if a stale hold slips through
+    // this window.
+    const holdCutoff = new Date(now.getTime() - PENDING_HOLD_TTL_MINUTES * 60 * 1000);
 
     const [blocks, booked] = await Promise.all([
       db.expertAvailabilityBlock.findMany({
         where: { date: { gte: rangeStart, lte: rangeEnd } },
       }),
       db.expertSession.findMany({
-        where: { status: "SCHEDULED", scheduledAt: { gte: rangeStart, lte: rangeEnd } },
+        where: {
+          scheduledAt: { gte: rangeStart, lte: rangeEnd },
+          OR: [{ status: "SCHEDULED" }, { status: "PENDING_PAYMENT", createdAt: { gte: holdCutoff } }],
+        },
         select: { scheduledAt: true },
       }),
     ]);

--- a/server/src/module/expert-session/expert-session.service.ts
+++ b/server/src/module/expert-session/expert-session.service.ts
@@ -75,6 +75,11 @@ function generateSlotCandidates(now: Date): Date[] {
   return slots;
 }
 
+/** Cutoff before which a PENDING_PAYMENT hold is treated as abandoned. */
+function pendingHoldCutoff(now: Date): Date {
+  return new Date(now.getTime() - PENDING_HOLD_TTL_MINUTES * 60 * 1000);
+}
+
 export class ExpertSessionService {
   /**
    * Business-hours slots minus admin blocks, existing bookings, and the minimum lead time.
@@ -98,7 +103,7 @@ export class ExpertSessionService {
     // as free again. The partial unique index still protects against a
     // genuinely-concurrent double booking even if a stale hold slips through
     // this window.
-    const holdCutoff = new Date(now.getTime() - PENDING_HOLD_TTL_MINUTES * 60 * 1000);
+    const holdCutoff = pendingHoldCutoff(now);
 
     const [blocks, booked] = await Promise.all([
       db.expertAvailabilityBlock.findMany({
@@ -158,6 +163,21 @@ export class ExpertSessionService {
       // in case this method is ever called outside a Serializable transaction.
       return await prisma.$transaction(
         async (tx) => {
+          // The availability check below treats a PENDING_PAYMENT hold older
+          // than PENDING_HOLD_TTL_MINUTES as abandoned and ignores it — but
+          // the partial unique index doesn't know about that TTL, it just
+          // sees an existing active row and rejects the insert. Without this
+          // delete, a slot could show as available and then always 409 on
+          // create. Clear out any stale hold for *this exact slot* first so
+          // the two checks agree.
+          await tx.expertSession.deleteMany({
+            where: {
+              scheduledAt: input.scheduledAt,
+              status: "PENDING_PAYMENT",
+              createdAt: { lt: pendingHoldCutoff(now) },
+            },
+          });
+
           const available = await this.getAvailableSlots(now, tx);
           const isAvailable = available.some((slot) => slot.getTime() === input.scheduledAt.getTime());
           if (!isAvailable) {

--- a/server/src/module/expert-session/expert-session.service.ts
+++ b/server/src/module/expert-session/expert-session.service.ts
@@ -1,5 +1,10 @@
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../database/db.js";
 import { sendEmail } from "../../utils/email.utils.js";
+
+/** Anything that exposes the model delegates we need — either the top-level
+ * PrismaClient or a `tx` handed to us inside `prisma.$transaction`. */
+type DbClient = Prisma.TransactionClient | typeof prisma;
 
 const IST_OFFSET_MINUTES = 330; // UTC+5:30, fixed offset (India has no DST)
 const SLOT_DURATION_MINUTES = 30;
@@ -67,8 +72,13 @@ function generateSlotCandidates(now: Date): Date[] {
 }
 
 export class ExpertSessionService {
-  /** Business-hours slots minus admin blocks, existing bookings, and the minimum lead time. */
-  async getAvailableSlots(now: Date = new Date()): Promise<Date[]> {
+  /**
+   * Business-hours slots minus admin blocks, existing bookings, and the minimum lead time.
+   *
+   * Accepts an optional `db` client so `bookSession` can re-run this same check
+   * inside its transaction against a consistent snapshot (see below).
+   */
+  async getAvailableSlots(now: Date = new Date(), db: DbClient = prisma): Promise<Date[]> {
     const minTime = new Date(now.getTime() + MIN_LEAD_HOURS * 60 * 60 * 1000);
     const candidates = generateSlotCandidates(now).filter((slot) => slot >= minTime);
     if (candidates.length === 0) return [];
@@ -77,10 +87,10 @@ export class ExpertSessionService {
     const rangeEnd = candidates[candidates.length - 1]!;
 
     const [blocks, booked] = await Promise.all([
-      prisma.expertAvailabilityBlock.findMany({
+      db.expertAvailabilityBlock.findMany({
         where: { date: { gte: rangeStart, lte: rangeEnd } },
       }),
-      prisma.expertSession.findMany({
+      db.expertSession.findMany({
         where: { status: "SCHEDULED", scheduledAt: { gte: rangeStart, lte: rangeEnd } },
         select: { scheduledAt: true },
       }),
@@ -121,23 +131,54 @@ export class ExpertSessionService {
     },
     now: Date = new Date(),
   ) {
-    const available = await this.getAvailableSlots(now);
-    const isAvailable = available.some((slot) => slot.getTime() === input.scheduledAt.getTime());
-    if (!isAvailable) {
-      throw Object.assign(new Error("That slot is no longer available"), { status: 409 });
-    }
+    try {
+      // Serializable transaction closes the TOCTOU gap between the
+      // availability check and the insert: if two requests race for the same
+      // slot, Postgres aborts the loser with a P2034 serialization failure
+      // instead of letting both reads see the slot as free (same pattern as
+      // usageLimit middleware). The partial unique index added in migration
+      // 20260712000000_add_expert_session_slot_unique_index is the backstop
+      // in case this method is ever called outside a Serializable transaction.
+      return await prisma.$transaction(
+        async (tx) => {
+          const available = await this.getAvailableSlots(now, tx);
+          const isAvailable = available.some((slot) => slot.getTime() === input.scheduledAt.getTime());
+          if (!isAvailable) {
+            throw Object.assign(new Error("That slot is no longer available"), { status: 409 });
+          }
 
-    return prisma.expertSession.create({
-      data: {
-        userId,
-        scheduledAt: input.scheduledAt,
-        targetRole: input.targetRole,
-        experienceLevel: input.experienceLevel,
-        focusAreas: input.focusAreas,
-        notes: input.notes,
-        status: "PENDING_PAYMENT",
-      },
-    });
+          return tx.expertSession.create({
+            data: {
+              userId,
+              scheduledAt: input.scheduledAt,
+              targetRole: input.targetRole,
+              experienceLevel: input.experienceLevel,
+              focusAreas: input.focusAreas,
+              notes: input.notes,
+              status: "PENDING_PAYMENT",
+            },
+          });
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+    } catch (err) {
+      // Our own "not available" check above already carries a `.status`, so
+      // just propagate it as-is.
+      if (typeof err === "object" && err !== null && "status" in err) {
+        throw err;
+      }
+
+      const code = typeof err === "object" && err !== null && "code" in err ? (err as { code: unknown }).code : undefined;
+      // P2034 = Prisma serialization failure (lost the Serializable race).
+      // P2002 = unique constraint violation on the partial index below.
+      // Both mean a concurrent request booked this exact slot first.
+      if (code === "P2034" || code === "P2002") {
+        throw Object.assign(new Error("This slot has just been booked. Please choose another available slot."), {
+          status: 409,
+        });
+      }
+      throw err;
+    }
   }
 
   async attachCheckout(id: number, dodoPaymentId: string, dodoCheckoutUrl: string) {


### PR DESCRIPTION
## Description of issue no #2691 
Fixes a race condition (TOCTOU) in `expert-session.service.ts#bookSession`. The
method previously did a read-then-write availability check with no transaction
or lock between the check and the write, so two concurrent requests could both
pass the check and book the same slot.

Fix has two layers:

1. **Serializable transaction** — the availability check and the `create` now
   run inside a single `prisma.$transaction(..., { isolationLevel:
   Prisma.TransactionIsolationLevel.Serializable })`, the same pattern already
   used in `usage-limit.middleware.ts` for an identical check-then-act
   scenario. `getAvailableSlots` now accepts an optional `db` client so it can
   run against the transaction's `tx` instead of the top-level `prisma`.

2. **Partial unique index (DB-level backstop)** — new migration
   `20260712000000_add_expert_session_slot_unique_index` adds a unique index
   on `scheduledAt` scoped to `status IN ('PENDING_PAYMENT', 'SCHEDULED')`, so
   cancelled/completed sessions don't block rebooking a freed slot. This makes
   a double booking impossible to *write* even if the transaction layer above
   is ever bypassed.

Prisma error codes `P2034` (serialization failure) and `P2002` (unique
constraint violation) are both caught in `bookSession` and converted into a
friendly `409`: *"This slot has just been booked. Please choose another
available slot."* No automatic retry — surfacing the conflict lets the client
re-fetch available slots rather than silently placing the user into a slot
they didn't pick.

Also added a comment above `model expertSession` in `roadmap.prisma`
explaining why the partial index isn't declared via `@@unique` — Prisma's
schema DSL can't express filtered unique constraints.

**Not covered by this PR:** `getAvailableSlots` only excludes `SCHEDULED`
sessions from the availability list, not `PENDING_PAYMENT` ones, so a slot
someone else has a pending checkout on still shows as available until the
second user tries to book it (at which point they correctly get the 409
above). Left as-is since there's no cleanup job for abandoned
`PENDING_PAYMENT` rows — excluding them without a TTL would risk permanently
locking a slot if a user just closes the checkout tab. Might be worth its own
issue.

## Related Issue
Fixes #2691

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing
Added a new `ExpertSessionService.bookSession concurrency (regression for
#2691)` suite in `expert-session.service.test.ts` — two tests using an
in-memory DB double that reproduces real transaction semantics (serialized
transaction bodies, unique-constraint enforcement on active sessions):
- Two concurrent `bookSession` calls for the **same** slot → exactly one
  resolves, the other rejects with `status: 409` and the friendly message.
- Two concurrent `bookSession` calls for **different** slots → both succeed.

Ran full suite locally: `npm test` → 314/314 tests passing, including all 13
in `expert-session.service.test.ts` (11 existing + 2 new).
`npm run typecheck` → clean.

**Caveat:** I did not have a live Postgres database available locally, so I
was not able to run `npx prisma migrate dev` end-to-end to verify the
migration applies cleanly against a real database. The SQL follows the same
partial-index pattern already used elsewhere in this repo's migration
history. Flagging this so it gets a check in review/CI before merge.

## Screenshots / Video
_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing) — N/A, no UI changes
Closes #2691 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate expert-session bookings for the same `scheduledAt` while a slot is active.
  * Availability checks now treat recent `PENDING_PAYMENT` holds as blocking.
  * Booking conflicts under concurrency now consistently return 409 (“slot just been booked”), and stale holds are cleared within a single Serializable transaction.
  * Cancelled/completed sessions remain rebookable.
* **Database**
  * Added a partial unique index to enforce unique active `scheduledAt` values.
* **Tests**
  * Improved Prisma transaction mocking and added concurrent booking regression coverage.
* **Documentation**
  * Added a roadmap note clarifying the filtered unique index approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->