### PR TITLE
fix: return 409 on duplicate email registration instead of 201

### DIFF
--- a/server/src/module/auth/auth.controller.ts
+++ b/server/src/module/auth/auth.controller.ts
@@ -38,7 +38,7 @@ export class AuthController {
       return res.status(201).json({ message: "Registration successful. Please verify your email to continue.", user: data.user });
     } catch (error) {
       if (error instanceof Error && error.message === "Email already registered") {
-        return res.status(201).json({ message: "Registration successful. Please verify your email to continue." });
+        return res.status(409).json({ message: "An account with this email already exists. Please log in or reset your password." });
       }
       console.error(error);
       return res.status(500).json({ message: "Internal Server Error" });


### PR DESCRIPTION
# Pull Request

## Description
auth.register() was returning HTTP 201 with a success message when authService.register() threw "Email already registered". No user record was created, no OTP generated, and no verification email was sent -- yet the client received a 2xx success response and silently waited for a verification email that never arrives.

The catch block now returns HTTP 409 Conflict with a clear message guiding the user to log in or reset their password.

## Related Issue
Fixes #2692

## Type of Change
- [x] Bug Fix

## Problem
- Controller returned `res.status(201).json({ message: "Registration successful..." })` when email was already taken
- Client success path tried to access `data.user.isVerified` which was undefined in the fake-201 response, causing a silent crash
- User had no feedback that their account already exists

## Fix
- Changed `res.status(201)` to `res.status(409)` in the "Email already registered" catch block
- Updated message to "An account with this email already exists. Please log in or reset your password."

## Client Impact
The client catch block (RegisterPage.tsx:275+) already handles non-2xx responses by displaying the backend error message. Returning 409 correctly routes the user to the error path where they see the "already exists" message -- no client changes needed.

## How to Test
1. Register with a new email -> 201, user + OTP created (unchanged behavior)
2. Register again with the same email -> 409 + "An account with this email already exists. Please log in or reset your password."
3. Verify client shows the error message instead of silently failing

## Checklist
- [x] Code follows project style conventions
- [x] No new TypeScript errors introduced
- [x] No secrets or credentials committed
- [x] Tested manually
