### PR TITLE
fix(#2804): guard completedStepIds with Array.isArray to prevent TypeError crash

### DIFF
--- a/server/src/module/resume/resume.service.ts
+++ b/server/src/module/resume/resume.service.ts
@@ -63,7 +63,7 @@ export class ResumeService {
       domain: String(repo.domain),
       difficulty: String(repo.difficulty),
     }));
-    const completedStepCount = firstPrProgress?.completedStepIds.length ?? 0;
+    const completedStepCount = Array.isArray(firstPrProgress?.completedStepIds) ? firstPrProgress.completedStepIds.length : 0;
     const completedGuides =
       completedStepCount > 0
         ? [{ name: "First PR Guide", completedSteps: completedStepCount, totalSteps: FIRST_PR_TOTAL_STEPS }]


### PR DESCRIPTION
## Summary

If \completedStepIds\ is \
ull\ (e.g. if the Prisma JSON field is empty), calling \.length\ on it throws \TypeError: Cannot read properties of null (reading 'length')\. This patch uses \Array.isArray\ before accessing \.length\.

## Changes

- \server/src/module/resume/resume.service.ts\: Replaced optional chaining with \Array.isArray\ guard so that a \
ull\ \completedStepIds\ field returns 0 without crashing.

Closes #2804

GSSOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guide-progress tracking when completed-step data is missing or invalid.
  * Progress completion now safely defaults to zero instead of causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->