### PR TITLE
fix(s3): guard against undefined Body in getBufferFromS3 -- closes #2777

### DIFF
--- a/server/src/utils/s3.utils.ts
+++ b/server/src/utils/s3.utils.ts
@@ -79,7 +79,8 @@ export async function getBufferFromS3(key: string): Promise<Buffer> {
       Key: key,
     }),
   );
-  return Buffer.from(await response.Body!.transformToByteArray());
+  if (!response.Body) throw new Error("S3 returned an empty body");
+  return Buffer.from(await response.Body.transformToByteArray());
 }
 
 export function getS3KeyFromUrl(url: string): string | null {


### PR DESCRIPTION
﻿## Closes #2777

### Problem
getBufferFromS3 uses a non-null assertion on response.Body which can be undefined for zero-byte objects or edge cases, causing a TypeError crash.

### Fix
Replaced the non-null assertion with an explicit guard that throws a descriptive error when Body is missing.

### Changes
- server/src/utils/s3.utils.ts: Added null check for response.Body before calling transformToByteArray()
