### PR TITLE
fix: use ON_HOLD status instead of EXPIRED for holdSubscription

### DIFF
--- a/server/src/database/prisma/schema/base.prisma
+++ b/server/src/database/prisma/schema/base.prisma
@@ -1703,6 +1703,7 @@ enum SubscriptionStatus {
   ACTIVE
   EXPIRED
   CANCELLED
+  ON_HOLD
 }
 
 enum AIProviderType {

--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -315,7 +315,7 @@ export class PaymentService {
 
     await prisma.user.update({
       where: { id: payment.userId },
-      data: { subscriptionStatus: "EXPIRED" },
+      data: { subscriptionStatus: "ON_HOLD" },
     });
     await invalidateUserTierCache(payment.userId);
   }


### PR DESCRIPTION
## Summary
`holdSubscription()` was setting `subscriptionStatus` to `"EXPIRED"`, which incorrectly signals the subscription has ended permanently. The Dodo webhook `subscription.on_hold` event means the subscription is temporarily paused (e.g., payment failure), not expired.

## Changes
- Added `ON_HOLD` to Prisma `SubscriptionStatus` enum
- Changed `holdSubscription` to set `subscriptionStatus: "ON_HOLD"` instead of `"EXPIRED"`
- `expireSubscription` continues to use `"EXPIRED"` — the two states are now distinct

## Migration
A Prisma migration is needed to add `ON_HOLD` to the enum. Run from `server/src/database/`:
```
npx prisma migrate dev --name add_on_hold_subscription_status
```

## Testing
Premium gating only checks for `"ACTIVE"`, so `ON_HOLD` correctly does not grant premium access.

Fixes #2796

GSSoC