### PR TITLE
fix: add orderBy to DSA daily problem query for deterministic selection

### DIFF
--- a/server/src/module/dsa/dsa.service.ts
+++ b/server/src/module/dsa/dsa.service.ts
@@ -1353,7 +1353,9 @@ Return ONLY a JSON array with exactly ${testCases.length} items in the same orde
   async getDailyProblem(userId?: number) {
     const today = new Date().toISOString().slice(0, 10);
 
-    const problems = await prisma.dsaProblem.findMany();
+    const problems = await prisma.dsaProblem.findMany({
+      orderBy: { id: "asc" },
+    });
 
     if (!problems.length) {
       throw new Error("No DSA problems found");


### PR DESCRIPTION
Closes #2864

This PR adds orderBy: { id: 'asc' } to the DSA daily problem query which previously had no ordering. Without an explicit ORDER BY, PostgreSQL does not guarantee row order, so the 'daily problem' could change between requests depending on the query planner.

Changes:
- server/src/module/dsa/dsa.service.ts — Added orderBy: { id: 'asc' } to prisma.dsaProblem.findMany() in getDailyProblem()

GSSOC