### PR TITLE
fix: validate notes controller inputs

### DIFF
--- a/server/src/module/notes/notes.controller.ts
+++ b/server/src/module/notes/notes.controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import { NotesService } from "./notes.service.js";
+import { noteParamSchema, notesQuerySchema } from "./notes.validation.js";
 
 export class NotesController {
   constructor(private readonly notesService = new NotesService()) {}
@@ -8,7 +9,8 @@ export class NotesController {
     try {
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: "Unauthorized" });
-      const notes = await this.notesService.getNotes(userId, req.query as any);
+      const filters = notesQuerySchema.parse(req.query);
+      const notes = await this.notesService.getNotes(userId, filters);
       res.json({ notes });
     } catch (err) {
       next(err);
@@ -19,11 +21,11 @@ export class NotesController {
     try {
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: "Unauthorized" });
-      const { contentType, contentId } = req.params;
+      const { contentType, contentId } = noteParamSchema.parse(req.params);
       const note = await this.notesService.getNote(
         userId,
-        contentType as any,
-        contentId as string
+        contentType,
+        contentId
       );
       res.json({ note });
     } catch (err) {
@@ -35,12 +37,12 @@ export class NotesController {
     try {
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: "Unauthorized" });
-      const { contentType, contentId } = req.params;
+      const { contentType, contentId } = noteParamSchema.parse(req.params);
       const { note } = req.body;
       const saved = await this.notesService.saveNote(
         userId,
-        contentType as any,
-        contentId as string,
+        contentType,
+        contentId,
         note
       );
       res.json({ note: saved });
@@ -53,11 +55,11 @@ export class NotesController {
     try {
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: "Unauthorized" });
-      const { contentType, contentId } = req.params;
+      const { contentType, contentId } = noteParamSchema.parse(req.params);
       const result = await this.notesService.deleteNote(
         userId,
-        contentType as any,
-        contentId as string
+        contentType,
+        contentId
       );
       res.json(result);
     } catch (err) {
@@ -65,4 +67,3 @@ export class NotesController {
     }
   }
 }
-


### PR DESCRIPTION
## Summary
- remove unsafe `as any` casts from the notes controller
- reuse the existing Zod query and route-parameter schemas before calling the service

## Validation
- `npx eslint src/module/notes/notes.controller.ts src/module/notes/notes.validation.ts`
- `npm run typecheck`
- `npm test -- --run src/__tests__/notes.test.ts` (8 passed)
- `git diff --check`

Fixes #2735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and normalization of note request parameters and filters.
  * Prevented invalid or malformed note queries from being passed to note operations.
  * Enhanced consistency when retrieving, saving, and deleting notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->