### PR TITLE
fix(payment): allow subscription upgrades by correctly identifying du…

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -231,14 +231,17 @@ export class PaymentService {
     // race conditions where concurrent webhooks create duplicate records.
     // All operations must succeed atomically or entire transaction rolls back.
     await prisma.$transaction(async (tx) => {
-      // Check if subscription is already active to prevent duplicate activations
-      const existingSubscription = await tx.user.findUnique({
-        where: { id: userId },
-        select: { subscriptionStatus: true },
+      // Check if this specific subscription ID has already been activated to prevent
+      // duplicate webhook deliveries from creating duplicate records or placeholders.
+      // We do NOT check `user.subscriptionStatus === "ACTIVE"` here, because that would
+      // incorrectly block legitimate subscription upgrades (e.g. Monthly to Yearly).
+      const alreadyActivated = await tx.payment.findFirst({
+        where: { dodoSubscriptionId: sub.subscription_id },
+        select: { id: true },
       });
 
-      if (existingSubscription?.subscriptionStatus === "ACTIVE") {
-        console.log(`[Webhook] Subscription already active for user ${userId}, skipping duplicate activation`);
+      if (alreadyActivated) {
+        console.log(`[Webhook] Subscription ${sub.subscription_id} already activated, skipping duplicate delivery`);
         return;
       }
 


### PR DESCRIPTION
## Description
Fixes #2762

This PR fixes a critical billing bug in `payment.service.ts` where legitimate subscription upgrades (e.g., upgrading from Monthly to Yearly) were being incorrectly ignored by the webhook handler.

### What was happening?
The `activateSubscription` webhook handler was checking if a user's `subscriptionStatus` was already `"ACTIVE"`. If it was, the handler would abort to prevent duplicate activations. However, this logic was flawed because a user upgrading their plan is already `"ACTIVE"` under their old plan. Because of this, the new `subscription.active` webhook from Dodo was entirely ignored, the new Dodo subscription ID was never linked to their payment, and their plan was never updated on the platform.

### What changed?
- Removed the broad `user.subscriptionStatus === "ACTIVE"` check from `activateSubscription`.
- Replaced it with a specific check that queries the `payment` table to see if the exact `sub.subscription_id` provided by the incoming webhook has already been processed. 
- This preserves the idempotent protection against duplicate webhook deliveries without blocking brand-new subscriptions (upgrades) from being activated.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription webhook handling to prevent duplicate payment records.
  * Legitimate subscription upgrades are no longer incorrectly blocked when a subscription is already active.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->