### PR TITLE
fix(admin): invalidate JWT sessions when banning a user -- closes #2764

### DIFF
--- a/server/src/module/admin/admin-platform.service.ts
+++ b/server/src/module/admin/admin-platform.service.ts
@@ -195,11 +195,17 @@ export class AdminPlatformService {
     if (userId === adminId) throw new Error("Cannot modify your own status");
 
     try {
-      return await prisma.user.update({
+      const user = await prisma.user.update({
         where: { id: userId },
         data: { isActive },
         select: { id: true, name: true, email: true, role: true, isActive: true },
       });
+
+      if (!isActive) {
+        invalidateVersionCache(userId);
+      }
+
+      return user;
     } catch (err) {
       if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025") {
         throw new Error("User not found");


### PR DESCRIPTION
﻿## Closes #2764

### Problem
When an admin bans a user via updateUserStatus, the user's active JWT sessions are not invalidated, allowing banned users to continue accessing the platform.

### Fix
Added invalidateVersionCache(userId) call when deactivating a user, matching the behavior of deleteUser.

### Changes
- server/src/module/admin/admin-platform.service.ts: Added invalidateVersionCache call when isActive is false
