### PR TITLE
fix(analytics): sanitize error messages in 500 responses to prevent information disclosure

### DIFF
--- a/server/src/module/analytics/analytics.controller.ts
+++ b/server/src/module/analytics/analytics.controller.ts
@@ -26,8 +26,9 @@ export const getLearnAnalytics = async (req: Request, res: Response) => {
   try {
     const stats = await analyticsService.getLearnAnalytics();
     res.status(200).json(stats);
-  } catch (error: any) {
-    res.status(500).json({ message: error.message });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Internal Server Error" });
   }
 };
 
@@ -35,7 +36,8 @@ export const getUnderperformingItems = async (req: Request, res: Response) => {
   try {
     const result = await analyticsService.highlightUnderperformingItems();
     res.status(200).json(result);
-  } catch (error: any) {
-    res.status(500).json({ message: error.message });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Internal Server Error" });
   }
 };


### PR DESCRIPTION
## Description

`getLearnAnalytics` and `getUnderperformingItems` in `analytics.controller.ts` catch errors and send `error.message` directly to the client in 500 responses. This leaks internal error details (database errors, Prisma query details, file paths) to external users and bypasses the centralized error sanitization in `error.middleware.ts`.

Note: `trackContentView` (line 20) already correctly uses `"Internal server error"` — only these two endpoints are affected.

## Related Issue

Closes #2737

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Replaced `error.message` with generic `"Internal Server Error"` in both catch blocks
- Added `console.error(error)` for server-side logging

## Testing

- Verified 500 responses now return generic message
- Verified errors are still logged server-side

## Screenshots / Video

No UI changes.

## Checklist

- [x] My code follows the project style
- [x] I have not introduced new warnings

---

**GSSoC**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized server error responses for learning analytics and underperforming item requests.
  * Prevented internal error details from being exposed in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->