### PR TITLE
fix: add NaN validation for parseInt in aptitude controller

### DIFF
--- a/server/src/module/aptitude/aptitude.controller.ts
+++ b/server/src/module/aptitude/aptitude.controller.ts
@@ -31,6 +31,7 @@ export class AptitudeController {
   async submitAnswer(req: Request, res: Response, next: NextFunction) {
     try {
       const questionId = parseInt(req.params.id as string);
+      if (isNaN(questionId)) return res.status(400).json({ error: "Invalid question ID" });
       const studentId = req.user!.id;
       const { answer } = req.body;
       if (!answer) return res.status(400).json({ error: "Answer is required" });


### PR DESCRIPTION
Closes #2861

This PR adds NaN validation after parseInt(req.params.id) in the aptitude controller's submitAnswer method. Previously, non-numeric :id parameters would pass NaN directly to Prisma, causing a 500 error.

Changes:
- server/src/module/aptitude/aptitude.controller.ts — Added if (isNaN(questionId)) check returning 400 Bad Request

GSSOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for invalid question IDs when submitting answers.
  - Requests with malformed question IDs now return a clear 400 error instead of being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->