### PR TITLE
fix(admin): invalidate JWT sessions immediately when banning users

### DIFF
--- a/server/src/module/admin/admin-platform.service.ts
+++ b/server/src/module/admin/admin-platform.service.ts
@@ -192,11 +192,13 @@ export class AdminPlatformService {
     if (userId === adminId) throw new Error("Cannot modify your own status");
 
     try {
-      return await prisma.user.update({
+      const user = await prisma.user.update({
         where: { id: userId },
-        data: { isActive },
+        data: { isActive, tokenVersion: { increment: 1 } },
         select: { id: true, name: true, email: true, role: true, isActive: true },
       });
+      invalidateVersionCache(userId);
+      return user;
     } catch (err) {
       if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025") {
         throw new Error("User not found");

--- a/server/src/module/student/student.controller.ts
+++ b/server/src/module/student/student.controller.ts
@@ -86,4 +86,27 @@ export class StudentController {
       return res.status(500).json({ message: "Internal Server Error" });
     }
   }
+
+  async deleteExternalApplication(req: Request, res: Response) {
+    try {
+      if (!req.user) return res.status(401).json({ message: "Authentication required" });
+
+      const applicationId = parseInt(String(req.params["applicationId"]), 10);
+      if (isNaN(applicationId)) return res.status(400).json({ message: "Invalid application ID" });
+
+      await this.studentService.deleteExternalApplication(applicationId, req.user.id);
+      return res.status(200).json({ success: true, message: "Application deleted successfully" });
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === "External application not found") {
+          return res.status(404).json({ message: error.message });
+        }
+        if (error.message === "Not authorized") {
+          return res.status(403).json({ message: error.message });
+        }
+      }
+      logger.error("Failed to delete external application", error);
+      return res.status(500).json({ message: "Internal Server Error" });
+    }
+  }
 }

--- a/server/src/module/student/student.controller.ts
+++ b/server/src/module/student/student.controller.ts
@@ -87,26 +87,5 @@ export class StudentController {
     }
   }
 
-  async deleteExternalApplication(req: Request, res: Response) {
-    try {
-      if (!req.user) return res.status(401).json({ message: "Authentication required" });
 
-      const applicationId = parseInt(String(req.params["applicationId"]), 10);
-      if (isNaN(applicationId)) return res.status(400).json({ message: "Invalid application ID" });
-
-      await this.studentService.deleteExternalApplication(applicationId, req.user.id);
-      return res.status(200).json({ success: true, message: "Application deleted successfully" });
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message === "External application not found") {
-          return res.status(404).json({ message: error.message });
-        }
-        if (error.message === "Not authorized") {
-          return res.status(403).json({ message: error.message });
-        }
-      }
-      logger.error("Failed to delete external application", error);
-      return res.status(500).json({ message: "Internal Server Error" });
-    }
-  }
 }


### PR DESCRIPTION
Fixes #2764 

This PR fixes a critical security bug where banned users could continue using the platform because their existing JWTs were not invalidated upon deactivation.

### What was happening? 
The updateUserStatus method in admin-platform.service.ts updated the isActive flag in the database but failed to increment the user's tokenVersion or invalidate the version cache. Because the auth middleware only checks tokenVersion and not the isActive flag on every request, banned users remained authenticated until their token expired naturally.

### What changed?

Updated updateUserStatus to increment tokenVersion: { increment: 1 } when changing a user's status.
Added a call to invalidateVersionCache(userId) immediately after the database update to ensure existing sessions are instantly revoked.