### PR TITLE
fix: guard against undefined S3 Body instead of using non-null assertion (#2777)

### DIFF
--- a/server/src/utils/s3.utils.ts
+++ b/server/src/utils/s3.utils.ts
@@ -89,7 +89,10 @@ export async function getBufferFromS3(key: string): Promise<Buffer> {
       Key: key,
     }),
   );
-  return Buffer.from(await response.Body!.transformToByteArray());
+  if (!response.Body) {
+    throw new Error(`S3 object not found: ${key}`);
+  }
+  return Buffer.from(await response.Body.transformToByteArray());
 }
 
 export function getS3KeyFromUrl(url: string): string | null {


### PR DESCRIPTION
## Description

\getBufferFromS3\ used \esponse.Body!.transformToByteArray()\ with a non-null assertion. When \Body\ is \undefined\ (e.g., object doesn't exist, or S3 returns a \NoSuchKey\ response), this throws a \TypeError: Cannot read properties of undefined\ instead of a meaningful error.

**Fix:** Check \esponse.Body\ explicitly and throw a descriptive error if it's falsy, then remove the non-null assertion.

Closes #2777