### PR TITLE
fix: add single-quote escaping to escapeHtml in email-inbound controller

### DIFF
--- a/server/src/module/email-inbound/email-inbound.controller.ts
+++ b/server/src/module/email-inbound/email-inbound.controller.ts
@@ -138,5 +138,6 @@ function escapeHtml(str: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }


### PR DESCRIPTION
## Description

Added single-quote escaping (`&#39;`) to the `escapeHtml` function in `email-inbound.controller.ts`. Without this, user-controlled values like `subject`, `from`, or `textBody` with `'` characters could break out of HTML attributes, creating a stored XSS vector.

The same function in `email-templates.ts` already had this fix — this makes the inbound controller consistent.

## Changes
- Added `.replace(/'/g, "&#39;")` to `escapeHtml` in `email-inbound.controller.ts`

Closes #2700

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML escaping for forwarded emails by encoding apostrophes, helping prevent malformed or unsafe HTML output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->