### PR TITLE
fix: revoke ATS preview object URLs

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Link, useNavigate } from "react-router";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import toast from "@/components/ui/toast";
@@ -281,9 +281,18 @@ export default function AtsScorePage({ guestMode = false }: { guestMode?: boolea
   });
 
   const loading = analyzeMutation.isPending;
-  const previewUrl = useMemo(() => {
-    if (!file) return "";
-    return URL.createObjectURL(file);
+  const [previewUrl, setPreviewUrl] = useState("");
+
+  useEffect(() => {
+    if (!file) {
+      setPreviewUrl("");
+      return;
+    }
+
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+
+    return () => URL.revokeObjectURL(url);
   }, [file]);
 
   const validateFile = (file: File): string | null => {


### PR DESCRIPTION
## Summary
- revoke ATS resume preview blob URLs when the selected file changes
- revoke the active preview URL when the page unmounts
- preserve the existing PDF preview behavior

## Validation
- `git diff --check`
- focused object URL lifecycle check
- client typecheck/lint skipped: dependencies are not installed locally

Closes #2754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume preview URL handling for more reliable previews.
  * Prevented stale preview references and reduced potential memory usage issues when files change or are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->