### PR TITLE
fix(behavioral): remove unnecessary as any cast on usageLimit action

### DIFF
--- a/server/src/module/behavioral/behavioral.routes.ts
+++ b/server/src/module/behavioral/behavioral.routes.ts
@@ -12,4 +12,4 @@ export const behavioralRouter = Router();
 
 behavioralRouter.use(authMiddleware, requireRole("STUDENT"));
 
-behavioralRouter.post("/evaluate", usageLimit("BEHAVIORAL_EVAL" as any), (req, res, next) => behavioralController.evaluate(req, res, next));
+behavioralRouter.post("/evaluate", usageLimit("BEHAVIORAL_EVAL"), (req, res, next) => behavioralController.evaluate(req, res, next));


### PR DESCRIPTION
## Description

`behavioral.routes.ts` line 15 uses `as any` to bypass TypeScript validation on the `usageLimit` middleware:

```typescript
usageLimit("BEHAVIORAL_EVAL" as any)
```

The `as any` cast suppresses the type check, meaning if `BEHAVIORAL_EVAL` is removed from the Prisma `UsageAction` enum during a migration, TypeScript will NOT report a compile-time error. At runtime, the invalid value would silently bypass the usage limit.

`BEHAVIORAL_EVAL` is confirmed to exist in the Prisma `UsageAction` enum, so the `as any` cast is unnecessary and can be safely removed.

## Related Issue

Closes #2741

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Removed `as any` cast from `usageLimit("BEHAVIORAL_EVAL" as any)`
- TypeScript now enforces the `UsageAction` enum at compile time

## Testing

- Verified TypeScript compiles without errors after removing the cast
- Verified `BEHAVIORAL_EVAL` is a valid `UsageAction` enum value

## Screenshots / Video

No UI changes.

## Checklist

- [x] My code follows the project style
- [x] I have not introduced new warnings

---

**GSSoC**
