### PR TITLE
fix(payment): check subscription ID instead of status to allow upgrades -- closes #2762

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -183,14 +183,14 @@ export class PaymentService {
     // race conditions where concurrent webhooks create duplicate records.
     // All operations must succeed atomically or entire transaction rolls back.
     await prisma.$transaction(async (tx) => {
-      // Check if subscription is already active to prevent duplicate activations
-      const existingSubscription = await tx.user.findUnique({
-        where: { id: userId },
-        select: { subscriptionStatus: true },
+      // Check if this specific subscription has already been processed
+      const alreadyLinked = await tx.payment.findFirst({
+        where: { dodoSubscriptionId: sub.subscription_id },
+        select: { id: true },
       });
 
-      if (existingSubscription?.subscriptionStatus === "ACTIVE") {
-        console.log(`[Webhook] Subscription already active for user ${userId}, skipping duplicate activation`);
+      if (alreadyLinked) {
+        console.log(`[Webhook] Subscription ${sub.subscription_id} already linked, skipping duplicate activation`);
         return;
       }
 


### PR DESCRIPTION
﻿## Closes #2762

### Problem
activateSubscription aborts when subscriptionStatus is already ACTIVE, blocking legitimate upgrades (e.g., Monthly to Yearly).

### Fix
Replaced the ACTIVE status check with a check for whether the subscription ID has already been linked to a payment record. This correctly prevents duplicate webhooks while allowing upgrades.

### Changes
- server/src/module/payment/payment.service.ts: Changed duplicate check from subscriptionStatus to dodoSubscriptionId lookup
