### PR TITLE
fix: make requirePremium accept feature name for configurable error message (#2894)

### DIFF
--- a/server/src/middleware/premium.middleware.ts
+++ b/server/src/middleware/premium.middleware.ts
@@ -10,38 +10,37 @@ import { getPlanTier } from "../config/usage-limits.js";
  * plan+status check. Centralising the per-request lookup here removes the
  * duplicated `user.findUnique` that previously sat in every controller method.
  */
-export async function requirePremium(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<void> {
-  if (!req.user) {
-    res.status(401).json({ message: "Authentication required" });
-    return;
-  }
+export function requirePremium(feature?: string) {
+  const featureMsg = feature ?? "this feature";
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    if (!req.user) {
+      res.status(401).json({ message: "Authentication required" });
+      return;
+    }
 
-  const user = await prisma.user.findUnique({
-    where: { id: req.user.id },
-    select: {
-      subscriptionPlan: true,
-      subscriptionStatus: true,
-      subscriptionEndDate: true,
-    },
-  });
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      select: {
+        subscriptionPlan: true,
+        subscriptionStatus: true,
+        subscriptionEndDate: true,
+      },
+    });
 
-  if (
-    !user ||
-    getPlanTier(
-      user.subscriptionPlan,
-      user.subscriptionStatus,
-      user.subscriptionEndDate,
-    ) !== "PREMIUM"
-  ) {
-    res
-      .status(403)
-      .json({ message: "Premium subscription required for peer mock interviews" });
-    return;
-  }
+    if (
+      !user ||
+      getPlanTier(
+        user.subscriptionPlan,
+        user.subscriptionStatus,
+        user.subscriptionEndDate,
+      ) !== "PREMIUM"
+    ) {
+      res
+        .status(403)
+        .json({ message: `Premium subscription required for ${featureMsg}` });
+      return;
+    }
 
-  next();
+    next();
+  };
 }


### PR DESCRIPTION
Closes #2894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved premium-access checks to handle unauthenticated requests correctly.
  * Premium-only features now display a clearer, feature-specific message when access is denied.
  * Access is consistently validated against the user’s current subscription plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->