### PR TITLE
fix(internship): replace any with Zod-inferred types on create/update methods

### DIFF
--- a/server/src/module/internship/internship.service.ts
+++ b/server/src/module/internship/internship.service.ts
@@ -1,4 +1,6 @@
 import { prisma } from "../../database/db.js";
+import { type z } from "zod";
+import { createGovInternshipSchema, updateGovInternshipSchema } from "./internship.validation.js";
 
 interface ListParams {
   page: number;
@@ -59,11 +61,11 @@ export class InternshipService {
     };
   }
 
-  async create(data: any) {
+  async create(data: z.infer<typeof createGovInternshipSchema>) {
     return prisma.govInternship.create({ data });
   }
 
-  async update(id: number, data: any) {
+  async update(id: number, data: z.infer<typeof updateGovInternshipSchema>) {
     return prisma.govInternship.update({
       where: { id },
       data,


### PR DESCRIPTION
## Description

`InternshipService.create()` and `InternshipService.update()` accept `data: any` with no type safety. The Zod schemas already exist in `internship.validation.ts` and the controller already validates with them before calling the service — but the service methods themselves use `any`, bypassing TypeScript's type checking.

This PR replaces `any` with Zod-inferred types, ensuring the service methods only accept validated data matching the schema.

## Related Issue

Closes #2739

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Imported Zod types and validation schemas into `internship.service.ts`
- Changed `create(data: any)` to `create(data: z.infer<typeof createGovInternshipSchema>)`
- Changed `update(id: number, data: any)` to `update(id: number, data: z.infer<typeof updateGovInternshipSchema>)`

## Testing

- Verified TypeScript compiles without errors
- Verified the controller's existing Zod validation still gates all input before reaching the service

## Screenshots / Video

No UI changes.

## Checklist

- [x] My code follows the project style
- [x] I have not introduced new warnings

---

**GSSoC**
