### PR TITLE
fix(#2755): return 200 from webhook on processing errors to avoid Dodo retries

### DIFF
--- a/server/src/module/payment/payment.controller.ts
+++ b/server/src/module/payment/payment.controller.ts
@@ -46,13 +46,14 @@ export class PaymentController {
       res.json({ received: true });
     } catch (err) {
       console.error("[Webhook] Error processing webhook:", err);
-      // Still return 200 to avoid retries for known errors
       // Return 401 only for signature verification failures
       if (err instanceof Error && err.message.includes("signature")) {
         res.status(401).json({ error: "Invalid signature" });
         return;
       }
-      next(err);
+      // Always return 200 to acknowledge receipt and avoid Dodo retries;
+      // transient/known errors must not trigger a retry storm or duplicate emails.
+      res.json({ received: true });
     }
   }
 


### PR DESCRIPTION
## Summary

The webhook handler now returns HTTP 200 even when webhook processing fails, instead of forwarding the error to Express's error middleware (which produced HTTP 500). Dodo retries any non-2xx response, and the confirmation email is sent outside the transaction — so each retry caused duplicate emails and wasted server resources.

## Changes

- `server/src/module/payment/payment.controller.ts`: In the catch block, keep returning `{ received: true }` (HTTP 200) for all non-signature errors. Signature verification failures still return 401 so Dodo can surface genuinely invalid webhooks.

Closes #2755

GSSOC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment webhook requests now receive a successful acknowledgment when processing errors occur, while invalid signatures continue to return an unauthorized response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->