### PR TITLE
fix: add validateBody middleware to interview progress PATCH route

### DIFF
--- a/server/src/module/interview-progress/interview-progress.routes.ts
+++ b/server/src/module/interview-progress/interview-progress.routes.ts
@@ -3,6 +3,8 @@ import { InterviewProgressController } from "./interview-progress.controller.js"
 import { InterviewProgressService } from "./interview-progress.service.js";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
 import { requireRole } from "../../middleware/role.middleware.js";
+import { validateBody } from "../../middleware/validation.middleware.js";
+import { updateInterviewProgressSchema } from "./interview-progress.validation.js";
 
 const interviewProgressService = new InterviewProgressService();
 
@@ -23,6 +25,7 @@ interviewProgressRouter.patch(
   "/",
   authMiddleware,
   requireRole("STUDENT"),
+  validateBody(updateInterviewProgressSchema),
   (req, res, next) =>
     interviewProgressController.updateProgress(req, res, next)
 );


### PR DESCRIPTION
## Description
The interview progress PATCH route was missing `validateBody(updateInterviewProgressSchema)` middleware, allowing unvalidated data to reach the controller.

### Changes
- Added `validateBody(updateInterviewProgressSchema)` to the PATCH route

Closes #2734

GSSoC