### PR TITLE
fix: revoke URL.createObjectURL on file change and unmount to prevent memory leak in AtsScorePage

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import { Link, useNavigate } from "react-router";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import toast from "@/components/ui/toast";
@@ -359,9 +359,25 @@ export default function AtsScorePage() {
   });
 
   const loading = analyzeMutation.isPending;
-  const previewUrl = useMemo(() => {
-    if (!file) return "";
-    return URL.createObjectURL(file);
+  const previewUrlRef = useRef<string>("");
+  const [previewUrl, setPreviewUrl] = useState("");
+
+  useEffect(() => {
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+    }
+    if (!file) {
+      previewUrlRef.current = "";
+      setPreviewUrl("");
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    previewUrlRef.current = url;
+    setPreviewUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+      previewUrlRef.current = "";
+    };
   }, [file]);
 
   const validateFile = (file: File): string | null => {


### PR DESCRIPTION
## Summary
`AtsScorePage.tsx` calls `URL.createObjectURL()` in a `useMemo` without ever calling `URL.revokeObjectURL()`. Every file selection creates a new blob URL that persists until the document is unloaded, causing a memory leak over time.

## Changes
- Replaced `useMemo` + raw `URL.createObjectURL()` with `useEffect` that tracks the current URL via `useRef` and revokes it on cleanup and on re-render with a different file

## Testing
Verified component behavior: preview renders correctly on file select, previous URL is revoked on file change, and URL is revoked on unmount.

Fixes #2798

GSSoC