### PR TITLE
fix: flush debounced localStorage save on unmount to prevent data loss (#2928)

### DIFF
--- a/client/src/module/student/ats/ResumeBuilderPage.tsx
+++ b/client/src/module/student/ats/ResumeBuilderPage.tsx
@@ -464,7 +464,10 @@ export default function ResumeBuilderPage() {
     const t = setTimeout(() => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
     }, 500);
-    return () => clearTimeout(t);
+    return () => {
+      clearTimeout(t);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    };
   }, [data]);
   useEffect(() => {
     localStorage.setItem(TEMPLATE_KEY, selectedTemplate);


### PR DESCRIPTION
The cleanup function cancelled the pending setTimeout without saving,
so navigating away within 500ms of an edit lost those changes. Now
flushes synchronously in the cleanup.

Closes #2928

GSSOC
