### PR TITLE
fix: move premium check before usageLimit in ATS routes so quota is not wasted on blocked requests (#2927)

### DIFF
--- a/server/src/middleware/premium.middleware.ts
+++ b/server/src/middleware/premium.middleware.ts
@@ -39,7 +39,7 @@ export async function requirePremium(
   ) {
     res
       .status(403)
-      .json({ message: "Premium subscription required for peer mock interviews" });
+      .json({ message: "Premium subscription required" });
     return;
   }
 

--- a/server/src/module/ats/ats.controller.ts
+++ b/server/src/module/ats/ats.controller.ts
@@ -6,7 +6,7 @@ import { prisma } from "../../database/db.js";
 import { DAILY_LIMITS, MONTHLY_LIMITS, getPlanTier, type UsageAction } from "../../config/usage-limits.js";
 import { sendEmail } from "../../utils/email.utils.js";
 import { atsScoreReportHtml } from "../../utils/email-templates.js";
-import { isPremiumUser } from "../../utils/premium.utils.js";
+
 
 export class AtsController {
   constructor(private readonly atsService: AtsService) {}
@@ -111,12 +111,6 @@ export class AtsController {
     try {
       if (!req.user) {
         res.status(401).json({ message: "Authentication required" });
-        return;
-      }
-
-      const isPremium = await isPremiumUser(req.user.id);
-      if (!isPremium) {
-        res.status(403).json({ message: "Premium subscription required to apply AI suggestions" });
         return;
       }
 

--- a/server/src/module/ats/ats.routes.ts
+++ b/server/src/module/ats/ats.routes.ts
@@ -10,6 +10,7 @@ import { LatexChatService } from "./latex-chat.service.js";
 import { authMiddleware } from "../../middleware/auth.middleware.js";
 import { requireRole } from "../../middleware/role.middleware.js";
 import { usageLimit } from "../../middleware/usage-limit.middleware.js";
+import { requirePremium } from "../../middleware/premium.middleware.js";
 
 const atsService = new AtsService();
 const atsController = new AtsController(atsService);
@@ -36,12 +37,12 @@ atsRouter.use(authMiddleware, requireRole("STUDENT"));
 
 atsRouter.get("/usage", (req, res, next) => atsController.getUsageStats(req, res, next));
 atsRouter.post("/score", usageLimit("ATS_SCORE", "monthly"), (req, res, next) => atsController.scoreResume(req, res, next));
-atsRouter.post("/apply-suggestions", usageLimit("GENERATE_RESUME"), (req, res, next) => atsController.applySuggestions(req, res, next));
+atsRouter.post("/apply-suggestions", requirePremium, usageLimit("GENERATE_RESUME"), (req, res, next) => atsController.applySuggestions(req, res, next));
 atsRouter.post("/cover-letter", usageLimit("COVER_LETTER"), (req, res, next) => coverLetterController.generate(req, res, next));
 atsRouter.get("/cover-letter/history", (req, res, next) => coverLetterController.getHistory(req, res, next));
 atsRouter.get("/cover-letter/history/:id", (req, res, next) => coverLetterController.getOne(req, res, next));
 atsRouter.delete("/cover-letter/history/:id", (req, res, next) => coverLetterController.deleteOne(req, res, next));
 atsRouter.post("/generate-resume", usageLimit("GENERATE_RESUME"), (req, res, next) => resumeGenController.generate(req, res, next));
 atsRouter.get("/resume-history", (req, res, next) => resumeGenController.getHistory(req, res, next));
-atsRouter.post("/latex-chat", usageLimit("GENERATE_RESUME"), (req, res, next) => latexChatController.chat(req, res, next));
-atsRouter.post("/latex-optimize-jd", usageLimit("GENERATE_RESUME"), (req, res, next) => latexChatController.optimizeForJD(req, res, next));
+atsRouter.post("/latex-chat", requirePremium, usageLimit("GENERATE_RESUME"), (req, res, next) => latexChatController.chat(req, res, next));
+atsRouter.post("/latex-optimize-jd", requirePremium, usageLimit("GENERATE_RESUME"), (req, res, next) => latexChatController.optimizeForJD(req, res, next));

--- a/server/src/module/ats/latex-chat.controller.ts
+++ b/server/src/module/ats/latex-chat.controller.ts
@@ -1,7 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import type { LatexChatService } from "./latex-chat.service.js";
 import { latexChatSchema, latexJDOptimizeSchema } from "./latex-chat.validation.js";
-import { isPremiumUser } from "../../utils/premium.utils.js";
 
 export class LatexChatController {
   constructor(private readonly chatService: LatexChatService) {}
@@ -10,12 +9,6 @@ export class LatexChatController {
     try {
       if (!req.user) {
         res.status(401).json({ message: "Authentication required" });
-        return;
-      }
-
-      const isPremium = await isPremiumUser(req.user.id);
-      if (!isPremium) {
-        res.status(403).json({ message: "Premium subscription required to use AI Resume Assistant" });
         return;
       }
 
@@ -37,12 +30,6 @@ export class LatexChatController {
     try {
       if (!req.user) {
         res.status(401).json({ message: "Authentication required" });
-        return;
-      }
-
-      const isPremium = await isPremiumUser(req.user.id);
-      if (!isPremium) {
-        res.status(403).json({ message: "Premium subscription required to use AI Resume Assistant" });
         return;
       }
 


### PR DESCRIPTION
usageLimit middleware was running before the controller's premium
check, so free users' daily GENERATE_RESUME quota was consumed
even though they were blocked with 403. Added requirePremium
middleware before usageLimit on premium-gated routes and removed
the now-redundant isPremiumUser checks from the controllers.

Closes #2927

GSSOC
