### PR TITLE
fix: remove as any casts in notes controller

### DIFF
--- a/server/src/module/notes/notes.controller.ts
+++ b/server/src/module/notes/notes.controller.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from "express";
+import { NoteContentType } from "@prisma/client";
 import { NotesService } from "./notes.service.js";
 
 export class NotesController {
@@ -8,7 +9,8 @@ export class NotesController {
     try {
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: "Unauthorized" });
-      const notes = await this.notesService.getNotes(userId, req.query as any);
+      const { contentType, search } = req.query as { contentType?: NoteContentType; search?: string };
+      const notes = await this.notesService.getNotes(userId, { contentType, search });
       res.json({ notes });
     } catch (err) {
       next(err);
@@ -22,8 +24,8 @@ export class NotesController {
       const { contentType, contentId } = req.params;
       const note = await this.notesService.getNote(
         userId,
-        contentType as any,
-        contentId as string
+        contentType as NoteContentType,
+        contentId
       );
       res.json({ note });
     } catch (err) {
@@ -39,8 +41,8 @@ export class NotesController {
       const { note } = req.body;
       const saved = await this.notesService.saveNote(
         userId,
-        contentType as any,
-        contentId as string,
+        contentType as NoteContentType,
+        contentId,
         note
       );
       res.json({ note: saved });
@@ -56,8 +58,8 @@ export class NotesController {
       const { contentType, contentId } = req.params;
       const result = await this.notesService.deleteNote(
         userId,
-        contentType as any,
-        contentId as string
+        contentType as NoteContentType,
+        contentId
       );
       res.json(result);
     } catch (err) {


### PR DESCRIPTION
## Description

The notes.controller.ts used \s any\ casts for the \contentType\ parameter, bypassing TypeScript's type checking.

**Changes**
- Replaced \s any\ casts with proper \NoteContentType\ enum casts
- Added \NoteContentType\ import from the notes validation module
- Extracted \contentType\ and \search\ from \eq.query\ with explicit type narrowing instead of passing \ParsedQs\ directly to \getNotes\

Closes #2735

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of note content types when retrieving, saving, and deleting notes.
  * Enhanced note search requests to process content type and search filters more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->