### PR TITLE
fix: bound presigned-URL generation concurrency to prevent resource spikes (#2818)

### DIFF
--- a/server/src/utils/s3.utils.ts
+++ b/server/src/utils/s3.utils.ts
@@ -109,7 +109,18 @@ export async function signUrl(url: string, expiresIn = 3600): Promise<string> {
 
 /** Sign every URL in a string array (e.g. user.resumes). */
 export async function signUrls(urls: string[], expiresIn = 3600): Promise<string[]> {
-  return Promise.all(urls.map((u) => signUrl(u, expiresIn)));
+  // Cap concurrency to prevent spiking outbound calls and resource contention
+  const CONCURRENCY_LIMIT = 10;
+  const results: string[] = [];
+
+  for (let i = 0; i < urls.length; i += CONCURRENCY_LIMIT) {
+    const chunk = urls.slice(i, i + CONCURRENCY_LIMIT);
+    // Process only 10 URLs concurrently
+    const signedChunk = await Promise.all(chunk.map((u) => signUrl(u, expiresIn)));
+    results.push(...signedChunk);
+  }
+
+  return results;
 }
 
 


### PR DESCRIPTION
# Pull Request

## Description
This PR resolves an unbounded concurrency vulnerability in `s3.utils.ts`. 

Previously, `signUrls` utilized an unbounded `Promise.all`, which risked spiking outbound network calls, hitting rate limits, and contending for event loop resources if passed a massive array of URLs. 

The function has been refactored to chunk the input array, safely processing the presigned URL generation in bounded batches (max 10 concurrent operations).

## Related Issue
Fixes #2818

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
*   Verified that chunking logic correctly concatenates and resolves the full original array.
*   Ran `npm run lint` locally to ensure no syntax or typing violations.

## Screenshots / Video

> **REQUIRED for any UI change.** PRs that modify visible UI (layout, components, styles, pages) will be rejected without this.

_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [x] **Screenshot or video attached for every UI change** (PR will be rejected if missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved handling of multiple file links by processing them in controlled batches.
  * Reduced the likelihood of slowdowns or service strain when generating many signed links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->