### PR TITLE
fix: log actual modelName instead of providerType in ai-request-logger

### DIFF
--- a/server/src/lib/ai-provider-registry.ts
+++ b/server/src/lib/ai-provider-registry.ts
@@ -59,6 +59,11 @@ export function getServiceConfigId(service: AIServiceType): number | null {
   return serviceCache.get(service)?.configId ?? null;
 }
 
+/** Get the model name for a service (used by logger). */
+export function getServiceModelName(service: AIServiceType): string | null {
+  return serviceCache.get(service)?.modelName ?? null;
+}
+
 /** Switch a specific service to a different provider/model. Updates DB + refreshes cache. */
 export async function switchServiceProvider(
   service: AIServiceType,

--- a/server/src/lib/ai-request-logger.ts
+++ b/server/src/lib/ai-request-logger.ts
@@ -1,7 +1,7 @@
 import type { AIServiceType } from "@prisma/client";
 import { prisma } from "../database/db.js";
 import type { AIProviderResponse } from "./ai-provider.js";
-import { getProviderForService, getServiceConfigId } from "./ai-provider-registry.js";
+import { getProviderForService, getServiceConfigId, getServiceModelName } from "./ai-provider-registry.js";
 
 /** Fire-and-forget: log an AI request to the database. */
 export function logAIRequest(
@@ -21,7 +21,7 @@ export function logAIRequest(
         serviceConfigId: configId,
         service,
         providerName: provider.providerType,
-        modelName: provider.providerType, // will use the modelName from cache
+        modelName: getServiceModelName(service) ?? provider.providerType,
         latencyMs: response.latencyMs,
         inputTokens: response.inputTokens ?? null,
         outputTokens: response.outputTokens ?? null,


### PR DESCRIPTION
## Summary
`ai-request-logger.ts` was logging `provider.providerType` (e.g., "GEMINI", "GROQ") into the `modelName` field instead of the actual model name (e.g., "gemini-2.5-flash-lite"). This corrupted observability data.

## Changes
- Added `getServiceModelName()` to `ai-provider-registry.ts` to expose the cached model name per service
- Changed `ai-request-logger.ts` to use `getServiceModelName(service)` instead of `provider.providerType`

## Testing
Verified the change compiles with TypeScript.

Fixes #2799

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI request logs now record the configured model name when available.
  * Added a fallback to the provider type when no model name is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->