### PR TITLE
test: cover aptitude scoring, streak calculation, and progress upserts

### DIFF
--- a/server/src/module/aptitude/__tests__/aptitude.service.test.ts
+++ b/server/src/module/aptitude/__tests__/aptitude.service.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, vi, type Mocked } from 'vitest';
+import { AptitudeService } from '../aptitude.service.js';
+import { prisma } from '../../../database/db.js';
+import * as difficultyHelpers from '../aptitude.difficulty.js';
+
+// Mock the database and external dependencies
+vi.mock('../../../database/db.js', () => ({
+  prisma: {
+    aptitudeQuestion: { count: vi.fn(), findUnique: vi.fn() },
+    studentAptitudeProgress: { findMany: vi.fn(), count: vi.fn(), upsert: vi.fn() },
+    studentAptitudeTopicProgress: { findUnique: vi.fn(), upsert: vi.fn() },
+  }
+}));
+
+// Mock the milestone service so tests don't try to trigger side effects.
+// We use an actual ES6 class here because AptitudeService calls `new MilestoneService()`,
+// and arrow functions cannot be used as constructors.
+vi.mock('../../milestone/milestone.service.js', () => ({
+  MilestoneService: class {
+    checkAptitudeMilestone = vi.fn().mockResolvedValue(undefined);
+  }
+}));
+
+// Mock the pure function that calculates difficulty shifts
+vi.mock('../aptitude.difficulty.js', () => ({
+  applyAptitudeDifficultyChange: vi.fn(),
+}));
+
+describe('AptitudeService - Scoring & Progress', () => {
+  let service: AptitudeService;
+  const mockedPrisma = prisma as unknown as Mocked<typeof prisma>;
+
+  beforeEach(() => {
+    service = new AptitudeService();
+    vi.clearAllMocks();
+  });
+
+  describe('getProgress (Score computation and Streak logic)', () => {
+    const NOW_MS = Date.now();
+    const TODAY = new Date(NOW_MS);
+    TODAY.setUTCHours(0, 0, 0, 0);
+
+    const YESTERDAY = new Date(TODAY.getTime() - 86400000);
+    const TWO_DAYS_AGO = new Date(TODAY.getTime() - 86400000 * 2);
+    const THREE_DAYS_AGO = new Date(TODAY.getTime() - 86400000 * 3);
+
+    it('handles a fresh user with 0 questions attempted', async () => {
+      mockedPrisma.aptitudeQuestion.count.mockResolvedValue(100);
+      mockedPrisma.studentAptitudeProgress.findMany.mockResolvedValue([]);
+
+      const result = await service.getProgress(1);
+
+      expect(result.totalQuestions).toBe(100);
+      expect(result.totalAnswered).toBe(0);
+      expect(result.totalCorrect).toBe(0);
+      expect(result.currentStreak).toBe(0);
+    });
+
+    it('computes correct totals for all correct answers', async () => {
+      mockedPrisma.aptitudeQuestion.count.mockResolvedValue(100);
+      mockedPrisma.studentAptitudeProgress.findMany.mockResolvedValue([
+        { correct: true, lastPracticedAt: TODAY },
+        { correct: true, lastPracticedAt: TODAY },
+      ] as any);
+
+      const result = await service.getProgress(1);
+
+      expect(result.totalAnswered).toBe(2);
+      expect(result.totalCorrect).toBe(2);
+    });
+
+    it('computes correct totals for all incorrect answers', async () => {
+      mockedPrisma.aptitudeQuestion.count.mockResolvedValue(100);
+      mockedPrisma.studentAptitudeProgress.findMany.mockResolvedValue([
+        { correct: false, lastPracticedAt: TODAY },
+        { correct: false, lastPracticedAt: TODAY },
+      ] as any);
+
+      const result = await service.getProgress(1);
+
+      expect(result.totalAnswered).toBe(2);
+      expect(result.totalCorrect).toBe(0);
+    });
+
+    it('calculates streak correctly if practiced today, yesterday, and two days ago', async () => {
+      mockedPrisma.aptitudeQuestion.count.mockResolvedValue(100);
+      mockedPrisma.studentAptitudeProgress.findMany.mockResolvedValue([
+        { correct: true, lastPracticedAt: TODAY },
+        { correct: false, lastPracticedAt: YESTERDAY },
+        { correct: true, lastPracticedAt: TWO_DAYS_AGO },
+      ] as any);
+
+      const result = await service.getProgress(1);
+      
+      // Streak should be 3
+      expect(result.currentStreak).toBe(3);
+    });
+
+    it('streak falls back to 0 if yesterday and today were missed', async () => {
+      mockedPrisma.aptitudeQuestion.count.mockResolvedValue(100);
+      mockedPrisma.studentAptitudeProgress.findMany.mockResolvedValue([
+        { correct: true, lastPracticedAt: TWO_DAYS_AGO },
+        { correct: true, lastPracticedAt: THREE_DAYS_AGO },
+      ] as any);
+
+      const result = await service.getProgress(1);
+      
+      // Expected today or yesterday. The latest is two days ago, so streak breaks.
+      expect(result.currentStreak).toBe(0);
+    });
+  });
+
+  describe('submitAnswer (Progress Upsert semantics)', () => {
+    it('throws if question does not exist', async () => {
+      mockedPrisma.aptitudeQuestion.findUnique.mockResolvedValue(null);
+      await expect(service.submitAnswer(1, 999, 'A')).rejects.toThrow('Question not found');
+    });
+
+    it('upserts best/latest score correctly for a correct answer', async () => {
+      // 1. Setup mock question
+      mockedPrisma.aptitudeQuestion.findUnique.mockResolvedValue({
+        id: 10,
+        topicId: 5,
+        correctAnswer: 'C',
+        explanation: 'Because C is correct',
+      } as any);
+
+      // 2. Setup mock topic state (previous difficulty)
+      mockedPrisma.studentAptitudeTopicProgress.findUnique.mockResolvedValue({
+        currentDifficulty: 'MEDIUM'
+      } as any);
+
+      // 3. Setup the pure function mock
+      vi.mocked(difficultyHelpers.applyAptitudeDifficultyChange).mockReturnValue({
+        next: 'HARD',
+        difficultyChange: 'INCREASED'
+      } as any);
+
+      // Execute
+      const result = await service.submitAnswer(1, 10, 'C');
+
+      // Assertions
+      expect(result.correct).toBe(true);
+      expect(result.correctAnswer).toBe('C');
+      expect(result.previousDifficulty).toBe('MEDIUM');
+      expect(result.currentDifficulty).toBe('HARD');
+
+      // Verify Upserts: Should set correct: true
+      expect(mockedPrisma.studentAptitudeProgress.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ answered: true, correct: true }),
+          update: expect.objectContaining({ answered: true, correct: true }),
+        })
+      );
+
+      // Verify Topic difficulty upserted
+      expect(mockedPrisma.studentAptitudeTopicProgress.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ currentDifficulty: 'HARD' }),
+          update: expect.objectContaining({ currentDifficulty: 'HARD' }),
+        })
+      );
+    });
+
+    it('upserts correctly for an incorrect answer', async () => {
+      mockedPrisma.aptitudeQuestion.findUnique.mockResolvedValue({
+        id: 10,
+        topicId: 5,
+        correctAnswer: 'A',
+        explanation: 'Because A is correct',
+      } as any);
+
+      mockedPrisma.studentAptitudeTopicProgress.findUnique.mockResolvedValue({
+        currentDifficulty: 'HARD'
+      } as any);
+
+      vi.mocked(difficultyHelpers.applyAptitudeDifficultyChange).mockReturnValue({
+        next: 'MEDIUM',
+        difficultyChange: 'DECREASED'
+      } as any);
+
+      const result = await service.submitAnswer(1, 10, 'B'); // Wrong answer
+
+      expect(result.correct).toBe(false);
+      expect(result.correctAnswer).toBe('A');
+
+      // Verify Upserts: Should set correct: false
+      expect(mockedPrisma.studentAptitudeProgress.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ answered: true, correct: false }),
+          update: expect.objectContaining({ answered: true, correct: false }),
+        })
+      );
+    });
+  });
+});

