### PR TITLE
fix(expert-session): sanitize error messages in 500 responses across all 8 endpoints

### DIFF
--- a/server/src/module/expert-session/expert-session.controller.ts
+++ b/server/src/module/expert-session/expert-session.controller.ts
@@ -11,8 +11,15 @@ export class ExpertSessionController {
     try {
       const slots = await service.getAvailableSlots();
       res.json({ slots: slots.map((s) => s.toISOString()) });
-    } catch (err: any) {
-      res.status(err.status || 500).json({ message: err.message || "Failed to fetch available slots" });
+    } catch (err: unknown) {
+      console.error(err);
+      const status = typeof err === "object" && err !== null && "status" in err
+        ? (err as { status: number }).status || 500
+        : 500;
+      const message = status < 500
+        ? ((err as { message?: string }).message || "Operation failed")
+        : "Internal Server Error";
+      res.status(status).json({ message });
     }
   }
 
@@ -49,18 +56,20 @@ export class ExpertSessionController {
         await service.deletePendingSession(session.id);
         throw checkoutErr;
       }
-    } catch (err: any) {
-      // A payment-provider failure (e.g. Dodo returning 401 for a bad/rotated API
-      // key) is a server-side misconfiguration, not a client auth problem. Never
-      // mirror the provider's status to the browser: the global axios interceptor
-      // logs the user out on any 401, so passing Dodo's 401 through would silently
-      // sign the student out mid-checkout. Surface it as 502 and log the real cause.
+    } catch (err: unknown) {
+      console.error(err);
       if (err instanceof DodoPaymentsError) {
         console.error("[ExpertSession] Payment provider error during checkout:", err);
         res.status(502).json({ message: "Payment is temporarily unavailable. Please try again shortly." });
         return;
       }
-      res.status(err.status || 500).json({ message: err.message || "Failed to start checkout" });
+      const status = typeof err === "object" && err !== null && "status" in err
+        ? (err as { status: number }).status || 500
+        : 500;
+      const message = status < 500
+        ? ((err as { message?: string }).message || "Operation failed")
+        : "Internal Server Error";
+      res.status(status).json({ message });
     }
   }
 
@@ -77,8 +86,15 @@ export class ExpertSessionController {
       }
       const session = await service.getStatus(req.user.id, id);
       res.json(session);
-    } catch (err: any) {
-      res.status(err.status || 500).json({ message: err.message || "Failed to fetch session status" });
+    } catch (err: unknown) {
+      console.error(err);
+      const status = typeof err === "object" && err !== null && "status" in err
+        ? (err as { status: number }).status || 500
+        : 500;
+      const message = status < 500
+        ? ((err as { message?: string }).message || "Operation failed")
+        : "Internal Server Error";
+      res.status(status).json({ message });
     }
   }
 
@@ -90,8 +106,15 @@ export class ExpertSessionController {
       }
       const sessions = await service.getMySessions(req.user.id);
       res.json(sessions);
-    } catch (err: any) {
-      res.status(err.status || 500).json({ message: err.message || "Failed to fetch sessions" });
+    } catch (err: unknown) {
+      console.error(err);
+      const status = typeof err === "object" && err !== null && "status" in err
+        ? (err as { status: number }).status || 500
+        : 500;
+      const message = status < 500
+        ? ((err as { message?: string }).message || "Operation failed")
+        : "Internal Server Error";
+      res.status(status).json({ message });
     }
   }
 
@@ -100,8 +123,15 @@ export class ExpertSessionController {
     try {
       const blocks = await service.listAvailabilityBlocks();
       res.json(blocks);
-    } catch (err: any) {
-      res.status(err.status || 500).json({ message: err.message || "Failed to fetch availability blocks" });
+    } catch (err: unknown) {
+      console.error(err);
+      const status = typeof err === "object" && err !== null && "status" in err
+        ? (err as { status: number }).status || 500
+        : 500;
+      const message = status < 500
+        ? ((err as { message?: string }).message || "Operation failed")
+        : "Internal Server Error";
+      res.status(status).json({ message });
     }
   }
 
@@ -115,8 +145,15 @@ export class ExpertSessionController {
         reason,
       });
       res.status(201).json(block);
-    } catch (err: any) {
-      res.status(err.status || 500).json({ message: err.message || "Failed to create availability block" });
+    } catch (err: unknown) {
+      console.error(err);
+      const status = typeof err === "object" && err !== null && "status" in err
+        ? (err as { status: number }).status || 500
+        : 500;
+      const message = status < 500
+        ? ((err as { message?: string }).message || "Operation failed")
+        : "Internal Server Error";
+      res.status(status).json({ message });
     }
   }
 
@@ -129,8 +166,15 @@ export class ExpertSessionController {
       }
       await service.deleteAvailabilityBlock(id);
       res.json({ message: "Availability block removed" });
-    } catch (err: any) {
-      res.status(err.status || 500).json({ message: err.message || "Failed to delete availability block" });
+    } catch (err: unknown) {
+      console.error(err);
+      const status = typeof err === "object" && err !== null && "status" in err
+        ? (err as { status: number }).status || 500
+        : 500;
+      const message = status < 500
+        ? ((err as { message?: string }).message || "Operation failed")
+        : "Internal Server Error";
+      res.status(status).json({ message });
     }
   }
 
@@ -138,8 +182,15 @@ export class ExpertSessionController {
     try {
       const bookings = await service.listBookings();
       res.json(bookings);
-    } catch (err: any) {
-      res.status(err.status || 500).json({ message: err.message || "Failed to fetch bookings" });
+    } catch (err: unknown) {
+      console.error(err);
+      const status = typeof err === "object" && err !== null && "status" in err
+        ? (err as { status: number }).status || 500
+        : 500;
+      const message = status < 500
+        ? ((err as { message?: string }).message || "Operation failed")
+        : "Internal Server Error";
+      res.status(status).json({ message });
     }
   }
 }


### PR DESCRIPTION
## Description

Every catch block in `ExpertSessionController` sends `err.message` directly to the client. For 500-level errors, this leaks internal error details (database errors, Prisma query failures, file paths) and bypasses the centralized error sanitization in `error.middleware.ts`.

Affected endpoints (8 total):
- `getAvailableSlots`
- `checkout`
- `getStatus`
- `getMySessions`
- `listAvailabilityBlocks`
- `createAvailabilityBlock`
- `deleteAvailabilityBlock`
- `listBookings`

For 500-level errors, the fix uses a generic `"Internal Server Error"` message. For known business errors (4xx), the original message is preserved.

## Related Issue

Closes #2738

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Changed `err: any` to `err: unknown` with proper type narrowing
- 500-level errors now return generic `"Internal Server Error"` message
- 4xx errors preserve the original error message for client feedback
- Added `console.error(err)` for server-side logging in all 8 catch blocks

## Testing

- Verified 500 responses return generic message
- Verified 4xx responses still return specific error messages
- Verified errors are logged server-side

## Screenshots / Video

No UI changes.

## Checklist

- [x] My code follows the project style
- [x] I have not introduced new warnings

---

**GSSoC**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling consistency across expert session operations.
  * Error responses now provide more reliable HTTP status codes and standardized fallback messages.
  * Added error logging to support faster diagnosis of failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->