### PR TITLE
fix: always reset saving state in ImageCropModal handleConfirm (#2778)

### DIFF
--- a/client/src/components/ImageCropModal.tsx
+++ b/client/src/components/ImageCropModal.tsx
@@ -50,6 +50,8 @@ export default function ImageCropModal({ imageSrc, aspect, onCrop, onClose }: Pr
       const blob = await getCroppedImg(imageSrc, croppedArea);
       onCrop(blob);
     } catch {
+      // Error logged by getCroppedImg
+    } finally {
       setSaving(false);
     }
   };


### PR DESCRIPTION
## Description

\handleConfirm\ sets \setSaving(true)\ before the async crop operation, but only resets it on error (in the \catch\ block). On success, \onCrop(blob)\ is called but \setSaving(false)\ is never invoked, leaving the button disabled permanently.

**Fix:** Move \setSaving(false)\ into a \inally\ block so it runs on both success and error paths.

Closes #2778

GSSoC