### PR TITLE
fix: reset subscriptionPlan to FREE in holdSubscription

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -366,7 +366,10 @@ export class PaymentService {
 
     await prisma.user.update({
       where: { id: payment.userId },
-      data: { subscriptionStatus: "EXPIRED" },
+      data: {
+        subscriptionStatus: "EXPIRED",
+        subscriptionPlan: "FREE",
+      },
     });
     await invalidateUserTierCache(payment.userId);
   }


### PR DESCRIPTION
Closes #2863

This PR fixes the holdSubscription method in payment.service.ts which was setting subscriptionStatus: 'EXPIRED' without resetting subscriptionPlan to 'FREE'. This caused stale plan data to persist, unlike the expireSubscription method which correctly resets both fields.

Changes:
- server/src/module/payment/payment.service.ts — Added subscriptionPlan: 'FREE' to the holdSubscription update call

GSSOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired subscriptions now correctly switch to the free plan, preventing outdated subscription plan information from being retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->