### PR TITLE
fix: log error when service provider initialization fails

### DIFF
--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -7,7 +7,9 @@ import { initServiceProviders } from "../src/lib/ai-provider-registry.js";
 // the module async, which breaks Vercel's default-export detection ("the default
 // export must be a function or server"). Failures are swallowed so a cold start
 // still serves.
-void initServiceProviders().catch(() => {});
+void initServiceProviders().catch((err) => {
+  console.error("[api] Failed to initialize service providers:", err);
+});
 
 // Vercel serves the configured Express app directly.
 export default app;


### PR DESCRIPTION
## Description

The `initServiceProviders()` call in `server/api/index.ts` had an empty catch clause that silently swallowed all initialization errors. When the AI provider registry failed to load (e.g., database unreachable, Prisma schema out of sync, config table empty), the server would start without any error signal, and subsequent AI requests would silently fall back to default or broken provider configurations.

## Changes
- Replaced `catch(() => {})` with `catch((err) => { console.error("[api] Failed to initialize service providers:", err); })`

Closes #2711

GSSoC