### PR TITLE
fix(#2802): whitelist allowed keys in upsertPreferences to prevent mass assignment

### DIFF
--- a/server/src/module/job-agent/job-agent.service.ts
+++ b/server/src/module/job-agent/job-agent.service.ts
@@ -159,11 +159,18 @@ async function searchJobsFromFilters(filters: any): Promise<any[]> {
   }));
 }
 
+const ALLOWED_PREF_KEYS = new Set([
+  "desiredRoles", "desiredSkills", "desiredLocations",
+  "minSalary", "workMode", "experienceLevel", "domains",
+]);
+
 async function upsertPreferences(userId: number, updatedPreferences: any): Promise<boolean> {
   if (!updatedPreferences) return false;
   const updates: Record<string, any> = {};
   for (const [key, val] of Object.entries(updatedPreferences)) {
-    if (val !== null && val !== undefined) updates[key] = val;
+    if (ALLOWED_PREF_KEYS.has(key) && val !== null && val !== undefined) {
+      updates[key] = val;
+    }
   }
   if (Object.keys(updates).length === 0) return false;
   await prisma.userJobPreference.upsert({


### PR DESCRIPTION
## Summary

Adds an ALLOWED_PREF_KEYS whitelist to \upsertPreferences\ so that AI-generated \updatedPreferences\ cannot write arbitrary keys (e.g. \userId\, \hasEmbedding\, \createdAt\) into the \userJobPreference\ table.

## Changes

- \server/src/module/job-agent/job-agent.service.ts\: Only keys in the whitelist (\desiredRoles\, \desiredSkills\, \desiredLocations\, \minSalary\, \workMode\, \experienceLevel\, \domains\) are accepted; all others are silently ignored.

Closes #2802

GSSOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted preference updates to supported preference fields.
  * Prevented unsupported or unexpected values from being saved.
  * Skipped unnecessary updates when no valid preference changes are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->