### PR TITLE
fix: add LRU eviction to cacheSet instead of silently dropping entries (#2776)

### DIFF
--- a/server/src/utils/cache.ts
+++ b/server/src/utils/cache.ts
@@ -23,13 +23,23 @@ export async function cacheGet<T>(key: string): Promise<T | null> {
     store.delete(key);
     return null;
   }
+  // Move to end to mark as recently used
+  store.delete(key);
+  store.set(key, entry);
   return JSON.parse(entry.val) as T;
 }
 
+function evictLRU(): void {
+  const oldest = store.keys().next().value;
+  if (oldest !== undefined) store.delete(oldest);
+}
+
 export async function cacheSet(key: string, value: unknown, ttlSeconds: number): Promise<void> {
-  if (store.size >= MAX_ENTRIES && !store.has(key)) {
-    sweepExpired();
-    if (store.size >= MAX_ENTRIES) return;
+  if (!store.has(key)) {
+    if (store.size >= MAX_ENTRIES) {
+      sweepExpired();
+      while (store.size >= MAX_ENTRIES) evictLRU();
+    }
   }
   store.set(key, { val: JSON.stringify(value), exp: Date.now() + ttlSeconds * 1000 });
 }


### PR DESCRIPTION
## Description

When the in-memory cache reached \MAX_ENTRIES\ (10,000) and neither \sweepExpired()\ nor the new-key check freed space, \cacheSet\ silently returned without storing the entry. This meant valid cache writes were lost with no indication.

**Fix:**
- \cacheGet\ now re-inserts accessed entries to maintain LRU order
- \cacheSet\ evicts the least-recently-used entry (oldest by insertion/access order) instead of dropping the new entry when at capacity
- Eviction runs in a loop to ensure space for the new entry

Closes #2776