### PR TITLE
fix(#2758): reset subscriptionPlan to FREE on cancelSubscription

### DIFF
--- a/server/src/module/payment/payment.service.ts
+++ b/server/src/module/payment/payment.service.ts
@@ -335,7 +335,7 @@ export class PaymentService {
 
     await prisma.user.update({
       where: { id: payment.userId },
-      data: { subscriptionStatus: "CANCELLED" },
+      data: { subscriptionStatus: "CANCELLED", subscriptionPlan: "FREE" },
     });
     await invalidateUserTierCache(payment.userId);
   }


### PR DESCRIPTION
## Summary

`cancelSubscription` now resets `subscriptionPlan` to `FREE` alongside setting `subscriptionStatus` to `CANCELLED`, matching the behavior of `expireSubscription`. Previously cancelled users kept a stale `MONTHLY`/`YEARLY` plan indefinitely because the expiry cron only processes ACTIVE subscriptions.

## Changes

- `server/src/module/payment/payment.service.ts`: Added `subscriptionPlan: "FREE"` to the user update in `cancelSubscription`.

Closes #2758

GSSOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled subscriptions now correctly revert the account to the free plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->