### PR TITLE
feat: add CSV export functionality and replace report download button with a popover menu

### DIFF
--- a/client/src/module/student/ats/AtsScorePage.tsx
+++ b/client/src/module/student/ats/AtsScorePage.tsx
@@ -22,10 +22,12 @@ import {
   ArrowRight,
   Mail,
   Download,
+  FileSpreadsheet,
 } from "lucide-react";
 import api from "../../../lib/axios";
 import { SEO } from "../../../components/SEO";
 import { CopyButton } from "../../../components/ui/CopyButton";
+import { Popover, PopoverTrigger, PopoverContent, PopoverBody } from "../../../components/ui/popover";
 import AtsToolsNav from "./AtsToolsNav";
 import { queryKeys } from "../../../lib/query-keys";
 import type { AtsScore, UsageStats } from "../../../lib/types";
@@ -170,6 +172,42 @@ export default function AtsScorePage({ guestMode = false }: { guestMode?: boolea
 
     doc.save(filename);
   };
+
+  const handleDownloadCsv = () => {
+    if (!result) return;
+    
+    // Create CSV content
+    const rows = [
+      ["ATS Analysis Report"],
+      ["Resume", getResumeName(result.resumeUrl)],
+      ["Generated", new Date().toISOString().slice(0, 10)],
+      ["Overall Score", result.overallScore.toString()],
+      [],
+      ["Category Scores"],
+      ...Object.entries(result.categoryScores).map(([k, v]) => [CATEGORY_LABELS[k] ?? k, v.toString()]),
+      [],
+      ["Missing Keywords"],
+      ...result.keywordAnalysis.missing.map(k => [k]),
+      [],
+      ["Suggestions"],
+      ...result.suggestions.map((suggestion) => {
+        const text = typeof suggestion === "string" ? suggestion : (suggestion as any).suggestion ?? String(suggestion);
+        return [text];
+      })
+    ];
+    
+    const csvContent = rows.map(e => e.map(val => `"${val?.replace(/"/g, '""') || ''}"`).join(",")).join("\n");
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.setAttribute("href", url);
+    link.setAttribute("download", `ats-report-${new Date().toISOString().slice(0, 10)}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
 
   const [guestLimitReached, setGuestLimitReached] = useState(false);
 
@@ -1012,16 +1050,37 @@ export default function AtsScorePage({ guestMode = false }: { guestMode?: boolea
                         );
                       })}
                     </div>
-                    <button
-                      type="button"
-                      onClick={handleDownloadPdf}
-                      disabled={loading}
-                      className="shrink-0 mr-1 inline-flex items-center gap-2 px-3.5 py-3 text-xs font-mono uppercase tracking-widest text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 transition-colors border-0 bg-transparent cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed print:hidden"
-                      title="Download or print this ATS report"
-                    >
-                      <Download className="w-3.5 h-3.5" />
-                      <span className="hidden sm:inline">Download Report</span>
-                    </button>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          disabled={loading || !result}
+                          className="shrink-0 mr-1 inline-flex items-center gap-2 px-3.5 py-3 text-xs font-mono uppercase tracking-widest text-stone-600 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-50 transition-colors border-0 bg-transparent cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed print:hidden"
+                          title="Export this ATS report"
+                        >
+                          <Download className="w-3.5 h-3.5" />
+                          <span className="hidden sm:inline">Export</span>
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent align="end" className="w-48 p-1 rounded-lg">
+                        <PopoverBody className="flex flex-col gap-1 p-1">
+                          <button
+                            onClick={handleDownloadPdf}
+                            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left text-stone-700 dark:text-stone-300 hover:bg-stone-100 dark:hover:bg-stone-800 rounded-md transition-colors border-0 bg-transparent cursor-pointer"
+                          >
+                            <FileText className="w-4 h-4" />
+                            Export as PDF
+                          </button>
+                          <button
+                            onClick={handleDownloadCsv}
+                            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left text-stone-700 dark:text-stone-300 hover:bg-stone-100 dark:hover:bg-stone-800 rounded-md transition-colors border-0 bg-transparent cursor-pointer"
+                          >
+                            <FileSpreadsheet className="w-4 h-4" />
+                            Export as CSV
+                          </button>
+                        </PopoverBody>
+                      </PopoverContent>
+                    </Popover>
                   </div>
 
                   <div className="p-5">


### PR DESCRIPTION
# Pull Request

## Description

Adds an **Export** action to the ATS Score page, allowing users to download their ATS analysis in **PDF** or **CSV** format.

### Changes made

* Replaced the existing **Download Report** button with a new **Export** dropdown using the project's Radix UI `Popover` component.
* Added **Export as PDF** option using the existing client-side `jsPDF` implementation.
* Added **Export as CSV** option with a new client-side CSV generation utility.
* CSV export includes:

  * Overall ATS score
  * Category-wise score breakdown
  * Missing keywords
  * Improvement suggestions
* Implemented browser-based file download without requiring any server-side changes or additional API endpoints.

## Related Issue

Fixes #2851 

## Type of Change

* [ ] Bug Fix
* [x] Feature
* [ ] Enhancement
* [ ] Documentation

## Testing

Verified the feature with the following steps:

1. Ran `npm run typecheck` successfully.
2. Started the application using `npm run dev`.
3. Opened the ATS Score page.
4. Clicked the **Export** button and verified the popover opens correctly.
5. Selected **Export as PDF** and confirmed a formatted PDF report downloads successfully.
6. Selected **Export as CSV** and confirmed a CSV file downloads containing the overall score, category breakdown, missing keywords, and suggestions.
7. Opened the exported files to verify the exported data matches the ATS analysis shown in the UI.

## Checklist

* [x] Code follows project guidelines
* [x] No new compile/type errors
* [x] Tested manually (steps included above)
* [x] No `.env`, credentials, or `node_modules` committed
* [ ] Docs updated (if needed)
* [ ] Screenshot or video attached for every UI change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV export for ATS results, including scores, missing keywords, and suggestions.
  * Replaced the single report download button with an export menu.
  * Retained PDF export as an available option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->