### PR TITLE
fix: persist retry state in sessionStorage to prevent infinite reload loop (#2774)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,14 +11,15 @@ import ScrollProgressBar from "./components/common/ScrollProgressBar";
 import ScrollToTop from "./components/common/ScrollToTop";
 const ContributorsPage = lazyWithRetry(() => import("./module/contributors/ContributorsPage"));
 
-const retryState = new Map<() => Promise<{ default: ComponentType<unknown> }>, boolean>();
+const RETRY_KEY_PREFIX = "lazy-retry:";
 
 function lazyWithRetry<T extends ComponentType<unknown>>(factory: () => Promise<{ default: T }>): LazyExoticComponent<T> {
+  const retryKey = RETRY_KEY_PREFIX + factory.toString();
   return lazy(
     () =>
       factory().catch((err: unknown) => {
-        if (!retryState.get(factory)) {
-          retryState.set(factory, true);
+        if (!sessionStorage.getItem(retryKey)) {
+          sessionStorage.setItem(retryKey, "1");
           window.location.reload();
           return new Promise<never>(() => { });
         }


### PR DESCRIPTION
## Description

\etryState\ was a module-level \Map\, which gets recreated empty on every page reload. This means the check \if (!retryState.get(factory))\ is always truthy, causing \window.location.reload()\ to be called infinitely every time a chunk fails to load.

**Fix:** Replace the in-memory Map with \sessionStorage\, which persists across reloads. The retry key is derived from the factory function's source string (which is stable across reloads since it matches the import path).

Closes #2774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when loading application routes or components fails.
  * Retry attempts now persist across page reloads during the same browser session, helping prevent repeated reload loops while still allowing a one-time recovery attempt.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->