### PR TITLE
fix: TOCTOU race on concurrent YC company scrapes

### DIFF
--- a/server/src/module/yc/yc.routes.ts
+++ b/server/src/module/yc/yc.routes.ts
@@ -24,6 +24,10 @@ interface Founder {
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
+// Per-slug scrape lock: prevents concurrent requests for the same company
+// from triggering duplicate scrapes (TOCTOU race).
+const pendingScrapes = new Map<string, Promise<void>>();
+
 async function scrapeYCPage(slug: string) {
   const url = `https://www.ycombinator.com/companies/${slug}`;
   const res = await fetch(url, {
@@ -262,13 +266,22 @@ router.get("/companies/:slug", cacheMiddleware(1800, "yc:detail"), async (req: R
       return;
     }
 
-    // If not scraped yet or stale, scrape in background and update
+    // If not scraped yet or stale, scrape on demand
     if (needsScrape(company)) {
-      // Don't block the response - fire and forget, but also try to return fresh data
-      try {
+      // Per-slug lock: if a scrape for this slug is already in flight,
+      // await it and return the freshly-updated company data.
+      const inFlight = pendingScrapes.get(company.slug);
+      if (inFlight) {
+        await inFlight;
+        const fresh = await prisma.ycCompany.findFirst({ where: { slug: company.slug } });
+        res.json(fresh ?? company);
+        return;
+      }
+
+      const scrapePromise = (async () => {
         const scraped = await scrapeYCPage(company.slug);
         if (scraped) {
-          const updated = await prisma.ycCompany.update({
+          await prisma.ycCompany.update({
             where: { id: company.id },
             data: {
               founders: scraped.founders.length > 0 ? (scraped.founders as unknown as Prisma.InputJsonValue) : undefined,
@@ -277,25 +290,30 @@ router.get("/companies/:slug", cacheMiddleware(1800, "yc:detail"), async (req: R
               scrapedAt: new Date(),
             },
           });
-          res.json(updated);
-          return;
         } else {
-          // If scraping returned null, update scrapedAt to prevent constant retries
           await prisma.ycCompany.update({
             where: { id: company.id },
             data: { scrapedAt: new Date() },
           });
         }
+      })();
+
+      pendingScrapes.set(company.slug, scrapePromise);
+
+      try {
+        await scrapePromise;
+        const fresh = await prisma.ycCompany.findFirst({ where: { slug: company.slug } });
+        res.json(fresh ?? company);
       } catch (scrapeErr) {
         logger.error(`Scrape failed for ${company.slug}`, scrapeErr);
-        // Mark as scraped to avoid retrying immediately
         await prisma.ycCompany
-          .update({
-            where: { id: company.id },
-            data: { scrapedAt: new Date() },
-          })
+          .update({ where: { id: company.id }, data: { scrapedAt: new Date() } })
           .catch((err) => console.error("Failed to update scrapedAt:", err));
+        res.json(company);
+      } finally {
+        pendingScrapes.delete(company.slug);
       }
+      return;
     }
 
     res.json(company);


### PR DESCRIPTION
## Description
The YC company scrape endpoint had a TOCTOU race condition: concurrent requests for the same company slug would all start a separate scrape, wasting API credits and database writes.

### Changes
- Added a per-slug `pendingScrapes` Map that stores the in-flight scrape promise
- Concurrent requests for the same slug now await the same promise instead of starting a duplicate scrape

Closes #2733

GSSoC