### PR TITLE
fix: revoke previous blob URL before creating new one in AtsScorePage

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import { Link, useNavigate } from "react-router";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import toast from "@/components/ui/toast";
@@ -281,9 +281,25 @@ export default function AtsScorePage({ guestMode = false }: { guestMode?: boolea
   });
 
   const loading = analyzeMutation.isPending;
-  const previewUrl = useMemo(() => {
-    if (!file) return "";
-    return URL.createObjectURL(file);
+  const previewUrlRef = useRef<string | null>(null);
+  const [previewUrl, setPreviewUrl] = useState("");
+
+  useEffect(() => {
+    return () => {
+      if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+    if (!file) {
+      previewUrlRef.current = null;
+      setPreviewUrl("");
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    previewUrlRef.current = url;
+    setPreviewUrl(url);
   }, [file]);
 
   const validateFile = (file: File): string | null => {


### PR DESCRIPTION
## Description

Memory leak: \URL.createObjectURL\ in AtsScorePage.tsx never calls \evokeObjectURL\.

### Problem
Each file selection creates a new blob URL without revoking the previous one, causing blob URLs to accumulate in browser memory.

### Changes
- Added \useRef\ to track the previous blob URL
- Revoke old blob URL via a cleanup \useEffect\ on unmount
- Revoke old blob URL before creating a new one in a separate \useEffect\ on \ile\ changes

Closes #2754

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume preview handling to prevent stale previews and release temporary resources when files change or the page is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->