### PR TITLE
fix: wrap resume upload in Prisma transaction to prevent TOCTOU race (#2775)

### DIFF
--- a/server/src/module/upload/upload.controller.ts
+++ b/server/src/module/upload/upload.controller.ts
@@ -251,21 +251,27 @@ export class UploadController {
       }
 
       const userId = req.user.id;
-      const current = await prisma.user.findUnique({ where: { id: userId }, select: { resumes: true } });
 
-      let updatedResumes = current?.resumes ?? [];
-      if (updatedResumes.length >= MAX_RESUMES) {
-        const oldest = updatedResumes[0]!;
-        deleteFile(oldest);
-        updatedResumes = [...updatedResumes.slice(1), fileUrl];
-      } else {
-        updatedResumes = [...updatedResumes, fileUrl];
-      }
+      const user = await prisma.$transaction(async (tx) => {
+        const current = await tx.user.findUnique({
+          where: { id: userId },
+          select: { resumes: true },
+        });
 
-      const user = await prisma.user.update({
-        where: { id: userId },
-        data: { resumes: updatedResumes },
-        select: { id: true, name: true, email: true, role: true, contactNo: true, profilePic: true, resumes: true, company: true, designation: true, createdAt: true },
+        let updatedResumes = current?.resumes ?? [];
+        if (updatedResumes.length >= MAX_RESUMES) {
+          const oldest = updatedResumes[0]!;
+          deleteFile(oldest);
+          updatedResumes = [...updatedResumes.slice(1), fileUrl];
+        } else {
+          updatedResumes = [...updatedResumes, fileUrl];
+        }
+
+        return tx.user.update({
+          where: { id: userId },
+          data: { resumes: updatedResumes },
+          select: { id: true, name: true, email: true, role: true, contactNo: true, profilePic: true, resumes: true, company: true, designation: true, createdAt: true },
+        });
       });
 
       const signedResumes = await signUrls(user.resumes);

--- a/server/src/module/upload/upload.controller.ts
+++ b/server/src/module/upload/upload.controller.ts
@@ -252,27 +252,38 @@ export class UploadController {
 
       const userId = req.user.id;
 
-      const user = await prisma.$transaction(async (tx) => {
+      const { user, evictedResume } = await prisma.$transaction(async (tx) => {
+        // Serialize concurrent uploads for the same user: acquire a row lock so
+        // two parallel uploads cannot both read the same resumes array and then
+        // overwrite each other's write (lost update).
+        await tx.$queryRaw`SELECT id FROM "user" WHERE id = ${userId} FOR UPDATE`;
+
         const current = await tx.user.findUnique({
           where: { id: userId },
           select: { resumes: true },
         });
 
         let updatedResumes = current?.resumes ?? [];
+        let evictedResume: string | undefined;
         if (updatedResumes.length >= MAX_RESUMES) {
-          const oldest = updatedResumes[0]!;
-          deleteFile(oldest);
+          evictedResume = updatedResumes[0]!;
           updatedResumes = [...updatedResumes.slice(1), fileUrl];
         } else {
           updatedResumes = [...updatedResumes, fileUrl];
         }
 
-        return tx.user.update({
+        const updated = await tx.user.update({
           where: { id: userId },
           data: { resumes: updatedResumes },
-          select: { id: true, name: true, email: true, role: true, contactNo: true, profilePic: true, resumes: true, company: true, designation: true, createdAt: true },
+          select: { id: true, name: true, email: true, role: true, profilePic: true, resumes: true, company: true, designation: true, createdAt: true },
         });
+
+        return { user: updated, evictedResume };
       });
+
+      // S3 deletes are not transactional and cannot be rolled back, so the
+      // evicted file is removed only after the DB transaction commits.
+      if (evictedResume) deleteFile(evictedResume);
 
       const signedResumes = await signUrls(user.resumes);
 


### PR DESCRIPTION
## Description

\uploadProfileResume\ performed a read-then-write (\indUnique\ → compute → \update\) outside a transaction. Two concurrent uploads could both read the same old resume list, and the second \update\ would silently overwrite the first, losing a resume.

**Fix:** Wrap the read and write inside \prisma.\\ so the entire read-modify-write sequence is atomic. If two requests race, one will retry automatically and see the correct state.

Closes #2775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume uploads to prevent conflicting updates when multiple uploads occur close together.
  * Ensured resume records remain consistent if an upload update fails.
  * Continued enforcing the maximum resume limit by removing the oldest stored resume when necessary.
  * Resume files are now removed only after the updated resume information is successfully saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->