### PR TITLE
feat: apply tier-aware caching to job feed and roadmap public lists

### DIFF
--- a/server/src/module/job-feed/job-feed.service.ts
+++ b/server/src/module/job-feed/job-feed.service.ts
@@ -1,12 +1,18 @@
 ﻿import { Prisma } from "@prisma/client";
 import { prisma } from "../../database/db.js";
 import { jobIndexService } from "../job-index/job-index.service.js";
-import { cacheGet, cacheSet, cacheDel } from "../../utils/cache.js";
+import { cacheGet, cacheSet, cacheDel, cacheDelPattern } from "../../utils/cache.js";
+import type { PlanTier } from "../../config/usage-limits.js";
 
 const prefKey = (id: number) => `job-pref:${id}`;
+const FEED_TTL = 300; // 5 minutes TTL for feed data
 
 export class JobFeedService {
-  async getFeed(userId: number, page = 1, limit = 10) {
+  async getFeed(userId: number, page = 1, limit = 10, tier: PlanTier = "FREE") {
+    const cacheKey = `job-feed:list:${tier}:${userId}:${page}:${limit}`;
+    const cached = await cacheGet(cacheKey);
+    if (cached) return cached as never;
+
     const skip = (page - 1) * limit;
 
     const [matches, total] = await Promise.all([
@@ -20,7 +26,7 @@ export class JobFeedService {
       prisma.jobMatch.count({ where: { userId, dismissed: false } }),
     ]);
 
-    return {
+    const result = {
       matches: matches.map((m: any) => ({
         matchId: m.id,
         score: Math.round(m.score * 100),
@@ -46,6 +52,9 @@ export class JobFeedService {
       })),
       pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
     };
+
+    await cacheSet(cacheKey, result, FEED_TTL);
+    return result;
   }
 
   async dismiss(userId: number, matchId: number) {
@@ -66,6 +75,9 @@ export class JobFeedService {
       }
       throw err;
     });
+
+    // Invalidate the feed cache so the dismissed job disappears immediately
+    await cacheDelPattern(`job-feed:list:*:${userId}:*`);
   }
 
   async save(userId: number, matchId: number) {
@@ -73,6 +85,9 @@ export class JobFeedService {
       where: { id: matchId, userId },
       data: { saved: true },
     });
+    
+    // Invalidate caches
+    await cacheDelPattern(`job-feed:list:*:${userId}:*`);
   }
 
   async markSeen(userId: number, matchId: number) {
@@ -80,6 +95,9 @@ export class JobFeedService {
       where: { id: matchId, userId },
       data: { seen: true },
     });
+    
+    // Invalidate caches
+    await cacheDelPattern(`job-feed:list:*:${userId}:*`);
   }
 
   async getSaved(userId: number) {
@@ -138,6 +156,9 @@ export class JobFeedService {
     jobIndexService.generateUserEmbedding(userId).catch((err) => console.error("Failed to generate user embedding:", err));
 
     await cacheDel(prefKey(userId));
+    // Also clear the feed cache because their new preferences will change their matches
+    await cacheDelPattern(`job-feed:list:*:${userId}:*`);
+    
     return pref;
   }
 
@@ -152,4 +173,3 @@ export class JobFeedService {
 }
 
 export const jobFeedService = new JobFeedService();
-

--- a/server/src/module/job-feed/job-feed.service.ts
+++ b/server/src/module/job-feed/job-feed.service.ts
@@ -7,11 +7,51 @@ import type { PlanTier } from "../../config/usage-limits.js";
 const prefKey = (id: number) => `job-pref:${id}`;
 const FEED_TTL = 300; // 5 minutes TTL for feed data
 
+export interface JobFeedResponse {
+  matches: {
+    matchId: number;
+    score: number;
+    skillMatch: number;
+    locationMatch: number;
+    salaryMatch: number;
+    saved: boolean;
+    seen: boolean;
+    job: {
+      id: number;
+      title: string;
+      company: string;
+      location: string;
+      salary: string | null;
+      skills: string[];
+      workMode: string | null;
+      experienceLevel: string | null;
+      applicationUrl: string | null;
+      tags: string[];
+      domain: string | null;
+      createdAt: Date;
+    };
+  }[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+async function invalidateFeedCache(userId: number) {
+  await Promise.all(
+    ["FREE", "PREMIUM"].map((tier) =>
+      cacheDelPattern(`job-feed:list:${tier}:${userId}:`),
+    ),
+  );
+}
+
 export class JobFeedService {
   async getFeed(userId: number, page = 1, limit = 10, tier: PlanTier = "FREE") {
     const cacheKey = `job-feed:list:${tier}:${userId}:${page}:${limit}`;
-    const cached = await cacheGet(cacheKey);
-    if (cached) return cached as never;
+    const cached = await cacheGet<JobFeedResponse>(cacheKey);
+    if (cached) return cached;
 
     const skip = (page - 1) * limit;
 
@@ -26,7 +66,7 @@ export class JobFeedService {
       prisma.jobMatch.count({ where: { userId, dismissed: false } }),
     ]);
 
-    const result = {
+    const result: JobFeedResponse = {
       matches: matches.map((m: any) => ({
         matchId: m.id,
         score: Math.round(m.score * 100),
@@ -77,7 +117,7 @@ export class JobFeedService {
     });
 
     // Invalidate the feed cache so the dismissed job disappears immediately
-    await cacheDelPattern(`job-feed:list:*:${userId}:*`);
+    await invalidateFeedCache(userId);
   }
 
   async save(userId: number, matchId: number) {
@@ -87,7 +127,7 @@ export class JobFeedService {
     });
     
     // Invalidate caches
-    await cacheDelPattern(`job-feed:list:*:${userId}:*`);
+    await invalidateFeedCache(userId);
   }
 
   async markSeen(userId: number, matchId: number) {
@@ -97,7 +137,7 @@ export class JobFeedService {
     });
     
     // Invalidate caches
-    await cacheDelPattern(`job-feed:list:*:${userId}:*`);
+    await invalidateFeedCache(userId);
   }
 
   async getSaved(userId: number) {
@@ -157,7 +197,7 @@ export class JobFeedService {
 
     await cacheDel(prefKey(userId));
     // Also clear the feed cache because their new preferences will change their matches
-    await cacheDelPattern(`job-feed:list:*:${userId}:*`);
+    await invalidateFeedCache(userId);
     
     return pref;
   }

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -9,6 +9,49 @@ import type { PlanTier } from "../../config/usage-limits.js";
 const ROADMAP_STRUCTURE_TTL = 300; // 5 minutes
 const ROADMAP_LIST_TTL = 300; // 5 minutes
 
+export interface PublishedRoadmapsResponse {
+  roadmaps: {
+    id: number;
+    slug: string;
+    title: string;
+    shortDescription: string;
+    level: string;
+    estimatedHours: number;
+    coverImage: string | null;
+    ogImage: string | null;
+    topicCount: number;
+    enrolledCount: number;
+    tags: string[];
+    updatedAt: Date;
+    isAiGenerated: boolean;
+    ownerUserId: number | null;
+  }[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export type CommunityRoadmapsResponse = {
+  id: number;
+  slug: string;
+  title: string;
+  shortDescription: string;
+  level: string;
+  estimatedHours: number;
+  coverImage: string | null;
+  ogImage: string | null;
+  topicCount: number;
+  enrolledCount: number;
+  tags: string[];
+  updatedAt: Date;
+  isAiGenerated: boolean;
+  ownerUserId: number | null;
+  creatorName: string | null;
+}[];
+
 function stableKey(obj: Record<string, unknown>): string {
   return JSON.stringify(Object.fromEntries(Object.entries(obj).sort(([a], [b]) => a.localeCompare(b))));
 }
@@ -164,10 +207,10 @@ export async function listPublishedRoadmaps(
     userId?: number | undefined;
   },
   tier: PlanTier = "FREE"
-) {
+): Promise<PublishedRoadmapsResponse> {
   const cacheKey = `roadmaps:list:${tier}:${stableKey(opts as unknown as Record<string, unknown>)}`;
-  const cached = await cacheGet(cacheKey);
-  if (cached) return cached as never;
+  const cached = await cacheGet<PublishedRoadmapsResponse>(cacheKey);
+  if (cached) return cached;
 
   // Build the visibility condition: public roadmaps + caller's own unpublished ones
   const visibilityCondition: Prisma.roadmapWhereInput = opts.userId
@@ -234,7 +277,7 @@ export async function listPublishedRoadmaps(
     prisma.roadmap.count({ where }),
   ]);
 
-  const result = {
+  const result: PublishedRoadmapsResponse = {
     roadmaps,
     pagination: {
       page: opts.page,
@@ -248,10 +291,10 @@ export async function listPublishedRoadmaps(
   return result;
 }
 
-export async function listCommunityRoadmaps(limit = 24, tier: PlanTier = "FREE") {
+export async function listCommunityRoadmaps(limit = 24, tier: PlanTier = "FREE"): Promise<CommunityRoadmapsResponse> {
   const cacheKey = `roadmaps:community:${tier}:${limit}`;
-  const cached = await cacheGet(cacheKey);
-  if (cached) return cached as never;
+  const cached = await cacheGet<CommunityRoadmapsResponse>(cacheKey);
+  if (cached) return cached;
 
   const rows = await prisma.roadmap.findMany({
     where: { isPubliclyShared: true, isAiGenerated: true },
@@ -276,7 +319,7 @@ export async function listCommunityRoadmaps(limit = 24, tier: PlanTier = "FREE")
     },
   });
   
-  const result = rows.map(({ owner, ...r }) => ({
+  const result: CommunityRoadmapsResponse = rows.map(({ owner, ...r }) => ({
     ...r,
     creatorName: owner?.name ?? null,
   }));

--- a/server/src/module/roadmap/roadmap.service.ts
+++ b/server/src/module/roadmap/roadmap.service.ts
@@ -3,8 +3,15 @@ import { invalidateRecommendations } from "../recommendation/recommendation.serv
 import { appCache } from "../../middleware/cache.middleware.js";
 import { Prisma } from "@prisma/client";
 import type { EnrollInput } from "./roadmap.validation.js";
+import { cacheGet, cacheSet } from "../../utils/cache.js";
+import type { PlanTier } from "../../config/usage-limits.js";
 
 const ROADMAP_STRUCTURE_TTL = 300; // 5 minutes
+const ROADMAP_LIST_TTL = 300; // 5 minutes
+
+function stableKey(obj: Record<string, unknown>): string {
+  return JSON.stringify(Object.fromEntries(Object.entries(obj).sort(([a], [b]) => a.localeCompare(b))));
+}
 
 interface WeeklyPlanWeek {
   week: number;
@@ -146,15 +153,22 @@ export function buildWeeklyPlan(
   return { plan, targetEndDate };
 }
 
-export async function listPublishedRoadmaps(opts: {
-  page: number;
-  limit: number;
-  level?: string | undefined;
-  search?: string | undefined;
-  tag?: string | undefined;
-  category?: string | undefined;
-  userId?: number | undefined;
-}) {
+export async function listPublishedRoadmaps(
+  opts: {
+    page: number;
+    limit: number;
+    level?: string | undefined;
+    search?: string | undefined;
+    tag?: string | undefined;
+    category?: string | undefined;
+    userId?: number | undefined;
+  },
+  tier: PlanTier = "FREE"
+) {
+  const cacheKey = `roadmaps:list:${tier}:${stableKey(opts as unknown as Record<string, unknown>)}`;
+  const cached = await cacheGet(cacheKey);
+  if (cached) return cached as never;
+
   // Build the visibility condition: public roadmaps + caller's own unpublished ones
   const visibilityCondition: Prisma.roadmapWhereInput = opts.userId
     ? { OR: [{ isPublished: true }, { isPublished: false, ownerUserId: opts.userId }] }
@@ -220,7 +234,7 @@ export async function listPublishedRoadmaps(opts: {
     prisma.roadmap.count({ where }),
   ]);
 
-  return {
+  const result = {
     roadmaps,
     pagination: {
       page: opts.page,
@@ -229,9 +243,16 @@ export async function listPublishedRoadmaps(opts: {
       totalPages: Math.ceil(total / opts.limit),
     },
   };
+
+  await cacheSet(cacheKey, result, ROADMAP_LIST_TTL);
+  return result;
 }
 
-export async function listCommunityRoadmaps(limit = 24) {
+export async function listCommunityRoadmaps(limit = 24, tier: PlanTier = "FREE") {
+  const cacheKey = `roadmaps:community:${tier}:${limit}`;
+  const cached = await cacheGet(cacheKey);
+  if (cached) return cached as never;
+
   const rows = await prisma.roadmap.findMany({
     where: { isPubliclyShared: true, isAiGenerated: true },
     orderBy: { updatedAt: "desc" },
@@ -254,10 +275,14 @@ export async function listCommunityRoadmaps(limit = 24) {
       owner: { select: { name: true } },
     },
   });
-  return rows.map(({ owner, ...r }) => ({
+  
+  const result = rows.map(({ owner, ...r }) => ({
     ...r,
     creatorName: owner?.name ?? null,
   }));
+
+  await cacheSet(cacheKey, result, ROADMAP_LIST_TTL);
+  return result;
 }
 
 type RoadmapStructure = Prisma.roadmapGetPayload<{
@@ -1259,4 +1284,3 @@ export function summarizeProgress(
     hoursTotal,
   };
 }
-


### PR DESCRIPTION
# Pull Request

## Description
Implemented tier-aware caching for read-heavy public list endpoints in `job-feed.service.ts` and `roadmap.service.ts` (noted that `company.service.ts` was already completed). 
- Used deterministic keys encoding the `tier` and pagination/filter parameters.
- Added a 5-minute TTL (`cacheSet`) for both feeds and roadmaps.
- Added proactive cache invalidation (`cacheDelPattern`) in the job feed service when a user dismisses, saves, marks a job as seen, or updates their preferences so they never see stale data.

## Related Issue
Fixes #2822

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
- Ran `npm run typecheck` to verify no new TypeScript compilation errors.
- Verified that list endpoints correctly wrap requests in `cacheGet` and `cacheSet`.
- Ensured mutations in `job-feed.service.ts` successfully trigger `cacheDelPattern` to invalidate stale lists.

## Screenshots / Video

> **REQUIRED for any UI change.** PRs that modify visible UI (layout, components, styles, pages) will be rejected without this.

<!-- Add a screenshot or screen recording below. Drag and drop images/GIFs here, or paste a video link. -->

_No UI changes in this PR_

## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [ ] **Screenshot or video attached for every UI change** (PR will be rejected if missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved loading speed for job feeds and roadmap listings by reusing cached results.
  - Cache behavior is now consistent across different subscription tiers and varying filter options.

- **Bug Fixes**
  - Job feeds now refresh correctly after dismissing, saving, or marking jobs as seen.
  - Updated job preferences are reflected promptly in subsequent feed results.
  - Roadmap listings continue to display creator names consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->