### PR TITLE
fix: return 409 for duplicate email registration

### DIFF
--- a/client/src/module/auth/RegisterPage.tsx
+++ b/client/src/module/auth/RegisterPage.tsx
@@ -266,7 +266,7 @@ export default function RegisterPage() {
     try {
       const payload: Record<string, string> = { name: form.name, email: form.email, password: form.password };
       const { data } = await api.post("/auth/register", payload);
-      if (!data.user.isVerified) {
+      if (data.user && !data.user.isVerified) {
         navigate(`/verify-email?email=${encodeURIComponent(form.email)}`);
       } else {
         login(data.user);

--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -38,7 +38,7 @@ export class AuthController {
       return res.status(201).json({ message: "Registration successful. Please verify your email to continue.", user: data.user });
     } catch (error) {
       if (error instanceof Error && error.message === "Email already registered") {
-        return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });
+        return res.status(409).json({ message: "Email is already registered." });
       }
       console.error(error);
       return res.status(500).json({ message: "Internal Server Error" });


### PR DESCRIPTION
## Description

Two related fixes for duplicate email registration:

1. **Server: Return 409 Conflict** — The register endpoint incorrectly returned HTTP 201 Created with a success message when a user tried to register with an already-used email. This caused confusing UX (user thinks they succeeded) and made the client crash accessing `data.user` which was missing from the response.

2. **Client: Defensive null check** — Added `data.user &&` guard in RegisterPage.tsx before accessing `data.user.isVerified` for defense-in-depth.

## Changes
- `auth.controller.ts`: Changed status from `201` to `409` with message `"Email is already registered."`
- `RegisterPage.tsx`: Added `data.user &&` null guard before `data.user.isVerified`

Closes #2703, Closes #2709

GSSoC