--- a/server/src/module/aptitude/__tests__/aptitude.service.test.ts
+++ b/server/src/module/aptitude/__tests__/aptitude.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, type Mocked } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AptitudeService } from '../aptitude.service.js';
 import { prisma } from '../../../database/db.js';
 import * as difficultyHelpers from '../aptitude.difficulty.js';
@@ -28,7 +28,6 @@ vi.mock('../aptitude.difficulty.js', () => ({
 
 describe('AptitudeService - Scoring & Progress', () => {
   let service: AptitudeService;
-  const mockedPrisma = prisma as unknown as Mocked<typeof prisma>;
 
   beforeEach(() => {
     service = new AptitudeService();
@@ -45,8 +44,8 @@ describe('AptitudeService - Scoring & Progress', () => {
     const THREE_DAYS_AGO = new Date(TODAY.getTime() - 86400000 * 3);
 
     it('handles a fresh user with 0 questions attempted', async () => {
-      mockedPrisma.aptitudeQuestion.count.mockResolvedValue(100);
-      mockedPrisma.studentAptitudeProgress.findMany.mockResolvedValue([]);
+      vi.mocked(prisma.aptitudeQuestion.count).mockResolvedValue(100);
+      vi.mocked(prisma.studentAptitudeProgress.findMany).mockResolvedValue([]);
 
       const result = await service.getProgress(1);
 
@@ -57,8 +56,8 @@ describe('AptitudeService - Scoring & Progress', () => {
     });
 
     it('computes correct totals for all correct answers', async () => {
-      mockedPrisma.aptitudeQuestion.count.mockResolvedValue(100);
-      mockedPrisma.studentAptitudeProgress.findMany.mockResolvedValue([
+      vi.mocked(prisma.aptitudeQuestion.count).mockResolvedValue(100);
+      vi.mocked(prisma.studentAptitudeProgress.findMany).mockResolvedValue([
         { correct: true, lastPracticedAt: TODAY },
         { correct: true, lastPracticedAt: TODAY },
       ] as any);
@@ -70,8 +69,8 @@ describe('AptitudeService - Scoring & Progress', () => {
     });
 
     it('computes correct totals for all incorrect answers', async () => {
-      mockedPrisma.aptitudeQuestion.count.mockResolvedValue(100);
-      mockedPrisma.studentAptitudeProgress.findMany.mockResolvedValue([
+      vi.mocked(prisma.aptitudeQuestion.count).mockResolvedValue(100);
+      vi.mocked(prisma.studentAptitudeProgress.findMany).mockResolvedValue([
         { correct: false, lastPracticedAt: TODAY },
         { correct: false, lastPracticedAt: TODAY },
       ] as any);
@@ -83,8 +82,8 @@ describe('AptitudeService - Scoring & Progress', () => {
     });
 
     it('calculates streak correctly if practiced today, yesterday, and two days ago', async () => {
-      mockedPrisma.aptitudeQuestion.count.mockResolvedValue(100);
-      mockedPrisma.studentAptitudeProgress.findMany.mockResolvedValue([
+      vi.mocked(prisma.aptitudeQuestion.count).mockResolvedValue(100);
+      vi.mocked(prisma.studentAptitudeProgress.findMany).mockResolvedValue([
         { correct: true, lastPracticedAt: TODAY },
         { correct: false, lastPracticedAt: YESTERDAY },
         { correct: true, lastPracticedAt: TWO_DAYS_AGO },
@@ -97,8 +96,8 @@ describe('AptitudeService - Scoring & Progress', () => {
     });
 
     it('streak falls back to 0 if yesterday and today were missed', async () => {
-      mockedPrisma.aptitudeQuestion.count.mockResolvedValue(100);
-      mockedPrisma.studentAptitudeProgress.findMany.mockResolvedValue([
+      vi.mocked(prisma.aptitudeQuestion.count).mockResolvedValue(100);
+      vi.mocked(prisma.studentAptitudeProgress.findMany).mockResolvedValue([
         { correct: true, lastPracticedAt: TWO_DAYS_AGO },
         { correct: true, lastPracticedAt: THREE_DAYS_AGO },
       ] as any);
@@ -112,13 +111,13 @@ describe('AptitudeService - Scoring & Progress', () => {
 
   describe('submitAnswer (Progress Upsert semantics)', () => {
     it('throws if question does not exist', async () => {
-      mockedPrisma.aptitudeQuestion.findUnique.mockResolvedValue(null);
+      vi.mocked(prisma.aptitudeQuestion.findUnique).mockResolvedValue(null);
       await expect(service.submitAnswer(1, 999, 'A')).rejects.toThrow('Question not found');
     });
 
     it('upserts best/latest score correctly for a correct answer', async () => {
       // 1. Setup mock question
-      mockedPrisma.aptitudeQuestion.findUnique.mockResolvedValue({
+      vi.mocked(prisma.aptitudeQuestion.findUnique).mockResolvedValue({
         id: 10,
         topicId: 5,
         correctAnswer: 'C',
@@ -126,7 +125,7 @@ describe('AptitudeService - Scoring & Progress', () => {
       } as any);
 
       // 2. Setup mock topic state (previous difficulty)
-      mockedPrisma.studentAptitudeTopicProgress.findUnique.mockResolvedValue({
+      vi.mocked(prisma.studentAptitudeTopicProgress.findUnique).mockResolvedValue({
         currentDifficulty: 'MEDIUM'
       } as any);
 
@@ -146,7 +145,7 @@ describe('AptitudeService - Scoring & Progress', () => {
       expect(result.currentDifficulty).toBe('HARD');
 
       // Verify Upserts: Should set correct: true
-      expect(mockedPrisma.studentAptitudeProgress.upsert).toHaveBeenCalledWith(
+      expect(vi.mocked(prisma.studentAptitudeProgress.upsert)).toHaveBeenCalledWith(
         expect.objectContaining({
           create: expect.objectContaining({ answered: true, correct: true }),
           update: expect.objectContaining({ answered: true, correct: true }),
@@ -154,7 +153,7 @@ describe('AptitudeService - Scoring & Progress', () => {
       );
 
       // Verify Topic difficulty upserted
-      expect(mockedPrisma.studentAptitudeTopicProgress.upsert).toHaveBeenCalledWith(
+      expect(vi.mocked(prisma.studentAptitudeTopicProgress.upsert)).toHaveBeenCalledWith(
         expect.objectContaining({
           create: expect.objectContaining({ currentDifficulty: 'HARD' }),
           update: expect.objectContaining({ currentDifficulty: 'HARD' }),
@@ -163,14 +162,14 @@ describe('AptitudeService - Scoring & Progress', () => {
     });
 
     it('upserts correctly for an incorrect answer', async () => {
-      mockedPrisma.aptitudeQuestion.findUnique.mockResolvedValue({
+      vi.mocked(prisma.aptitudeQuestion.findUnique).mockResolvedValue({
         id: 10,
         topicId: 5,
         correctAnswer: 'A',
         explanation: 'Because A is correct',
       } as any);
 
-      mockedPrisma.studentAptitudeTopicProgress.findUnique.mockResolvedValue({
+      vi.mocked(prisma.studentAptitudeTopicProgress.findUnique).mockResolvedValue({
         currentDifficulty: 'HARD'
       } as any);
 
@@ -185,7 +184,7 @@ describe('AptitudeService - Scoring & Progress', () => {
       expect(result.correctAnswer).toBe('A');
 
       // Verify Upserts: Should set correct: false
-      expect(mockedPrisma.studentAptitudeProgress.upsert).toHaveBeenCalledWith(
+      expect(vi.mocked(prisma.studentAptitudeProgress.upsert)).toHaveBeenCalledWith(
         expect.objectContaining({
           create: expect.objectContaining({ answered: true, correct: false }),
           update: expect.objectContaining({ answered: true, correct: false }),


### PR DESCRIPTION
# Pull Request

## Description
Added comprehensive tests for the `aptitude.service.ts` to prevent math and logic regressions, addressing #2829.
- Covered `getProgress`, testing various scenarios: 0 questions answered, all correct, all incorrect, and edge cases for the streak calculation logic (active streak, broken streak, fallback to 0).
- Covered `submitAnswer`, verifying the `upsert` semantics correctly handle state updates (`answered: true`, correct vs incorrect), as well as validating that the difficulty adjustments shift properly based on performance.
- Extensively mocked `prisma`, `MilestoneService`, and `applyAptitudeDifficultyChange` to ensure tests are isolated and reliable.

## Related Issue
Fixes #2829

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
- Ran `vitest` against `aptitude.service.test.ts` to ensure 100% pass rate on scoring algorithms.

## Test Cases
<img width="480" height="224" alt="Screenshot 2026-07-30 005221" src="https://github.com/user-attachments/assets/139980f2-0016-4d66-af77-20f33c09416e" />


## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [ ] **Screenshot or video attached for every UI change** (PR will be rejected if missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for aptitude progress calculations, including scores, streaks, and streak resets.
  * Added coverage for answer submission outcomes, difficulty updates, progress tracking, and missing-question errors.
  * Improved validation of correct and incorrect answer handling across aptitude topics.
  * Added verification for consecutive-day streak tracking and fresh progress states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->