### PR TITLE
fix: sanitize URLs in markdown rendering to prevent stored XSS via javascript: protocol

### DIFF
--- a/client/src/module/admin/blog/AdminBlogEditor.tsx
+++ b/client/src/module/admin/blog/AdminBlogEditor.tsx
@@ -35,6 +35,12 @@ function escapeHtml(str: string): string {
     .replace(/'/g, '&#039;');
 }
 
+function sanitizeUrl(url: string): string {
+  if (/^(https?:|mailto:|ftp:)/i.test(url)) return url;
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/i.test(url)) return url;
+  return "#";
+}
+
 // ─── Simple markdown preview renderer ───────────────────────────
 function renderPreview(md: string): string {
   let html = md;
@@ -72,10 +78,10 @@ function renderPreview(md: string): string {
   html = html.replace(/\*(.+?)\*/g, "<em>$1</em>");
 
   // Images
-  html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" class="rounded-lg my-4 max-w-full" />');
+  html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt, src) => `<img src="${sanitizeUrl(src)}" alt="${alt}" class="rounded-lg my-4 max-w-full" />`);
 
   // Links
-  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="text-blue-400 underline">$1</a>');
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, text, url) => `<a href="${sanitizeUrl(url)}" class="text-blue-400 underline">${text}</a>`);
 
   // Horizontal rule
   html = html.replace(/^---$/gm, '<hr class="my-8 border-gray-700" />');

--- a/client/src/module/blog/BlogPostPage.tsx
+++ b/client/src/module/blog/BlogPostPage.tsx
@@ -56,6 +56,12 @@ function escapeHtml(str: string): string {
     .replace(/'/g, "&#039;");
 }
 
+function sanitizeUrl(url: string): string {
+  if (/^(https?:|mailto:|ftp:)/i.test(url)) return url;
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/i.test(url)) return url;
+  return "#";
+}
+
 // ─────────────────────────────────────────────────────────────
 // Markdown → HTML
 // ─────────────────────────────────────────────────────────────
@@ -124,10 +130,10 @@ function markdownToHtml(md: string): string {
   // Images
   html = html.replace(
     /!\[([^\]]*)\]\(([^)]+)\)/g,
-    `
+    (_match, alt, src) => `
       <img
-        src="$2"
-        alt="$1"
+        src="${sanitizeUrl(src)}"
+        alt="${alt}"
         class="rounded-2xl my-8 w-full border border-stone-200 dark:border-white/10"
       />
     `
@@ -136,14 +142,14 @@ function markdownToHtml(md: string): string {
   // Links
   html = html.replace(
     /\[([^\]]+)\]\(([^)]+)\)/g,
-    `
+    (_match, text, url) => `
       <a
-        href="$2"
+        href="${sanitizeUrl(url)}"
         target="_blank"
         rel="noopener noreferrer"
         class="text-lime-700 dark:text-lime-400 underline underline-offset-4 hover:text-lime-900 dark:hover:text-lime-300 transition-colors"
       >
-        $1
+        ${text}
       </a>
     `
   );


### PR DESCRIPTION
## Summary
Blog post markdown rendering used string-based regex replacements for images and links, inserting URLs directly into `href` and `src` attributes without protocol sanitization. A markdown link like `[x](javascript:alert(1))` would produce executable `<a href="javascript:alert(1)">` via `dangerouslySetInnerHTML`.

## Changes
- Added `sanitizeUrl()` helper that allows only `http:`, `https:`, `mailto:`, `ftp:` protocols and relative URLs
- Applied sanitization to link and image replacements in both `BlogPostPage.tsx` and `AdminBlogEditor.tsx`

## Testing
Verified that `javascript:`, `data:`, `vbscript:` URIs are replaced with `#`.

Fixes #2797

GSSoC