### PR TITLE
fix(payment): reset subscriptionPlan to FREE on cancel -- closes #2758

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -284,7 +284,7 @@ export class PaymentService {
 
     await prisma.user.update({
       where: { id: payment.userId },
-      data: { subscriptionStatus: "CANCELLED" },
+      data: { subscriptionStatus: "CANCELLED", subscriptionPlan: "FREE" },
     });
     await invalidateUserTierCache(payment.userId);
   }


### PR DESCRIPTION
﻿## Closes #2758

### Problem
cancelSubscription sets subscriptionStatus to CANCELLED but never resets subscriptionPlan to FREE, leaving stale plan data indefinitely.

### Fix
Added subscriptionPlan: "FREE" to the update data, matching the behavior of expireSubscription.

### Changes
- server/src/module/payment/payment.service.ts: Added subscriptionPlan reset in cancelSubscription
