### PR TITLE
fix: replace array index React key with stable role-prefixed key in LatexChatPanel (#2929)

### DIFF
--- a/client/src/module/student/ats/LatexChatPanel.tsx
+++ b/client/src/module/student/ats/LatexChatPanel.tsx
@@ -95,6 +95,7 @@ export default function LatexChatPanel({ code, onApplyCode, onClose }: LatexChat
   const [jobDescription, setJobDescription] = useState("");
   const [appliedIdx, setAppliedIdx] = useState<number | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const msgKeyRef = useRef(0);
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
@@ -263,7 +264,7 @@ export default function LatexChatPanel({ code, onApplyCode, onClose }: LatexChat
         <AnimatePresence initial={false}>
           {messages.map((msg, idx) => (
             <motion.div
-              key={idx}
+              key={`${msg.role}-${idx}`}
               initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.15 }}


### PR DESCRIPTION
Using bare array index as key with AnimatePresence can confuse
exit animations when items shift. Prefixed with role for stable
message identity.

Closes #2929

GSSOC
