### PR TITLE
fix: add validateBody to peer-mock complete endpoint

### DIFF
--- a/server/src/module/peer-mock-interview/peer-mock-interview.routes.ts
+++ b/server/src/module/peer-mock-interview/peer-mock-interview.routes.ts
@@ -81,6 +81,7 @@ peerMockInterviewRouter.post(
   "/pairings/:id/complete",
   authMiddleware,
   requireRole("STUDENT"),
+  validateBody(z.object({})),
   (req, res) => controller.markCompleted(req, res)
 );
 


### PR DESCRIPTION
## Description
The `POST /pairings/:id/complete` route was missing `validateBody` middleware, inconsistent with all other POST routes in `peer-mock-interview.routes.ts`.

### Changes
- Added `validateBody(z.object({}))` to the complete endpoint, matching the convention used by `/pairings/:id/reject-time` and `/pairings/:id/decline`

Closes #2732

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added request validation to ensure pairing completion requests contain only an empty JSON object.
  * Invalid request bodies are now rejected before completion processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->