### PR TITLE
fix: use crypto.timingSafeEqual for API key comparison to prevent timing attacks

### DIFF
--- a/server/src/module/admin/admin.controller.ts
+++ b/server/src/module/admin/admin.controller.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import type { Request, Response, NextFunction } from "express";
 import { validateRequestData } from "../../utils/validation.utils.js";
 import type { AdminService } from "./admin.service.js";
@@ -1059,7 +1060,16 @@ export class AdminController {
 
       const apiKey = req.headers["x-api-key"];
       const expectedKey = process.env["EXTERNAL_JOB_API_KEY"];
-      if (!expectedKey || apiKey !== expectedKey) {
+      if (!expectedKey || !apiKey || typeof apiKey !== "string") {
+        logger.warn("[ingestExternalJob] auth failed", {
+          expectedKeySet: !!expectedKey,
+          receivedKeyPresent: !!apiKey,
+        });
+        return res.status(401).json({ message: "Invalid or missing API key" });
+      }
+      const apiKeyBuf = Buffer.from(apiKey);
+      const expectedBuf = Buffer.from(expectedKey);
+      if (apiKeyBuf.length !== expectedBuf.length || !crypto.timingSafeEqual(apiKeyBuf, expectedBuf)) {
         logger.warn("[ingestExternalJob] auth failed", {
           expectedKeySet: !!expectedKey,
           receivedKeyPresent: !!apiKey,


### PR DESCRIPTION
## Summary
Replaced `!==` with `crypto.timingSafeEqual()` for API key comparison to prevent timing side-channel attacks.

## Changes
- Added `import crypto from "crypto"`
- Changed `apiKey !== expectedKey` to use `Buffer.from()` + `crypto.timingSafeEqual()` with length check guard
- Added runtime type guard for `apiKey` being a string

## Testing
Verified the change compiles.

Fixes #2800

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external job API key validation.
  * Requests with missing, invalid, or incorrect API keys now receive a clear unauthorized response.
  * Strengthened protection against timing-based authorization attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->