### PR TITLE
fix: replace rounded-full pill badges with rounded-md (#2817)

### DIFF
--- a/client/src/components/GrantsSection.tsx
+++ b/client/src/components/GrantsSection.tsx
@@ -46,7 +46,7 @@ export function GrantsSection() {
           transition={{ duration: 0.6 }}
           className="text-center mb-16"
         >
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 text-xs font-medium text-gray-500 dark:text-gray-500 uppercase tracking-wider mb-6">
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 text-xs font-medium text-gray-500 dark:text-gray-500 uppercase tracking-wider mb-6">
             <Award className="w-3.5 h-3.5" />
             Web3 Grants
           </div>

--- a/client/src/components/PricingSection.tsx
+++ b/client/src/components/PricingSection.tsx
@@ -197,7 +197,7 @@ className={cn(
                   <div className="absolute -top-3.5 left-1/2 -translate-x-1/2 z-10">
                     <span
                       className={cn(
-                        "inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full text-white text-xs font-semibold shadow-lg",
+                        "inline-flex items-center gap-1.5 px-4 py-1.5 rounded-md text-white text-xs font-semibold shadow-lg",
                         plan.badge.color,
                         plan.badge.shadow
                       )}

--- a/client/src/module/admin/AdminDashboard.tsx
+++ b/client/src/module/admin/AdminDashboard.tsx
@@ -91,7 +91,7 @@ export default function AdminDashboard() {
                     <p className="font-medium text-white text-sm sm:text-base truncate">{user.name}</p>
                     <p className="text-xs sm:text-sm text-gray-400 truncate">{user.email}</p>
                   </div>
-                  <span className={`inline-block px-2 sm:px-2.5 py-1 rounded-full text-xs font-medium shrink-0 ${getRoleBadge(user.role)}`}>
+                  <span className={`inline-block px-2 sm:px-2.5 py-1 rounded-md text-xs font-medium shrink-0 ${getRoleBadge(user.role)}`}>
                     {user.role}
                   </span>
                 </Link>
@@ -117,7 +117,7 @@ export default function AdminDashboard() {
                     <p className="text-xs sm:text-sm text-gray-400 truncate">{job.company} - {job.recruiter.name}</p>
                   </div>
                   <div className="text-right shrink-0">
-                    <span className={`inline-block px-2 sm:px-2.5 py-1 rounded-full text-xs font-medium ${getJobStatusBadge(job.status)}`}>
+                    <span className={`inline-block px-2 sm:px-2.5 py-1 rounded-md text-xs font-medium ${getJobStatusBadge(job.status)}`}>
                       {job.status}
                     </span>
                     <p className="text-xs text-gray-500 mt-1">{job._count.applications} apps</p>

--- a/client/src/module/admin/aptitude/AdminAptitudePage.tsx
+++ b/client/src/module/admin/aptitude/AdminAptitudePage.tsx
@@ -462,7 +462,7 @@ export default function AdminAptitudePage() {
                     {q.question.replace(/<[^>]*>/g, "").slice(0, 100)}
                   </span>
                   <span
-                    className={`text-xs px-2 py-0.5 rounded-full ${q.difficulty === "EASY" ? "bg-green-900/50 text-green-400" : q.difficulty === "HARD" ? "bg-red-900/50 text-red-400" : "bg-yellow-900/50 text-yellow-400"}`}
+                    className={`text-xs px-2 py-0.5 rounded-md ${q.difficulty === "EASY" ? "bg-green-900/50 text-green-400" : q.difficulty === "HARD" ? "bg-red-900/50 text-red-400" : "bg-yellow-900/50 text-yellow-400"}`}
                   >
                     {q.difficulty}
                   </span>
@@ -547,7 +547,7 @@ export default function AdminAptitudePage() {
                         {q.companies.map((c) => (
                           <span
                             key={c}
-                            className="text-xs px-2 py-0.5 bg-gray-800 rounded-full text-gray-300"
+                            className="text-xs px-2 py-0.5 bg-gray-800 rounded-md text-gray-300"
                           >
                             {c}
                           </span>

--- a/client/src/module/admin/blog/AdminBlogPage.tsx
+++ b/client/src/module/admin/blog/AdminBlogPage.tsx
@@ -191,11 +191,11 @@ export default function AdminBlogPage() {
                   </td>
                   <td className="px-4 py-3">
                     {post.status === "PUBLISHED" ? (
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-900/50 text-green-400 text-xs rounded-full">
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-900/50 text-green-400 text-xs rounded-md">
                         <Globe className="w-3 h-3" /> Published
                       </span>
                     ) : (
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-900/50 text-yellow-400 text-xs rounded-full">
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-yellow-900/50 text-yellow-400 text-xs rounded-md">
                         <FilePen className="w-3 h-3" /> Draft
                       </span>
                     )}

--- a/client/src/module/admin/companies/AdminCompaniesPage.tsx
+++ b/client/src/module/admin/companies/AdminCompaniesPage.tsx
@@ -84,11 +84,11 @@ export default function AdminCompaniesPage() {
                   <div className="flex items-center gap-2">
                     <p className="font-medium text-white truncate">{company.name}</p>
                     {company.isApproved ? (
-                      <span className="px-2 py-0.5 bg-green-900/50 text-green-400 text-xs rounded-full flex items-center gap-1">
+                      <span className="px-2 py-0.5 bg-green-900/50 text-green-400 text-xs rounded-md flex items-center gap-1">
                         <Eye className="w-3 h-3" /> Approved
                       </span>
                     ) : (
-                      <span className="px-2 py-0.5 bg-yellow-900/50 text-yellow-400 text-xs rounded-full flex items-center gap-1">
+                      <span className="px-2 py-0.5 bg-yellow-900/50 text-yellow-400 text-xs rounded-md flex items-center gap-1">
                         <EyeOff className="w-3 h-3" /> Pending
                       </span>
                     )}

--- a/client/src/module/admin/contributions/AdminContributionsPage.tsx
+++ b/client/src/module/admin/contributions/AdminContributionsPage.tsx
@@ -96,7 +96,7 @@ export default function AdminContributionsPage() {
               <div className="flex items-start justify-between">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
-                    <span className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${TYPE_COLORS[contribution.type] ?? "bg-gray-800 text-gray-400"}`}>
+                    <span className={`px-2.5 py-0.5 rounded-md text-xs font-medium ${TYPE_COLORS[contribution.type] ?? "bg-gray-800 text-gray-400"}`}>
                       {TYPE_LABELS[contribution.type] ?? contribution.type}
                     </span>
                     <p className="text-sm text-gray-400">

--- a/client/src/module/admin/jobs/AdminJobsListPage.tsx
+++ b/client/src/module/admin/jobs/AdminJobsListPage.tsx
@@ -136,7 +136,7 @@ export default function AdminJobsListPage() {
                     </td>
                     <td className="px-6 py-4 text-sm text-gray-400">{job.recruiter.name}</td>
                     <td className="px-6 py-4">
-                      <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${getJobStatusBadge(job.status)}`}>
+                      <span className={`px-2.5 py-1 rounded-md text-xs font-medium ${getJobStatusBadge(job.status)}`}>
                         {job.status}
                       </span>
                     </td>

--- a/client/src/module/admin/skill-tests/AdminSkillTestsPage.tsx
+++ b/client/src/module/admin/skill-tests/AdminSkillTestsPage.tsx
@@ -286,14 +286,14 @@ export default function AdminSkillTestsPage() {
                     {test.description && <div className="text-xs text-gray-500 truncate max-w-xs">{test.description}</div>}
                   </td>
                   <td className="px-4 py-3">
-                    <span className={`text-xs px-2.5 py-1 rounded-full font-medium ${test.difficulty === "BEGINNER" ? "bg-green-900/50 text-green-400" : test.difficulty === "ADVANCED" ? "bg-red-900/50 text-red-400" : "bg-yellow-900/50 text-yellow-400"}`}>
+                    <span className={`text-xs px-2.5 py-1 rounded-md font-medium ${test.difficulty === "BEGINNER" ? "bg-green-900/50 text-green-400" : test.difficulty === "ADVANCED" ? "bg-red-900/50 text-red-400" : "bg-yellow-900/50 text-yellow-400"}`}>
                       {test.difficulty}
                     </span>
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-300">{test._count?.questions ?? 0}</td>
                   <td className="px-4 py-3 text-sm text-gray-300">{test._count?.attempts ?? 0}</td>
                   <td className="px-4 py-3">
-                    <button onClick={() => handleToggle(test.id, !test.isActive)} className={`text-xs px-2.5 py-1 rounded-full font-medium transition-colors ${test.isActive ? "bg-green-900/50 text-green-400 hover:bg-green-900/70" : "bg-gray-800 text-gray-500 hover:bg-gray-700"}`}>
+                    <button onClick={() => handleToggle(test.id, !test.isActive)} className={`text-xs px-2.5 py-1 rounded-md font-medium transition-colors ${test.isActive ? "bg-green-900/50 text-green-400 hover:bg-green-900/70" : "bg-gray-800 text-gray-500 hover:bg-gray-700"}`}>
                       {test.isActive ? "Active" : "Inactive"}
                     </button>
                   </td>

--- a/client/src/module/admin/users/UserDetailPage.tsx
+++ b/client/src/module/admin/users/UserDetailPage.tsx
@@ -146,27 +146,27 @@ export default function UserDetailPage() {
                 <h1 className="text-2xl font-bold text-white">{user.name}</h1>
                 {user.bio && <p className="text-sm text-gray-400 mt-1 max-w-lg">{user.bio}</p>}
                 <div className="flex items-center gap-2 mt-2 flex-wrap">
-                  <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${getRoleBadge(user.role)}`}>
+                  <span className={`px-2.5 py-1 rounded-md text-xs font-medium ${getRoleBadge(user.role)}`}>
                     {user.role}
                   </span>
-                  <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${user.isActive ? "bg-green-900/50 text-green-400" : "bg-red-900/50 text-red-400"}`}>
+                  <span className={`px-2.5 py-1 rounded-md text-xs font-medium ${user.isActive ? "bg-green-900/50 text-green-400" : "bg-red-900/50 text-red-400"}`}>
                     {user.isActive ? "Active" : "Inactive"}
                   </span>
                   {user.isVerified && (
-                    <span className="px-2.5 py-1 rounded-full text-xs font-medium bg-blue-900/50 text-blue-400 flex items-center gap-1">
+                    <span className="px-2.5 py-1 rounded-md text-xs font-medium bg-blue-900/50 text-blue-400 flex items-center gap-1">
                       <CheckCircle className="w-3 h-3" /> Verified
                     </span>
                   )}
                   {!user.isVerified && (
-                    <span className="px-2.5 py-1 rounded-full text-xs font-medium bg-gray-800 text-gray-400 flex items-center gap-1">
+                    <span className="px-2.5 py-1 rounded-md text-xs font-medium bg-gray-800 text-gray-400 flex items-center gap-1">
                       <XCircle className="w-3 h-3" /> Unverified
                     </span>
                   )}
                   {user.isProfilePublic && (
-                    <span className="px-2.5 py-1 rounded-full text-xs font-medium bg-cyan-900/50 text-cyan-400">Public Profile</span>
+                    <span className="px-2.5 py-1 rounded-md text-xs font-medium bg-cyan-900/50 text-cyan-400">Public Profile</span>
                   )}
                   {user.adminProfile && (
-                    <span className="px-2.5 py-1 rounded-full text-xs font-medium bg-indigo-900/50 text-indigo-400">
+                    <span className="px-2.5 py-1 rounded-md text-xs font-medium bg-indigo-900/50 text-indigo-400">
                       {user.adminProfile.tier}
                     </span>
                   )}

--- a/client/src/module/admin/users/UsersListPage.tsx
+++ b/client/src/module/admin/users/UsersListPage.tsx
@@ -126,12 +126,12 @@ export default function UsersListPage() {
                     </td>
                     <td className="px-6 py-4 text-sm text-gray-400">{user.email}</td>
                     <td className="px-6 py-4">
-                      <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${getRoleBadge(user.role)}`}>
+                      <span className={`px-2.5 py-1 rounded-md text-xs font-medium ${getRoleBadge(user.role)}`}>
                         {user.role}
                       </span>
                     </td>
                     <td className="px-6 py-4">
-                      <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${user.isActive ? "bg-green-900/50 text-green-400" : "bg-red-900/50 text-red-400"}`}>
+                      <span className={`px-2.5 py-1 rounded-md text-xs font-medium ${user.isActive ? "bg-green-900/50 text-green-400" : "bg-red-900/50 text-red-400"}`}>
                         {user.isActive ? "Active" : "Inactive"}
                       </span>
                     </td>

--- a/client/src/module/blog/components/CategoryPills.tsx
+++ b/client/src/module/blog/components/CategoryPills.tsx
@@ -46,7 +46,7 @@ export default function CategoryPills({
               key={category}
               whileTap={{ scale: 0.96 }}
               onClick={() => onChange(category)}
-              className={`relative whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 border ${
+              className={`relative whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium transition-all duration-200 border ${
                 active
                   ? "bg-stone-950 dark:bg-white text-white dark:text-stone-950 border-stone-950 dark:border-white"
                   : "border-stone-200 dark:border-white/10 bg-white dark:bg-stone-900 text-stone-600 dark:text-stone-300 hover:border-lime-400/50 hover:text-stone-950 dark:hover:text-white"

--- a/client/src/module/recruiter/applications/ApplicationDetail.tsx
+++ b/client/src/module/recruiter/applications/ApplicationDetail.tsx
@@ -326,7 +326,7 @@ const fetchDetail = useCallback(async (signal?: AbortSignal) => {
     );
     return (
       <span
-        className={`text-sm font-semibold px-3 py-1 rounded-full ${
+        className={`text-sm font-semibold px-3 py-1 rounded-md ${
           pct >= 70
             ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
             : pct >= 40
@@ -343,7 +343,7 @@ const fetchDetail = useCallback(async (signal?: AbortSignal) => {
             {verifiedSkills.map((vs) => (
               <span
                 key={vs.skillName}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 rounded-full text-sm font-medium"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 rounded-md text-sm font-medium"
               >
                 <ShieldCheck className="w-3.5 h-3.5" />
                 {vs.skillName}
@@ -401,7 +401,7 @@ const fetchDetail = useCallback(async (signal?: AbortSignal) => {
                     {sub.round?.name || `Round ${i + 1}`}
                   </span>
                   <span
-                    className={`text-xs px-2 py-0.5 rounded-full ${getRoundStatusColor(sub.status)}`}
+                    className={`text-xs px-2 py-0.5 rounded-md ${getRoundStatusColor(sub.status)}`}
                   >
                     {sub.status}
                   </span>

--- a/client/src/module/recruiter/applications/ApplicationsList.tsx
+++ b/client/src/module/recruiter/applications/ApplicationsList.tsx
@@ -175,7 +175,7 @@ export default function ApplicationsList() {
                   <div className="h-4 w-32 bg-gray-200 dark:bg-gray-700 rounded"></div>
                   <div className="h-3 w-48 bg-gray-200 dark:bg-gray-700 rounded"></div>
                 </div>
-                <div className="h-6 w-24 bg-gray-200 dark:bg-gray-700 rounded-full"></div>
+                <div className="h-6 w-24 bg-gray-200 dark:bg-gray-700 rounded-md"></div>
                 <div className="h-4 w-16 bg-gray-200 dark:bg-gray-700 rounded"></div>
                 <div className="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded"></div>
                 <div className="flex gap-2">
@@ -230,7 +230,7 @@ export default function ApplicationsList() {
                             value={app.status}
                             disabled={updatingId === app.id}
                             onChange={(e) => handleStatusChange(app.id, e.target.value)}
-                            className={`text-xs px-2.5 py-1 rounded-full font-medium border-0 ${getStatusColor(app.status)} ${updatingId === app.id ? "opacity-50 cursor-not-allowed" : ""}`}>
+                            className={`text-xs px-2.5 py-1 rounded-md font-medium border-0 ${getStatusColor(app.status)} ${updatingId === app.id ? "opacity-50 cursor-not-allowed" : ""}`}>
                             <option value="APPLIED">Applied</option>
                             <option value="IN_PROGRESS">In Progress</option>
                             <option value="SHORTLISTED">Shortlisted</option>

--- a/client/src/module/recruiter/applications/CandidateImportPage.tsx
+++ b/client/src/module/recruiter/applications/CandidateImportPage.tsx
@@ -378,7 +378,7 @@ export default function CandidateImportPage() {
                     {r.message && (
                       <p className="text-xs text-gray-400 dark:text-gray-500 text-right flex-shrink-0 max-w-[200px] truncate">{r.message}</p>
                     )}
-                    <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
+                    <span className={`text-[10px] font-bold px-2 py-0.5 rounded-md ${
                       r.status === "success"
                         ? "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400"
                         : r.status === "duplicate"

--- a/client/src/module/student/applications/ApplicationProgressPage.tsx
+++ b/client/src/module/student/applications/ApplicationProgressPage.tsx
@@ -81,7 +81,7 @@ export default function ApplicationProgressPage() {
         </Link>
         <p className="text-gray-500">{application.job?.company}</p>
         <div className="flex items-center gap-3 mt-2">
-          <span className={`inline-block px-2.5 py-1 rounded-full text-xs font-medium ${getStatusColor(application.status)}`}>
+          <span className={`inline-block px-2.5 py-1 rounded-md text-xs font-medium ${getStatusColor(application.status)}`}>
             {application.status}
           </span>
           {application.job?.deadline && (
@@ -175,7 +175,7 @@ export default function ApplicationProgressPage() {
                     <Circle className="w-5 h-5 text-gray-300 dark:text-gray-600" />
                   )}
                   <h3 className="font-semibold text-gray-900 dark:text-white">Round {i + 1}: {round.name}</h3>
-                  <span className={`text-xs px-2 py-0.5 rounded-full ${isCompleted ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" :
+                  <span className={`text-xs px-2 py-0.5 rounded-md ${isCompleted ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" :
                     isActive ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400" :
                       "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500"
                     }`}>

--- a/client/src/module/student/exam-prep/ExamRunnerPage.tsx
+++ b/client/src/module/student/exam-prep/ExamRunnerPage.tsx
@@ -214,7 +214,7 @@ export default function ExamRunnerPage({ mode }: { mode: Mode }) {
                       <span className="font-medium text-gray-700 dark:text-gray-300 capitalize">{topic.replace(/-/g, " ")}</span>
                       <span className="tabular-nums text-gray-500">{s.correct}/{s.total}</span>
                     </div>
-                    <div className="h-1.5 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+                    <div className="h-1.5 bg-gray-100 dark:bg-gray-800 rounded-md overflow-hidden">
                       <div
                         className={`h-full ${p >= 70 ? "bg-green-500" : p >= 40 ? "bg-amber-500" : "bg-red-500"}`}
                         style={{ width: `${p}%` }}
@@ -272,7 +272,7 @@ export default function ExamRunnerPage({ mode }: { mode: Mode }) {
                     {q.question}
                   </p>
                   {userAns === undefined ? (
-                    <span className="text-[10px] px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 shrink-0">Skipped</span>
+                    <span className="text-[10px] px-2 py-0.5 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-500 shrink-0">Skipped</span>
                   ) : isCorrect ? (
                     <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
                   ) : (
@@ -337,7 +337,7 @@ export default function ExamRunnerPage({ mode }: { mode: Mode }) {
             Submit
           </button>
         </div>
-        <div className="h-1 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden mt-3">
+        <div className="h-1 bg-gray-100 dark:bg-gray-800 rounded-md overflow-hidden mt-3">
           <motion.div className="h-full bg-indigo-500" animate={{ width: `${pct}%` }} />
         </div>
         {tabSwitches > 0 && (
@@ -357,10 +357,10 @@ export default function ExamRunnerPage({ mode }: { mode: Mode }) {
         >
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2">
-              <span className="text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">
+              <span className="text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-md bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">
                 {current.topic.replace(/-/g, " ")}
               </span>
-              <span className="text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400">
+              <span className="text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-md bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400">
                 {current.difficulty}
               </span>
             </div>

--- a/client/src/module/student/opensource/MySubmissionsPage.tsx
+++ b/client/src/module/student/opensource/MySubmissionsPage.tsx
@@ -71,7 +71,7 @@ export default function MySubmissionsPage() {
             <Icon className="w-3.5 h-3.5" />
             {label}
             {counts[key] > 0 && (
-              <span className="ml-1 text-[10px] font-mono bg-stone-200 dark:bg-stone-700 px-1.5 py-0.5 rounded-full">
+              <span className="ml-1 text-[10px] font-mono bg-stone-200 dark:bg-stone-700 px-1.5 py-0.5 rounded-md">
                 {counts[key]}
               </span>
             )}
@@ -126,19 +126,19 @@ export default function MySubmissionsPage() {
                 </div>
                 <div className="shrink-0">
                   {req.status === "APPROVED" && (
-                    <span className="inline-flex items-center gap-1 text-[10px] font-bold text-emerald-700 bg-emerald-50 dark:bg-emerald-900/30 dark:text-emerald-400 px-2 py-1 rounded-full">
+                    <span className="inline-flex items-center gap-1 text-[10px] font-bold text-emerald-700 bg-emerald-50 dark:bg-emerald-900/30 dark:text-emerald-400 px-2 py-1 rounded-md">
                       <CheckCircle2 className="w-3 h-3" />
                       Approved
                     </span>
                   )}
                   {req.status === "PENDING" && (
-                    <span className="inline-flex items-center gap-1 text-[10px] font-bold text-amber-700 bg-amber-50 dark:bg-amber-900/30 dark:text-amber-400 px-2 py-1 rounded-full">
+                    <span className="inline-flex items-center gap-1 text-[10px] font-bold text-amber-700 bg-amber-50 dark:bg-amber-900/30 dark:text-amber-400 px-2 py-1 rounded-md">
                       <Clock className="w-3 h-3" />
                       Pending
                     </span>
                   )}
                   {req.status === "REJECTED" && (
-                    <span className="inline-flex items-center gap-1 text-[10px] font-bold text-red-700 bg-red-50 dark:bg-red-900/30 dark:text-red-400 px-2 py-1 rounded-full">
+                    <span className="inline-flex items-center gap-1 text-[10px] font-bold text-red-700 bg-red-50 dark:bg-red-900/30 dark:text-red-400 px-2 py-1 rounded-md">
                       <XCircle className="w-3 h-3" />
                       Rejected
                     </span>

--- a/client/src/module/student/opensource/RepoPublicPage.tsx
+++ b/client/src/module/student/opensource/RepoPublicPage.tsx
@@ -145,7 +145,7 @@ export default function RepoPublicPage() {
       <div className="min-h-screen bg-[#fafafa] dark:bg-gray-950">
         <Navbar />
         <div className="max-w-4xl mx-auto px-6 py-24 text-center">
-          <div className="inline-flex items-center justify-center p-4 bg-red-50 dark:bg-red-900/10 rounded-full mb-6">
+          <div className="inline-flex items-center justify-center p-4 bg-red-50 dark:bg-red-900/10 rounded-md mb-6">
             <AlertCircle className="w-12 h-12 text-red-500" />
           </div>
           <h1 className="text-3xl font-bold text-stone-900 dark:text-white mb-4">Repo Not Found</h1>
@@ -249,7 +249,7 @@ export default function RepoPublicPage() {
                 <div className="divide-y divide-stone-100 dark:divide-white/5">
                   {loadingIssues ? (
                     <div className="p-12 text-center">
-                      <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-primary mx-auto mb-4" />
+                      <div className="animate-spin rounded-md h-8 w-8 border-t-2 border-primary mx-auto mb-4" />
                       <p className="text-stone-500 text-sm">Fetching live issues...</p>
                     </div>
                   ) : issues.length > 0 ? (
@@ -277,7 +277,7 @@ export default function RepoPublicPage() {
                           {issue.labels.slice(0, 2).map((label) => (
                             <span
                               key={label.name}
-                              className="text-xs px-2 py-0.5 rounded-full font-medium"
+                              className="text-xs px-2 py-0.5 rounded-md font-medium"
                               style={{ backgroundColor: `#${label.color}22`, color: `#${label.color}` }}
                             >
                               {label.name}

--- a/client/src/module/student/profile/components/ProjectsSection.tsx
+++ b/client/src/module/student/profile/components/ProjectsSection.tsx
@@ -338,7 +338,7 @@ export function ProjectsSection({
               {draft.techStack.map((t, i) => (
                 <span
                   key={i}
-                  className="inline-flex items-center gap-1 px-2.5 py-1 text-xs bg-stone-100 dark:bg-stone-800 text-stone-700 dark:text-stone-300 rounded-full border border-stone-200 dark:border-white/10"
+                  className="inline-flex items-center gap-1 px-2.5 py-1 text-xs bg-stone-100 dark:bg-stone-800 text-stone-700 dark:text-stone-300 rounded-md border border-stone-200 dark:border-white/10"
                 >
                   {t}
                   <Button

--- a/client/src/module/student/roadmap/RoadmapsLandingPage.tsx
+++ b/client/src/module/student/roadmap/RoadmapsLandingPage.tsx
@@ -684,7 +684,7 @@ function EnrollmentCard({
               aria-valuemin={0}
               aria-valuemax={100}
               aria-label={`${r.title} progress`}
-              className="h-1 w-full bg-stone-100 dark:bg-stone-800 overflow-hidden rounded-full"
+              className="h-1 w-full bg-stone-100 dark:bg-stone-800 overflow-hidden rounded-md"
             >
               <motion.div
                 className="h-full bg-lime-500"
@@ -875,7 +875,7 @@ function FilterChip({ label, active, onClick }: { label: string; active: boolean
     <button
       onClick={onClick}
       aria-pressed={active}
-      className={`px-3 py-1 rounded-full text-[10px] font-mono uppercase tracking-widest transition-all ${
+      className={`px-3 py-1 rounded-md text-[10px] font-mono uppercase tracking-widest transition-all ${
         active
           ? "bg-lime-400 text-stone-950 font-bold border border-lime-500 shadow-sm"
           : "bg-white dark:bg-stone-900 text-stone-500 hover:text-stone-900 dark:hover:text-stone-300 border border-stone-200 dark:border-white/10"


### PR DESCRIPTION
**Description:**
Replaces pill-shaped (\ounded-full\) category/section tag badges with \ounded-md\ across the client to enforce the UI convention against pill badges above headings.

**Changes:**
- 46 \ounded-full\ → \ounded-md\ replacements across 21 files
- Admin: AdminDashboard, UsersListPage, UserDetailPage, AdminBlogPage, AdminSkillTestsPage, AdminJobsListPage, AdminContributionsPage, AdminCompaniesPage, AdminAptitudePage
- Recruiter: ApplicationDetail, ApplicationsList, CandidateImportPage
- Student: ApplicationProgressPage, ExamRunnerPage, MySubmissionsPage, RepoPublicPage, ProjectsSection, RoadmapsLandingPage
- Shared: CategoryPills, GrantsSection, PricingSection

Closes #2817

GSSoC