### PR TITLE
fix(cache): add LRU eviction to prevent silent drops when cache is full -- closes #2776

### DIFF
--- a/server/src/utils/cache.ts
+++ b/server/src/utils/cache.ts
@@ -5,7 +5,24 @@ interface FallbackEntry {
   exp: number;
 }
 
+const MAX_ENTRIES = 10_000;
 const fallback = new Map<string, FallbackEntry>();
+
+function evictExpired(): void {
+  const now = Date.now();
+  for (const [key, entry] of fallback) {
+    if (now > entry.exp) fallback.delete(key);
+  }
+}
+
+function evictOldest(count: number): void {
+  const it = fallback.keys();
+  for (let i = 0; i < count; i++) {
+    const { value, done } = it.next();
+    if (done) break;
+    fallback.delete(value);
+  }
+}
 
 export async function cacheGet<T>(key: string): Promise<T | null> {
   if (redis) {
@@ -25,6 +42,11 @@ export async function cacheSet(key: string, value: unknown, ttlSeconds: number):
   if (redis) {
     await redis.set(key, serialized, "EX", ttlSeconds);
     return;
+  }
+  if (fallback.has(key)) fallback.delete(key);
+  else if (fallback.size >= MAX_ENTRIES) {
+    evictExpired();
+    if (fallback.size >= MAX_ENTRIES) evictOldest(Math.ceil(MAX_ENTRIES * 0.1));
   }
   fallback.set(key, { val: serialized, exp: Date.now() + ttlSeconds * 1000 });
 }


### PR DESCRIPTION
﻿## Closes #2776

### Problem
The in-memory fallback cache had no size limit. Once the Map grew large, it would consume unbounded memory with no eviction strategy.

### Fix
Added a MAX_ENTRIES cap (10,000) with LRU-style eviction: when full, expired entries are swept first; if still full, the oldest 10% of entries are evicted to make room.

### Changes
- server/src/utils/cache.ts: Added MAX_ENTRIES, evictExpired, evictOldest functions; updated cacheSet to evict before inserting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache reliability when the primary caching service is unavailable.
  * Added automatic cleanup of expired and older cached data to prevent uncontrolled memory growth.
  * Limited fallback cache storage to maintain application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->