### PR TITLE
fix: escape regex special chars in user input to prevent ReDoS

### DIFF
--- a/server/src/module/gsoc/gsoc-review.service.ts
+++ b/server/src/module/gsoc/gsoc-review.service.ts
@@ -166,7 +166,7 @@ function buildFallback(input: GsocReviewInput): GsocReviewResult {
   const hasDeliverables = /deliver|acceptance\s*criteria|measurable|milestone/i.test(input.draft);
   const hasAboutMe = /github\.com|pr\s*#|pull\s*request|contribution|commit/i.test(input.draft);
   const hasOrgAlign = input.targetStack
-    ? new RegExp(input.targetStack.split(/[\s,]+/)[0] ?? "", "i").test(input.draft)
+    ? new RegExp((input.targetStack.split(/[\s,]+/)[0] ?? "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i").test(input.draft)
     : /tech\s*stack|framework|library/i.test(input.draft);
 
   return {


### PR DESCRIPTION
## Description

The `buildFallback` function in `gsoc-review.service.ts` passed user-supplied `input.targetStack` directly to `new RegExp()` without escaping special regex characters. A malicious user could submit a ReDoS payload (e.g., `(?:[^a]*[a]){100}`) that triggers catastrophic backtracking, blocking the Node.js event loop and causing a server-side denial of service.

This fallback path is reachable even without a configured Gemini API key, making it a viable attack vector.

## Changes
- Added `.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")` to escape regex special characters in the user-supplied token before passing it to `new RegExp()`

Closes #2713

GSSoC