### PR TITLE
fix: cap events array at 100 entries to prevent unbounded JSON column growth (#2893)

### DIFF
--- a/server/src/module/application-tracker/application-tracker.service.ts
+++ b/server/src/module/application-tracker/application-tracker.service.ts
@@ -190,6 +190,7 @@ export class ApplicationTrackerService {
     const existing = await prisma.trackedJobApplication.findFirst({ where: { id, userId } });
     if (!existing) return null;
     const events = Array.isArray(existing.events) ? existing.events as Prisma.InputJsonValue[] : [];
+    if (events.length >= 100) return null;
     const nextEvent = { ...event, createdAt: new Date().toISOString() } as Prisma.InputJsonObject;
     return prisma.trackedJobApplication.update({
       where: { id },


### PR DESCRIPTION
Closes #2893

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited tracked application event history to 100 entries.
  * Prevented additional events from being added once the limit is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->