### PR TITLE
fix: replace raw error messages with generic messages in error middleware

### DIFF
--- a/server/src/middleware/error.middleware.ts
+++ b/server/src/middleware/error.middleware.ts
@@ -159,15 +159,15 @@ export function errorMiddleware(err: Error, req: Request, res: Response, _next: 
   // Fallback: try partial matches for dynamic error messages
   const msg = err.message.toLowerCase();
   if (msg.includes("not found")) {
-    respond(req, res, 404, err.message, err);
+    respond(req, res, 404, "Resource not found", err);
     return;
   }
   if (msg.includes("already") && (msg.includes("exists") || msg.includes("registered") || msg.includes("applied"))) {
-    respond(req, res, 409, err.message, err);
+    respond(req, res, 409, "Resource already exists", err);
     return;
   }
   if (msg.includes("unauthorized") || msg.includes("not authorized")) {
-    respond(req, res, 403, err.message, err);
+    respond(req, res, 403, "Unauthorized", err);
     return;
   }
 


### PR DESCRIPTION
## Description

The error middleware's fallback partial string matching leaked raw `err.message` in HTTP responses. If any error happened to contain words like "not found", "already exists", or "unauthorized" in its message, the complete internal error text was sent to the client — potentially exposing connection strings, file paths, or schema details.

## Changes
- Replaced `err.message` with generic messages in all three fallback branches:
  - `"not found"` → `"Resource not found"`
  - `"already" + "exists/registered/applied"` → `"Resource already exists"`
  - `"unauthorized" / "not authorized"` → `"Unauthorized"`

Closes #2702

GSSoC