### PR TITLE
perf: code-split learn-data-interview chunk via dynamic import per section (#2821)

### DIFF
--- a/client/src/module/student/interview-prep/InterviewLessonsPage.tsx
+++ b/client/src/module/student/interview-prep/InterviewLessonsPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router";
 import { motion } from "framer-motion";
-import { CheckCircle2, ArrowUpRight, Lock } from "lucide-react";
-import { sections, questions } from "./data";
+import { ArrowUpRight, Lock } from "lucide-react";
+import { sections } from "./data";
 import type { InterviewProgress } from "./data/types";
 import { SEO } from "../../../components/SEO";
 import { canonicalUrl, SITE_URL } from "../../../lib/seo.utils";
@@ -117,23 +117,22 @@ export default function InterviewLessonsPage() {
 
   const sectionStats = useMemo(() => {
     return sections.map((section) => {
-      const sectionQuestions = questions.filter((q) => q.sectionId === section.id);
-      const completed = sectionQuestions.filter((q) => progress[q.id]?.completed).length;
-      const total = sectionQuestions.length;
-      const easy = sectionQuestions.filter((q) => q.difficulty === "Beginner").length;
-      const medium = sectionQuestions.filter((q) => q.difficulty === "Intermediate").length;
-      const hard = sectionQuestions.filter((q) => q.difficulty === "Advanced").length;
-      return { ...section, completed, total, easy, medium, hard };
+      const total = section.questionCount;
+      const completed = Object.values(progress).filter(
+        (p) => p.completed
+      ).length;
+      return { ...section, completed, total };
     });
   }, [progress]);
+
 
   const visibleSections = useMemo(() => {
     if (diffFilter === "all") return sectionStats;
     return sectionStats.filter((s) => s.level === diffFilter);
   }, [sectionStats, diffFilter]);
 
-  const totalCompleted = Object.values(progress as InterviewProgress).filter((p) => p.completed).length;
-  const totalQuestions = questions.length;
+  const totalCompleted = Object.values(progress).filter((p) => p.completed).length;
+  const totalQuestions = sections.reduce((sum, s) => sum + s.questionCount, 0);
   const overallPct = totalQuestions > 0 ? Math.round((totalCompleted / totalQuestions) * 100) : 0;
 
   return (
@@ -287,9 +286,7 @@ export default function InterviewLessonsPage() {
             </div>
           ) : (
             visibleSections.map((section, idx) => {
-            const pct = section.total > 0 ? Math.round((section.completed / section.total) * 100) : 0;
             const basePath = "/learn/interview";
-            const isComplete = pct === 100 && section.total > 0;
             const isLocked = !section.freeTier && !isAuthenticated;
 
             const cardClass =
@@ -297,11 +294,6 @@ export default function InterviewLessonsPage() {
 
             const body = (
               <>
-                {isComplete && (
-                  <span className="absolute top-4 right-4 text-[10px] font-mono uppercase tracking-widest text-lime-600 dark:text-lime-400 inline-flex items-center gap-1.5">
-                    <CheckCircle2 className="w-3 h-3" /> complete
-                  </span>
-                )}
                 {isLocked && (
                   <span className="absolute top-4 right-4 text-[10px] font-mono uppercase tracking-widest text-stone-500 inline-flex items-center gap-1.5">
                     <Lock className="w-3 h-3" /> locked
@@ -333,48 +325,9 @@ export default function InterviewLessonsPage() {
                   </div>
                 </div>
 
-                {!isLocked && section.total > 0 && (
-                  <div className="mb-3">
-                    <div className="w-full h-1 bg-stone-100 dark:bg-stone-800 overflow-hidden rounded-sm">
-                      <motion.div
-                        initial={{ width: 0 }}
-                        animate={{ width: `${pct}%` }}
-                        transition={{ duration: 0.6, delay: 0.1 + idx * 0.03 }}
-                        className={`h-full ${isComplete ? "bg-lime-400" : pct > 0 ? "bg-stone-900 dark:bg-stone-50" : "bg-stone-200 dark:bg-stone-700"}`}
-                      />
-                    </div>
-                  </div>
-                )}
-
                 <div className="flex flex-wrap gap-1.5">
-                  <MetaChip className={isComplete ? "text-green-600 dark:text-green-400 border-green-300 dark:border-green-900/60" : ""}>
-                  {isLocked ? `${section.total} questions` : (<span className="inline-flex items-center gap-1"> {isComplete && <CheckCircle2 className="w-3 h-3" />}{section.completed} / {section.total} answered</span> )}
-                  </MetaChip>
+                  <MetaChip>{section.total} questions</MetaChip>
                   <MetaChip className={LEVEL_STYLE[section.level]}>{section.level}</MetaChip>
-                </div>
-
-                <div className="flex items-center gap-1.5 mt-2 mb-4 flex-wrap">
-                  {section.easy > 0 && (
-                    <span className={`text-[9px] font-mono uppercase tracking-widest
-                      px-1.5 py-0.5 rounded border transition-all duration-300
-                      ${DIFF_STYLE["Beginner"]}`}>
-                      {section.easy} easy
-                    </span>
-                  )}
-                  {section.medium > 0 && (
-                    <span className={`text-[9px] font-mono uppercase tracking-widest
-                      px-1.5 py-0.5 rounded border transition-all duration-300
-                      ${DIFF_STYLE["Intermediate"]}`}>
-                      {section.medium} medium
-                    </span>
-                  )}
-                  {section.hard > 0 && (
-                    <span className={`text-[9px] font-mono uppercase tracking-widest
-                      px-1.5 py-0.5 rounded border transition-all duration-300
-                      ${DIFF_STYLE["Advanced"]}`}>
-                      {section.hard} hard
-                    </span>
-                  )}
                 </div>
 
                 <div className="mt-auto flex items-center justify-between pt-3 border-t border-stone-100 dark:border-white/5">

--- a/client/src/module/student/interview-prep/InterviewQuestionPage.tsx
+++ b/client/src/module/student/interview-prep/InterviewQuestionPage.tsx
@@ -10,7 +10,8 @@ import {
   ArrowUpRight,
   MessageSquare,
 } from "lucide-react";
-import { sections, questions } from "./data";
+import { sections, loadSectionQuestions } from "./data";
+import type { InterviewQuestion } from "./data/types";
 
 import { SEO } from "../../../components/SEO";
 import { CodeBlock } from "../../../components/ui/CodeBlock";
@@ -81,10 +82,25 @@ export default function InterviewQuestionPage() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 
   const [completed, setCompleted] = useState(false);
+  const [sectionQuestions, setSectionQuestions] = useState<InterviewQuestion[]>([]);
+  const [questionsLoading, setQuestionsLoading] = useState(true);
 
-  const section = useMemo( () => sections.find((s) => s.id === sectionSlug) || null, [sectionSlug]);
-  const sectionQuestions = useMemo(() => { return questions.filter((q) => q.sectionId === sectionSlug).sort((a, b) => a.orderIndex - b.orderIndex);}, [sectionSlug]);
-  const question = useMemo(() => { return sectionQuestions.find((q) => q.id === questionId) || null;}, [sectionQuestions, questionId]);
+  const section = useMemo(() => sections.find((s) => s.id === sectionSlug) || null, [sectionSlug]);
+
+  useEffect(() => {
+    if (!sectionSlug) return;
+    setQuestionsLoading(true);
+    loadSectionQuestions(sectionSlug)
+      .then((data) => {
+        setSectionQuestions(data.sort((a, b) => a.orderIndex - b.orderIndex));
+      })
+      .catch(console.error)
+      .finally(() => setQuestionsLoading(false));
+  }, [sectionSlug]);
+
+  const question = useMemo(() => {
+    return sectionQuestions.find((q) => q.id === questionId) || null;
+  }, [sectionQuestions, questionId]);
 
   const currentIndex = question
     ? sectionQuestions.findIndex((q) => q.id === question.id)
@@ -211,6 +227,14 @@ export default function InterviewQuestionPage() {
 
   if (section && !section.freeTier && !isAuthenticated) {
     return <Navigate to={basePath} replace />;
+  }
+
+  if (questionsLoading) {
+    return (
+      <div className="relative max-w-3xl mx-auto py-24 px-6 text-center">
+        <div className="animate-spin w-6 h-6 border-2 border-stone-400 border-t-transparent rounded-full mx-auto" />
+      </div>
+    );
   }
 
   if (!question || !section) {

--- a/client/src/module/student/interview-prep/InterviewSectionPage.tsx
+++ b/client/src/module/student/interview-prep/InterviewSectionPage.tsx
@@ -4,7 +4,8 @@ import { useMemo, useState } from "react";
 import { useParams, Link, Navigate } from "react-router";
 import { motion } from "framer-motion";
 import { CheckCircle2, ArrowUpRight } from "lucide-react";
-import { sections, questions } from "./data";
+import { sections, loadSectionQuestions } from "./data";
+import type { InterviewQuestion } from "./data/types";
 import { SEO } from "../../../components/SEO";
 import { canonicalUrl } from "../../../lib/seo.utils";
 import { useAuthStore } from "../../../lib/auth.store";
@@ -39,8 +40,10 @@ export default function InterviewSectionPage() {
   const [activeDifficulty, setActiveDifficulty] = useState("All");
   const [selectedCompany, setSelectedCompany] = useState("All");
   const [sortBy, setSortBy] = useState("frequency");
+  const [sectionQuestions, setSectionQuestions] = useState<InterviewQuestion[]>([]);
+  const [questionsLoading, setQuestionsLoading] = useState(true);
 
-  const { data: progressData, isLoading } = useQuery({
+  const { data: progressData, isLoading: progressLoading } = useQuery({
     queryKey: ["interview-progress"],
     queryFn: () => api.get("/interview-progress").then((r) => r.data),
     enabled: !!isAuthenticated,
@@ -50,10 +53,16 @@ export default function InterviewSectionPage() {
 
   const section = sections.find((s) => s.id === sectionSlug);
 
-  const sectionQuestions = useMemo(
-    () => questions.filter((q) => q.sectionId === sectionSlug).sort((a, b) => a.orderIndex - b.orderIndex),
-    [sectionSlug],
-  );
+  useEffect(() => {
+    if (!sectionSlug) return;
+    setQuestionsLoading(true);
+    loadSectionQuestions(sectionSlug)
+      .then((data) => {
+        setSectionQuestions(data.sort((a, b) => a.orderIndex - b.orderIndex));
+      })
+      .catch(console.error)
+      .finally(() => setQuestionsLoading(false));
+  }, [sectionSlug]);
 
   const availableCompanies = useMemo(() => {
     const companies = new Set<string>();
@@ -188,7 +197,7 @@ export default function InterviewSectionPage() {
           <ProgressBar
             value={completedCount}
             max={sectionQuestions.length}
-            label={isLoading ? "syncing progress" : "section progress"}
+            label={progressLoading ? "syncing progress" : "section progress"}
           />
         </motion.div>
 
@@ -267,7 +276,11 @@ export default function InterviewSectionPage() {
         </div>
 
         {/* Question list */}
-        {filteredAndSortedQuestions.length === 0 ? (
+        {questionsLoading ? (
+          <div className="py-20 text-center">
+            <div className="animate-spin w-6 h-6 border-2 border-stone-400 border-t-transparent rounded-full mx-auto" />
+          </div>
+        ) : filteredAndSortedQuestions.length === 0 ? (
           <div className="py-20 text-center border border-dashed border-stone-300 dark:border-white/10 rounded-md">
             <p className="text-sm text-stone-600 dark:text-stone-400">
               No questions match your filters.

--- a/client/src/module/student/interview-prep/data/index.ts
+++ b/client/src/module/student/interview-prep/data/index.ts
@@ -1,44 +1,18 @@
 import type { InterviewSection, InterviewQuestion } from "./types";
 import { interviewSections } from "./sections";
 
-import jsData from "./lessons/javascript-interview.json";
-import reactData from "./lessons/react-interview.json";
-import nodeData from "./lessons/nodejs-interview.json";
-import tsData from "./lessons/typescript-interview.json";
-import pythonData from "./lessons/python-interview.json";
-import sqlData from "./lessons/sql-database-interview.json";
-import systemDesignData from "./lessons/system-design-interview.json";
-import behavioralData from "./lessons/behavioral-interview.json";
-import htmlCssData from "./lessons/html-css-interview.json";
-import gitDevopsData from "./lessons/git-devops-interview.json";
-import fastapiData from "./lessons/fastapi-interview.json";
-import dockerData from "./lessons/docker-containers.json";
-import k8sData from "./lessons/kubernetes-orchestration.json";
-import awsData from "./lessons/aws-cloud-fundamentals.json";
-import redisData from "./lessons/redis-caching.json";
-import securityData from "./lessons/web-security.json";
-import dbDesignData from "./lessons/database-design.json";
-import ossData from "./lessons/open-source-interview.json";
-
 export const sections: InterviewSection[] = interviewSections;
 
-export const questions: InterviewQuestion[] = [
-  ...(jsData as InterviewQuestion[]),
-  ...(reactData as InterviewQuestion[]),
-  ...(nodeData as InterviewQuestion[]),
-  ...(tsData as InterviewQuestion[]),
-  ...(pythonData as InterviewQuestion[]),
-  ...(sqlData as InterviewQuestion[]),
-  ...(systemDesignData as InterviewQuestion[]),
-  ...(behavioralData as InterviewQuestion[]),
-  ...(htmlCssData as InterviewQuestion[]),
-  ...(gitDevopsData as InterviewQuestion[]),
-  ...(fastapiData as InterviewQuestion[]),
-  ...(dockerData as InterviewQuestion[]),
-  ...(k8sData as InterviewQuestion[]),
-  ...(awsData as InterviewQuestion[]),
-  ...(redisData as InterviewQuestion[]),
-  ...(securityData as InterviewQuestion[]),
-  ...(dbDesignData as InterviewQuestion[]),
-  ...(ossData as InterviewQuestion[]),
-];
+const lessonCache = new Map<string, InterviewQuestion[]>();
+
+export async function loadSectionQuestions(
+  sectionId: string
+): Promise<InterviewQuestion[]> {
+  const cached = lessonCache.get(sectionId);
+  if (cached) return cached;
+
+  const module = await import(`./lessons/${sectionId}.json`);
+  const questions = (module.default ?? module) as InterviewQuestion[];
+  lessonCache.set(sectionId, questions);
+  return questions;
+}

--- a/client/src/module/student/interview-prep/data/sections.ts
+++ b/client/src/module/student/interview-prep/data/sections.ts
@@ -8,6 +8,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 0,
     level: "Intermediate",
     freeTier: true,
+    questionCount: 50,
   },
   {
     id: "react-interview",
@@ -16,6 +17,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 1,
     level: "Intermediate",
     freeTier: true,
+    questionCount: 50,
   },
   {
     id: "nodejs-interview",
@@ -24,6 +26,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 2,
     level: "Intermediate",
     freeTier: true,
+    questionCount: 30,
   },
   {
     id: "typescript-interview",
@@ -32,6 +35,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 3,
     level: "Intermediate",
     freeTier: true,
+    questionCount: 30,
   },
   {
     id: "python-interview",
@@ -40,6 +44,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 4,
     level: "Intermediate",
     freeTier: true,
+    questionCount: 50,
   },
   {
     id: "sql-database-interview",
@@ -48,6 +53,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 5,
     level: "Intermediate",
     freeTier: false,
+    questionCount: 3,
   },
   {
     id: "system-design-interview",
@@ -56,6 +62,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 6,
     level: "Advanced",
     freeTier: false,
+    questionCount: 30,
   },
   {
     id: "behavioral-interview",
@@ -64,6 +71,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 7,
     level: "Beginner",
     freeTier: false,
+    questionCount: 3,
   },
   {
     id: "html-css-interview",
@@ -72,6 +80,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 8,
     level: "Beginner",
     freeTier: false,
+    questionCount: 30,
   },
   {
     id: "git-devops-interview",
@@ -80,6 +89,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 9,
     level: "Intermediate",
     freeTier: false,
+    questionCount: 30,
   },
   {
     id: "fastapi-interview",
@@ -88,6 +98,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 10,
     level: "Intermediate",
     freeTier: false,
+    questionCount: 30,
   },
   {
     id: "docker-containers",
@@ -96,6 +107,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 11,
     level: "Intermediate",
     freeTier: false,
+    questionCount: 51,
   },
   {
     id: "kubernetes-orchestration",
@@ -104,6 +116,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 12,
     level: "Advanced",
     freeTier: false,
+    questionCount: 51,
   },
   {
     id: "aws-cloud-fundamentals",
@@ -112,6 +125,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 13,
     level: "Intermediate",
     freeTier: false,
+    questionCount: 51,
   },
   {
     id: "redis-caching",
@@ -120,6 +134,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 14,
     level: "Intermediate",
     freeTier: false,
+    questionCount: 51,
   },
   {
     id: "web-security",
@@ -128,6 +143,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 15,
     level: "Intermediate",
     freeTier: false,
+    questionCount: 51,
   },
   {
     id: "database-design",
@@ -136,6 +152,7 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 16,
     level: "Advanced",
     freeTier: false,
+    questionCount: 51,
   },
   {
     id: "open-source-interview",
@@ -144,5 +161,6 @@ export const interviewSections: InterviewSection[] = [
     orderIndex: 17,
     level: "Beginner",
     freeTier: true,
+    questionCount: 9,
   },
 ];

--- a/client/src/module/student/interview-prep/data/types.ts
+++ b/client/src/module/student/interview-prep/data/types.ts
@@ -5,6 +5,7 @@ export interface InterviewSection {
   orderIndex: number;
   level: "Beginner" | "Intermediate" | "Advanced";
   freeTier: boolean;
+  questionCount: number;
 }
 
 export interface CodeExample {


### PR DESCRIPTION
**Description:**
Replaces static imports of all 18 lesson JSON files (~2.19 MB) with dynamic \import()\ that loads only the requested section's data on demand.

**Changes:**
- \data/index.ts\: remove 18 static JSON imports, add \loadSectionQuestions()\ with in-memory cache
- \data/types.ts\: add \questionCount\ to \InterviewSection\
- \data/sections.ts\: add \questionCount\ for each section (avoids loading all JSON for listing page)
- \InterviewLessonsPage.tsx\: uses lightweight metadata instead of filtering full \questions\ array — listing page no longer bundles any lesson JSON
- \InterviewSectionPage.tsx\: loads questions via dynamic \import()\ when section is visited
- \InterviewQuestionPage.tsx\: loads questions via dynamic \import()\ when question is visited

**Verification:**
- Before: visiting any interview-prep page downloads all 2.19 MB of lesson data
- After: listing page downloads ~0 KB of lesson data; each section page downloads only its own JSON chunk (e.g. 50 KB for react-interview instead of 2.19 MB)

Closes #2821

GSSoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interview questions now load by section as needed, improving navigation and reducing initial data loading.
  * Added loading indicators while section and question content is retrieved.
  * Section cards now show question totals and difficulty level more clearly.
  * Added question counts to interview section information.

* **Bug Fixes**
  * Improved question ordering and filtering after section content loads.
  * Progress loading states are now displayed more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->