### PR TITLE
fix: use Math.floor for days-until-interview so today reminder fires (#2926)

### DIFF
--- a/server/src/cron/peer-mock-interview-reminders.cron.ts
+++ b/server/src/cron/peer-mock-interview-reminders.cron.ts
@@ -41,7 +41,7 @@ export async function runPeerMockInterviewReminders(): Promise<void> {
   for (const pairing of upcomingPairings) {
     if (!pairing.scheduledAt) continue;
 
-    const diffDays = Math.ceil((pairing.scheduledAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+    const diffDays = Math.floor((pairing.scheduledAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
     if (!REMINDER_DAYS.includes(diffDays)) continue;
 
     const subject = diffDays === 0 ? "Reminder: Mock Interview today!" : "Reminder: Mock Interview tomorrow!";


### PR DESCRIPTION
Math.ceil rounds fractional days up, so an interview later today
would show 'Reminder: Mock Interview tomorrow!'. Changed to
Math.floor so diffDays === 0 is reachable for same-day interviews.

Closes #2926

GSSOC
