### PR TITLE
fix: use per-factory retry state in lazyWithRetry

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,14 +11,14 @@ import ScrollProgressBar from "./components/common/ScrollProgressBar";
 import ScrollToTop from "./components/common/ScrollToTop";
 const ContributorsPage = lazyWithRetry(() => import("./module/contributors/ContributorsPage"));
 
-let hasReloaded = false;
+const retryState = new Map<() => Promise<{ default: ComponentType<unknown> }>, boolean>();
 
 function lazyWithRetry<T extends ComponentType<unknown>>(factory: () => Promise<{ default: T }>): LazyExoticComponent<T> {
   return lazy(
     () =>
       factory().catch((err: unknown) => {
-        if (!hasReloaded) {
-          hasReloaded = true;
+        if (!retryState.get(factory)) {
+          retryState.set(factory, true);
           window.location.reload();
           return new Promise<never>(() => { });
         }


### PR DESCRIPTION
## Description

Replaced module-scoped `let hasReloaded` flag with a per-factory `Map` in `lazyWithRetry`. The original global flag meant that after ONE lazy chunk failed (and retried via page reload), ALL subsequent lazy route failures were thrown to the error boundary with no recovery — permanently breaking every lazy route for the session.

With a `Map<Function, boolean>`, each factory function gets its own retry state. A failure in route A no longer prevents route B from getting its own reload-based retry.

## Changes
- Replaced `let hasReloaded` with `const retryState = new Map()`
- Changed `if (!hasReloaded)` / `hasReloaded = true` to use `retryState.get(factory)` / `retryState.set(factory, true)`

Closes #2701

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when dynamically loaded app components fail to load.
  - Reload attempts are now handled independently for each component, reducing the chance of repeated or ineffective reloads.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->