### PR TITLE
fix: replace Math.random() with crypto.randomUUID for slug suffix (#2895)

### DIFF
--- a/server/src/__tests__/slug.test.ts
+++ b/server/src/__tests__/slug.test.ts
@@ -24,14 +24,14 @@ describe("slug.utils", () => {
   });
 
   describe("slugifyWithSuffix", () => {
-    it("should append a random 4-character suffix for uniqueness", () => {
+    it("should append a random 8-character hex suffix for uniqueness", () => {
       const slug = slugifyWithSuffix("My Awesome Title");
-      expect(slug).toMatch(/^my-awesome-title-[a-z0-9]{4}$/);
+      expect(slug).toMatch(/^my-awesome-title-[a-f0-9]{8}$/);
     });
 
     it("should use fallback if title generates an empty slug", () => {
       const slug = slugifyWithSuffix("!!!", "custom-fallback");
-      expect(slug).toMatch(/^custom-fallback-[a-z0-9]{4}$/);
+      expect(slug).toMatch(/^custom-fallback-[a-f0-9]{8}$/);
     });
   });
 });

--- a/server/src/utils/slug.utils.ts
+++ b/server/src/utils/slug.utils.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 /**
  * Convert a string to a URL-safe slug. Lowercases, strips diacritics, replaces
  * any run of non-alphanumeric characters with a single hyphen, and trims
@@ -16,6 +18,6 @@ export function slugify(input: string, maxLength?: number): string {
 /** Slug with a short random suffix for uniqueness when persistence isn't easy. */
 export function slugifyWithSuffix(input: string, fallback = "item"): string {
   const base = slugify(input) || fallback;
-  const suffix = Math.random().toString(36).slice(2, 6);
+  const suffix = randomUUID().split("-")[0];
   return `${base}-${suffix}`;
 }


### PR DESCRIPTION
Closes #2895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated slug suffixes with a consistent 8-character lowercase hexadecimal format.
  * Enhanced fallback slug generation for more reliable, unique results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->