### PR TITLE
fix: reset subscriptionPlan to FREE on cancellation

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -332,7 +332,7 @@ export class PaymentService {
 
     await prisma.user.update({
       where: { id: payment.userId },
-      data: { subscriptionStatus: "CANCELLED" },
+      data: { subscriptionStatus: "CANCELLED", subscriptionPlan: "FREE" },
     });
     await invalidateUserTierCache(payment.userId);
   }


### PR DESCRIPTION
## Description

cancelSubscription does not reset subscriptionPlan to FREE -- stale plan data persists indefinitely.

### Problem
After cancellation, the user retains subscriptionPlan: MONTHLY or YEARLY indefinitely. Compare with expireSubscription which correctly resets both status and plan.

### Changes
- Added subscriptionPlan: FREE to the cancelSubscription update payload, matching the pattern used in expireSubscription

Closes #2758

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled subscriptions now correctly switch to the Free plan.
  * Subscription status and plan remain consistent after cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->