### PR TITLE
test: add unit tests for useCopyToClipboard hook

### DIFF
--- a/client/src/hooks/useCopyToClipboard.test.ts
+++ b/client/src/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useCopyToClipboard } from "./useCopyToClipboard";
+
+const writeTextMock = vi.fn();
+
+Object.defineProperty(navigator, "clipboard", {
+    value: {
+        writeText: writeTextMock,
+    },
+    configurable: true,
+});
+
+describe("useCopyToClipboard", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("initializes with copied set to false", () => {
+        const { result } = renderHook(() =>
+            useCopyToClipboard()
+        );
+
+        expect(result.current.copied).toBe(false);
+    });
+
+    it("calls navigator.clipboard.writeText with the provided text", async () => {
+        writeTextMock.mockResolvedValueOnce(undefined);
+
+        const { result } = renderHook(() =>
+            useCopyToClipboard()
+        );
+
+        await act(async () => {
+            await result.current.copy("Hello InternHack");
+        });
+
+        expect(writeTextMock).toHaveBeenCalledTimes(1);
+        expect(writeTextMock).toHaveBeenCalledWith("Hello InternHack");
+    });
+
+    it("sets copied to true after a successful copy", async () => {
+        writeTextMock.mockResolvedValueOnce(undefined);
+
+        const { result } = renderHook(() =>
+            useCopyToClipboard()
+        );
+
+        await act(async () => {
+            await result.current.copy("Copied text");
+        });
+
+        expect(result.current.copied).toBe(true);
+    });
+
+    it("resets copied to false after the configured delay", async () => {
+        writeTextMock.mockResolvedValueOnce(undefined);
+
+        const { result } = renderHook(() =>
+            useCopyToClipboard(2000)
+        );
+
+        await act(async () => {
+            await result.current.copy("Copied text");
+        });
+
+        expect(result.current.copied).toBe(true);
+
+        act(() => {
+            vi.advanceTimersByTime(2000);
+        });
+
+        expect(result.current.copied).toBe(false);
+    });
+
+    it("handles clipboard API failures without throwing", async () => {
+        const error = new Error("Clipboard unavailable");
+
+        writeTextMock.mockRejectedValueOnce(error);
+
+        const consoleSpy = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => { });
+
+        const { result } = renderHook(() =>
+            useCopyToClipboard()
+        );
+
+        await expect(
+            act(async () => {
+                await result.current.copy("Hello");
+            })
+        ).resolves.not.toThrow();
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+            "Failed to copy:",
+            error
+        );
+
+        consoleSpy.mockRestore();
+    });
+
+    it("keeps copied false when clipboard write fails", async () => {
+        writeTextMock.mockRejectedValueOnce(
+            new Error("Clipboard error")
+        );
+
+        const consoleSpy = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => { });
+
+        const { result } = renderHook(() =>
+            useCopyToClipboard()
+        );
+
+        await act(async () => {
+            await result.current.copy("Hello");
+        });
+
+        expect(result.current.copied).toBe(false);
+
+        consoleSpy.mockRestore();
+    });
+
+    it("uses the provided reset delay", async () => {
+        writeTextMock.mockResolvedValueOnce(undefined);
+
+        const { result } = renderHook(() =>
+            useCopyToClipboard(500)
+        );
+
+        await act(async () => {
+            await result.current.copy("Hello");
+        });
+
+        expect(result.current.copied).toBe(true);
+
+        act(() => {
+            vi.advanceTimersByTime(499);
+        });
+
+        expect(result.current.copied).toBe(true);
+
+        act(() => {
+            vi.advanceTimersByTime(1);
+        });
+
+        expect(result.current.copied).toBe(false);
+    });
+});


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a dedicated Vitest test suite for the reusable `useCopyToClipboard` hook.

The new tests verify the hook's core behavior, including clipboard interactions, state updates, configurable reset timing, and error handling. This improves test coverage for a reusable hook and helps prevent regressions during future refactoring.

## Related Issue

Fixes #2808 

## Type of Change

- [ ] Bug Fix
- [ ] Feature
- [x] Enhancement
- [ ] Documentation

## Testing

The following scenarios were verified:

- Initial `copied` state is `false`
- `navigator.clipboard.writeText` is called with the provided text
- `copied` becomes `true` after a successful copy
- `copied` resets to `false` after the configured delay
- Custom reset delays are respected
- Clipboard API failures are handled gracefully without throwing
- `copied` remains `false` when the copy operation fails

Verified by running the Vitest test suite successfully.

## Screenshots / Video

_No UI changes in this PR._

## Checklist

- [x] Code follows project guidelines
- [x] No new compile/type errors
- [x] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (not required)
- [x] **Screenshot or video attached for every UI change** (Not applicable — no UI changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for clipboard copying behavior.
  * Verified success states, reset timing, custom delays, and handling of clipboard failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->