### PR TITLE
fix: migrate forbidden color tokens to lime/stone in computer-networks animations and dsa-foundations lessons

### DIFF
--- a/client/src/module/student/learn/computer-networks/module-1/_components/Anim1A.tsx
+++ b/client/src/module/student/learn/computer-networks/module-1/_components/Anim1A.tsx
@@ -68,7 +68,7 @@ export default function Anim1A() {
     <div className="grid md:grid-cols-2 gap-0 min-h-95">
 
       {/* ── SVG visualizer ── */}
-      <div className="relative flex items-center justify-center bg-[#0F172A] p-4 min-h-80">
+      <div className="relative flex items-center justify-center bg-[#1C1917] p-4 min-h-80">
         {/* subtle dot grid */}
         <svg
           className="absolute inset-0 w-full h-full opacity-20"
@@ -76,7 +76,7 @@ export default function Anim1A() {
         >
           <defs>
             <pattern id="dots" x="0" y="0" width="24" height="24" patternUnits="userSpaceOnUse">
-              <circle cx="1" cy="1" r="1" fill="#475569" />
+              <circle cx="1" cy="1" r="1" fill="#57534E" />
             </pattern>
           </defs>
           <rect width="100%" height="100%" fill="url(#dots)" />
@@ -197,7 +197,7 @@ export default function Anim1A() {
                   style={
                     step === i
                       ? { backgroundColor: lvl.color, color: "#fff", borderColor: lvl.color }
-                      : { backgroundColor: "#fff", color: "#9CA3AF", borderColor: "#E5E7EB" }
+                      : { backgroundColor: "#fff", color: "#A8A29E", borderColor: "#E7E5E4" }
                   }
                 >
                   {lvl.type}

--- a/client/src/module/student/learn/computer-networks/module-1/_components/Anim1B.tsx
+++ b/client/src/module/student/learn/computer-networks/module-1/_components/Anim1B.tsx
@@ -147,13 +147,13 @@ export default function Anim1B() {
     <div className="flex flex-col md:flex-row min-h-95">
 
       {/* ── SVG canvas ── */}
-      <div className="flex-1 relative bg-[#0F172A] overflow-hidden min-h-80">
+      <div className="flex-1 relative bg-[#1C1917] overflow-hidden min-h-80">
 
         {/* dot grid */}
         <svg className="absolute inset-0 w-full h-full opacity-10" xmlns="http://www.w3.org/2000/svg">
           <defs>
             <pattern id="grid-b" x="0" y="0" width="30" height="30" patternUnits="userSpaceOnUse">
-              <circle cx="1" cy="1" r="1" fill="#475569" />
+              <circle cx="1" cy="1" r="1" fill="#57534E" />
             </pattern>
           </defs>
           <rect width="100%" height="100%" fill="url(#grid-b)" />
@@ -172,7 +172,7 @@ export default function Anim1B() {
               <motion.line
                 key={`${topo}-e${i}`}
                 x1={na.x} y1={na.y} x2={nb.x} y2={nb.y}
-                stroke={broken_ ? "#F43F5E" : "#475569"}
+                stroke={broken_ ? "#F43F5E" : "#57534E"}
                 strokeWidth={broken_ ? 2 : 2}
                 strokeDasharray={broken_ ? "6 4" : "none"}
                 opacity={broken_ ? 0.7 : 0.9}
@@ -189,10 +189,10 @@ export default function Anim1B() {
             const isDisco  = isDisconnected(i)
             const isHub    = topo === "star" && i === 0
 
-            let fill   = isHub ? "#84CC16" : "#E2E8F0"
-            let stroke = isHub ? "#65A30D" : "#94A3B8"
+            let fill   = isHub ? "#84CC16" : "#E7E5E4"
+            let stroke = isHub ? "#65A30D" : "#A8A29E"
             if (isBroken) { fill = "#F43F5E"; stroke = "#E11D48" }
-            if (isDisco)  { fill = "#334155"; stroke = "#475569" }
+            if (isDisco)  { fill = "#44403C"; stroke = "#57534E" }
 
             return (
               <g key={`${topo}-n${i}`}>
@@ -230,8 +230,8 @@ export default function Anim1B() {
                   {/* laptop icon (simple SVG) */}
                   {!isBroken && (
                     <g transform={`translate(${n.x - 7}, ${n.y - 6})`} pointerEvents="none">
-                      <rect x={1} y={1} width={12} height={8} rx={1} fill="none" stroke={isHub ? "#A3E635" : "#64748B"} strokeWidth={1.2} />
-                      <rect x={0} y={9} width={14} height={1.5} rx={0.5} fill={isHub ? "#A3E635" : "#64748B"} />
+                      <rect x={1} y={1} width={12} height={8} rx={1} fill="none" stroke={isHub ? "#A3E635" : "#78716C"} strokeWidth={1.2} />
+                      <rect x={0} y={9} width={14} height={1.5} rx={0.5} fill={isHub ? "#A3E635" : "#78716C"} />
                     </g>
                   )}
 
@@ -240,7 +240,7 @@ export default function Anim1B() {
                     x={n.x}
                     y={n.y + 28}
                     textAnchor="middle"
-                    fill={isDisco ? "#475569" : isBroken ? "#F43F5E" : "#94A3B8"}
+                    fill={isDisco ? "#57534E" : isBroken ? "#F43F5E" : "#A8A29E"}
                     fontSize={9}
                     fontWeight={isHub ? "bold" : "normal"}
                   >
@@ -259,9 +259,9 @@ export default function Anim1B() {
                       <rect
                         x={n.x - 52} y={n.y - 60}
                         width={104} height={44}
-                        rx={6} fill="#1E293B" stroke="#334155" strokeWidth={1}
+                        rx={6} fill="#292524" stroke="#44403C" strokeWidth={1}
                       />
-                      <text x={n.x} y={n.y - 44} textAnchor="middle" fill="#E2E8F0" fontSize={9} fontWeight="bold">
+                      <text x={n.x} y={n.y - 44} textAnchor="middle" fill="#E7E5E4" fontSize={9} fontWeight="bold">
                         {isHub ? "Hub / Switch" : `Node ${i}`}
                       </text>
                       <text x={n.x} y={n.y - 30} textAnchor="middle" fill={isDisco ? "#F43F5E" : isBroken ? "#F43F5E" : "#10B981"} fontSize={8}>

--- a/client/src/module/student/learn/computer-networks/module-1/_components/Anim1C.tsx
+++ b/client/src/module/student/learn/computer-networks/module-1/_components/Anim1C.tsx
@@ -14,14 +14,14 @@ function Laptop({ label, ip, active }: { label: string; ip: string; active: bool
         animate={active ? { scale: [1, 1.06, 1] } : {}}
         transition={{ duration: 0.3 }}
         className={`w-16 h-16 rounded-xl flex items-center justify-center border-2 transition-colors ${
-          active ? "border-lime-400 bg-lime-950" : "border-[#1E293B] bg-[#0F172A]"
+          active ? "border-lime-400 bg-lime-950" : "border-[#292524] bg-[#1C1917]"
         }`}
       >
         <svg viewBox="0 0 48 40" width={38} height={32}>
-          <rect x={4} y={2} width={40} height={26} rx={3} fill="#E2E8F0" stroke="#94A3B8" strokeWidth={1.5} />
+          <rect x={4} y={2} width={40} height={26} rx={3} fill="#E7E5E4" stroke="#A8A29E" strokeWidth={1.5} />
           <rect x={7} y={5} width={34} height={20} rx={1} fill="#84CC16" opacity={active ? 0.7 : 0.15} />
-          <rect x={1} y={29} width={46} height={3} rx={1.5} fill="#94A3B8" />
-          <rect x={18} y={28} width={12} height={2} rx={1} fill="#CBD5E1" />
+          <rect x={1} y={29} width={46} height={3} rx={1.5} fill="#A8A29E" />
+          <rect x={18} y={28} width={12} height={2} rx={1} fill="#D6D3D1" />
         </svg>
       </motion.div>
       <span className="text-xs font-semibold text-stone-300">{label}</span>
@@ -34,25 +34,25 @@ function Router({ active }: { active: boolean }) {
   return (
     <div className="flex flex-col items-center gap-1.5">
       <motion.div
-        animate={active ? { scale: [1, 1.1, 1], borderColor: ["#334155", "#84CC16", "#334155"] } : {}}
+        animate={active ? { scale: [1, 1.1, 1], borderColor: ["#44403C", "#84CC16", "#44403C"] } : {}}
         transition={{ duration: 0.4 }}
-        className="w-14 h-14 rounded-xl flex items-center justify-center border-2 border-[#1E293B] bg-[#0F172A]"
-        style={{ borderColor: active ? "#84CC16" : "#1E293B" }}
+        className="w-14 h-14 rounded-xl flex items-center justify-center border-2 border-[#292524] bg-[#1C1917]"
+        style={{ borderColor: active ? "#84CC16" : "#292524" }}
       >
         <svg viewBox="0 0 40 36" width={34} height={30}>
           {/* router body */}
-          <rect x={2} y={10} width={36} height={16} rx={3} fill="#1E293B" stroke="#475569" strokeWidth={1.2} />
+          <rect x={2} y={10} width={36} height={16} rx={3} fill="#292524" stroke="#57534E" strokeWidth={1.2} />
           {/* status LEDs */}
-          <circle cx={9}  cy={18} r={2.5} fill={active ? "#10B981" : "#334155"} />
-          <circle cx={16} cy={18} r={2.5} fill={active ? "#84CC16" : "#334155"} />
-          <circle cx={23} cy={18} r={2.5} fill={active ? "#F59E0B" : "#334155"} />
+          <circle cx={9}  cy={18} r={2.5} fill={active ? "#10B981" : "#44403C"} />
+          <circle cx={16} cy={18} r={2.5} fill={active ? "#84CC16" : "#44403C"} />
+          <circle cx={23} cy={18} r={2.5} fill={active ? "#F59E0B" : "#44403C"} />
           {/* antenna */}
-          <line x1={32} y1={10} x2={32} y2={2} stroke="#475569" strokeWidth={1.5} strokeLinecap="round" />
-          <circle cx={32} cy={2} r={1.5} fill="#475569" />
+          <line x1={32} y1={10} x2={32} y2={2} stroke="#57534E" strokeWidth={1.5} strokeLinecap="round" />
+          <circle cx={32} cy={2} r={1.5} fill="#57534E" />
           {/* ports */}
-          <rect x={6}  y={26} width={6} height={3} rx={1} fill="#334155" />
-          <rect x={17} y={26} width={6} height={3} rx={1} fill="#334155" />
-          <rect x={28} y={26} width={6} height={3} rx={1} fill="#334155" />
+          <rect x={6}  y={26} width={6} height={3} rx={1} fill="#44403C" />
+          <rect x={17} y={26} width={6} height={3} rx={1} fill="#44403C" />
+          <rect x={28} y={26} width={6} height={3} rx={1} fill="#44403C" />
         </svg>
       </motion.div>
       <span className="text-xs font-semibold text-stone-400">Router</span>
@@ -103,7 +103,7 @@ export default function Anim1C() {
   const traveling = phase === "to-router" || phase === "at-router" || phase === "to-dest"
 
   return (
-    <div className="bg-[#0F172A] p-6 min-h-[360px] flex flex-col gap-6">
+    <div className="bg-[#1C1917] p-6 min-h-[360px] flex flex-col gap-6">
 
       {/* ── devices row ── */}
       <div className="flex items-start justify-between gap-2">
@@ -119,7 +119,7 @@ export default function Anim1C() {
               onKeyDown={e => e.key === "Enter" && send()}
               disabled={traveling}
               placeholder="Type a message…"
-              className="w-28 text-xs px-2.5 py-1.5 rounded-lg bg-[#1E293B] border border-[#334155] text-white placeholder:text-stone-500 focus:outline-none focus:border-lime-500 disabled:opacity-50"
+              className="w-28 text-xs px-2.5 py-1.5 rounded-lg bg-[#292524] border border-[#44403C] text-white placeholder:text-stone-500 focus:outline-none focus:border-lime-500 disabled:opacity-50"
             />
             <button
               onClick={send}
@@ -133,9 +133,9 @@ export default function Anim1C() {
 
         {/* wire A → Router */}
         <div className="flex-1 relative flex items-center mt-8">
-          <div className="w-full h-px bg-[#334155]" />
-          <div className="absolute left-0 w-1.5 h-1.5 rounded-full bg-[#334155]" />
-          <div className="absolute right-0 w-1.5 h-1.5 rounded-full bg-[#334155]" />
+          <div className="w-full h-px bg-[#44403C]" />
+          <div className="absolute left-0 w-1.5 h-1.5 rounded-full bg-[#44403C]" />
+          <div className="absolute right-0 w-1.5 h-1.5 rounded-full bg-[#44403C]" />
 
           <AnimatePresence>
             {phase === "to-router" && packet && (
@@ -169,9 +169,9 @@ export default function Anim1C() {
 
         {/* wire Router → Laptop B */}
         <div className="flex-1 relative flex items-center mt-8">
-          <div className="w-full h-px bg-[#334155]" />
-          <div className="absolute left-0 w-1.5 h-1.5 rounded-full bg-[#334155]" />
-          <div className="absolute right-0 w-1.5 h-1.5 rounded-full bg-[#334155]" />
+          <div className="w-full h-px bg-[#44403C]" />
+          <div className="absolute left-0 w-1.5 h-1.5 rounded-full bg-[#44403C]" />
+          <div className="absolute right-0 w-1.5 h-1.5 rounded-full bg-[#44403C]" />
 
           <AnimatePresence>
             {phase === "to-dest" && packet && (
@@ -263,7 +263,7 @@ function PacketDot({
               initial={{ opacity: 0, y: 4 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0 }}
-              className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-48 bg-[#1E293B] border border-[#334155] rounded-xl p-3 text-[10px] shadow-xl"
+              className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-48 bg-[#292524] border border-[#44403C] rounded-xl p-3 text-[10px] shadow-xl"
               onClick={e => e.stopPropagation()}
             >
               <p className="text-stone-400 font-bold uppercase tracking-wide mb-1.5">Packet Inspector</p>
@@ -272,7 +272,7 @@ function PacketDot({
                 <Row label="Destination" value="192.168.1.20" valueClass="text-lime-300" />
                 <Row label="Protocol"    value="TCP"          valueClass="text-emerald-400" />
                 <Row label="TTL"         value={String(ttl)}  valueClass={ttl < 64 ? "text-amber-400" : "text-stone-300"} />
-                <div className="mt-1.5 pt-1.5 border-t border-[#334155]">
+                <div className="mt-1.5 pt-1.5 border-t border-[#44403C]">
                   <span className="text-stone-400">Payload</span>
                   <p className="text-white mt-0.5 break-words">"{payload}"</p>
                 </div>

--- a/client/src/module/student/learn/computer-networks/module-1/_components/Anim1D.tsx
+++ b/client/src/module/student/learn/computer-networks/module-1/_components/Anim1D.tsx
@@ -104,11 +104,11 @@ export default function Anim1D() {
     <div className="grid md:grid-cols-[1fr_220px] min-h-95">
 
       {/* ── SVG canvas ── */}
-      <div className="relative bg-[#0F172A] flex items-center justify-center min-h-80">
+      <div className="relative bg-[#1C1917] flex items-center justify-center min-h-80">
         <svg className="absolute inset-0 w-full h-full opacity-10">
           <defs>
             <pattern id="grid-d" x="0" y="0" width="28" height="28" patternUnits="userSpaceOnUse">
-              <circle cx="1" cy="1" r="1" fill="#475569" />
+              <circle cx="1" cy="1" r="1" fill="#57534E" />
             </pattern>
           </defs>
           <rect width="100%" height="100%" fill="url(#grid-d)" />
@@ -129,7 +129,7 @@ export default function Anim1D() {
               {CLIENTS.map(c => (
                 <line key={c.id}
                   x1={SRV.x} y1={SRV.y} x2={c.x} y2={c.y}
-                  stroke="#1E293B" strokeWidth={2}
+                  stroke="#292524" strokeWidth={2}
                 />
               ))}
 
@@ -158,10 +158,10 @@ export default function Anim1D() {
               {/* server */}
               <motion.circle
                 cx={SRV.x} cy={SRV.y} r={30}
-                fill="#1E293B"
-                stroke={csPhase === "respond" ? "#84CC16" : "#334155"}
+                fill="#292524"
+                stroke={csPhase === "respond" ? "#84CC16" : "#44403C"}
                 strokeWidth={csPhase === "respond" ? 3 : 2}
-                animate={{ stroke: csPhase === "respond" ? "#84CC16" : "#334155" }}
+                animate={{ stroke: csPhase === "respond" ? "#84CC16" : "#44403C" }}
                 transition={{ duration: 0.2 }}
               />
               {csPhase === "respond" && (
@@ -171,7 +171,7 @@ export default function Anim1D() {
                   transition={{ duration: 0.7 }}
                 />
               )}
-              <text x={SRV.x} y={SRV.y} textAnchor="middle" fill="#E2E8F0"
+              <text x={SRV.x} y={SRV.y} textAnchor="middle" fill="#E7E5E4"
                 fontSize={9} fontWeight="bold" dominantBaseline="middle">
                 SERVER
               </text>
@@ -184,10 +184,10 @@ export default function Anim1D() {
                   <g key={c.id}>
                     <motion.circle
                       cx={c.x} cy={c.y} r={20}
-                      fill={isActive ? "#1E3A5F" : "#1E293B"}
-                      stroke={isActive ? "#3B82F6" : "#334155"}
+                      fill={isActive ? "#44403C" : "#292524"}
+                      stroke={isActive ? "#3B82F6" : "#44403C"}
                       strokeWidth={isActive ? 2.5 : 1.5}
-                      animate={{ stroke: isActive ? "#3B82F6" : "#334155" }}
+                      animate={{ stroke: isActive ? "#3B82F6" : "#44403C" }}
                       transition={{ duration: 0.3 }}
                     />
                     {isReceiving && (
@@ -197,7 +197,7 @@ export default function Anim1D() {
                         transition={{ duration: 0.5 }}
                       />
                     )}
-                    <text x={c.x} y={c.y} textAnchor="middle" fill="#94A3B8"
+                    <text x={c.x} y={c.y} textAnchor="middle" fill="#A8A29E"
                       fontSize={8} dominantBaseline="middle">
                       {c.label}
                     </text>
@@ -223,7 +223,7 @@ export default function Anim1D() {
                 return (
                   <motion.line key={`${a}-${b}`}
                     x1={na.x} y1={na.y} x2={nb.x} y2={nb.y}
-                    animate={{ stroke: active ? "#84CC16" : "#1E293B", opacity: active ? 0.9 : 0.35 }}
+                    animate={{ stroke: active ? "#84CC16" : "#292524", opacity: active ? 0.9 : 0.35 }}
                     transition={{ duration: 0.35 }}
                   />
                 )
@@ -255,12 +255,12 @@ export default function Anim1D() {
                   <g key={p.id}>
                     <motion.circle
                       cx={p.x} cy={p.y} r={22}
-                      fill={active ? "#1E3A5F" : "#1E293B"}
-                      animate={{ stroke: active ? "#84CC16" : "#334155" }}
+                      fill={active ? "#44403C" : "#292524"}
+                      animate={{ stroke: active ? "#84CC16" : "#44403C" }}
                       strokeWidth={active ? 2.5 : 1.5}
                       transition={{ duration: 0.35 }}
                     />
-                    <text x={p.x} y={p.y} textAnchor="middle" fill="#94A3B8"
+                    <text x={p.x} y={p.y} textAnchor="middle" fill="#A8A29E"
                       fontSize={8} dominantBaseline="middle">
                       {p.label}
                     </text>

--- a/client/src/module/student/learn/computer-networks/module-2/_components/Anim2A.tsx
+++ b/client/src/module/student/learn/computer-networks/module-2/_components/Anim2A.tsx
@@ -11,7 +11,7 @@ const OSI = [
   { n: 4, name: "Transport",    color: "#F59E0B" },
   { n: 3, name: "Network",      color: "#2563EB" },
   { n: 2, name: "Data Link",    color: "#10B981" },
-  { n: 1, name: "Physical",     color: "#64748B" },
+  { n: 1, name: "Physical",     color: "#78716C" },
 ]
 
 // ── Header strip definitions ──────────────────────────────────────────────────
@@ -52,8 +52,8 @@ const STEPS: {
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 function layerColor(side: "S"|"R"|"T", layer: number) {
-  if (side === "T") return "#64748B"
-  return OSI.find(l => l.n === layer)?.color ?? "#6B7280"
+  if (side === "T") return "#78716C"
+  return OSI.find(l => l.n === layer)?.color ?? "#78716C"
 }
 
 // ── component ─────────────────────────────────────────────────────────────────
@@ -75,7 +75,7 @@ export default function Anim2A() {
     <div className="grid md:grid-cols-[1fr_210px] min-h-95">
 
       {/* ── dark visualization area ── */}
-      <div className="bg-[#0F172A] flex items-center gap-2 px-4 py-5 min-h-80 overflow-x-auto">
+      <div className="bg-[#1C1917] flex items-center gap-2 px-4 py-5 min-h-80 overflow-x-auto">
 
         {/* Sender stack */}
         <OsiStack
@@ -96,7 +96,7 @@ export default function Anim2A() {
           </p>
 
           {/* Header strips */}
-          <div className="flex items-stretch h-9 rounded-lg overflow-hidden border border-[#1E293B]">
+          <div className="flex items-stretch h-9 rounded-lg overflow-hidden border border-[#292524]">
             <AnimatePresence initial={false}>
               {cur.hdrs.map(h => (
                 <motion.div
@@ -206,7 +206,7 @@ export default function Anim2A() {
                 marginTop: i === step ? 0 : 1.5,
                 backgroundColor: i === step
                   ? layerColor(s.side, s.layer)
-                  : "#E5E7EB",
+                  : "#E7E5E4",
               }}
             />
           ))}
@@ -239,20 +239,20 @@ function OsiStack({
             onClick={() => onClickLayer(l.n)}
             animate={{
               backgroundColor: isActive ? l.color + "22" : "transparent",
-              borderColor:     isActive ? l.color        : "#1E293B",
+              borderColor:     isActive ? l.color        : "#292524",
             }}
             transition={{ duration: 0.25 }}
             className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg border text-left"
           >
             <span
               className="w-4 h-4 rounded text-white text-[8px] font-bold flex items-center justify-center shrink-0 transition-colors"
-              style={{ backgroundColor: isActive ? l.color : "#334155" }}
+              style={{ backgroundColor: isActive ? l.color : "#44403C" }}
             >
               {l.n}
             </span>
             <span
               className="text-[9px] truncate transition-colors"
-              style={{ color: isActive ? l.color : "#475569" }}
+              style={{ color: isActive ? l.color : "#57534E" }}
             >
               {l.name}
             </span>

--- a/client/src/module/student/learn/computer-networks/module-2/_components/Anim2B.tsx
+++ b/client/src/module/student/learn/computer-networks/module-2/_components/Anim2B.tsx
@@ -10,7 +10,7 @@ const LAYERS = [
   { n: 4, name: "Transport",    color: "#F59E0B" },
   { n: 3, name: "Network",      color: "#2563EB" },
   { n: 2, name: "Data Link",    color: "#10B981" },
-  { n: 1, name: "Physical",     color: "#64748B" },
+  { n: 1, name: "Physical",     color: "#78716C" },
 ]
 
 const ITEMS = [
@@ -66,10 +66,10 @@ export default function Anim2B() {
   const selectedItem = ITEMS.find(i => i.id === selected)
 
   return (
-    <div className="relative grid md:grid-cols-[190px_1fr] min-h-95 bg-[#0F172A]">
+    <div className="relative grid md:grid-cols-[190px_1fr] min-h-95 bg-[#1C1917]">
 
       {/* ── items panel ── */}
-      <div className="border-r border-[#1E293B] p-4 flex flex-col gap-2">
+      <div className="border-r border-[#292524] p-4 flex flex-col gap-2">
         <p className="text-[9px] text-stone-500 font-bold uppercase tracking-widest mb-1">
           Items  click to select
         </p>
@@ -92,10 +92,10 @@ export default function Anim2B() {
                 disabled={isPlaced}
                 className={`flex items-center justify-between px-3 py-2 rounded-lg text-xs font-semibold text-left transition-all border ${
                   isPlaced
-                    ? "opacity-35 border-[#1E293B] text-stone-500 cursor-default"
+                    ? "opacity-35 border-[#292524] text-stone-500 cursor-default"
                     : isSelected
                     ? "border-lime-500 bg-lime-900/30 text-lime-200 shadow-[0_0_0_2px_#7C3AED33]"
-                    : "border-[#1E293B] text-stone-300 hover:border-[#334155] hover:bg-[#1E293B] cursor-pointer"
+                    : "border-[#292524] text-stone-300 hover:border-[#44403C] hover:bg-[#292524] cursor-pointer"
                 }`}
               >
                 <span>{item.label}</span>
@@ -110,7 +110,7 @@ export default function Anim2B() {
         {allPlaced && (
           <button
             onClick={reset}
-            className="mt-auto flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg text-xs text-stone-400 border border-[#334155] hover:bg-[#1E293B] transition-colors"
+            className="mt-auto flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg text-xs text-stone-400 border border-[#44403C] hover:bg-[#292524] transition-colors"
           >
             <RotateCcw size={10} /> Reset
           </button>
@@ -136,8 +136,8 @@ export default function Anim2B() {
               whileHover={canDrop ? { scale: 1.01 } : {}}
               className={`flex items-center gap-3 px-3 py-2.5 rounded-xl border text-left transition-all ${
                 canDrop
-                  ? "border-dashed border-[#334155] hover:border-lime-500 hover:bg-lime-900/15 cursor-pointer"
-                  : "border-[#1E293B] cursor-default"
+                  ? "border-dashed border-[#44403C] hover:border-lime-500 hover:bg-lime-900/15 cursor-pointer"
+                  : "border-[#292524] cursor-default"
               }`}
             >
               {/* layer badge */}
@@ -203,7 +203,7 @@ export default function Anim2B() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="absolute inset-0 bg-[#0F172A]/85 flex items-center justify-center rounded-b-2xl"
+            className="absolute inset-0 bg-[#1C1917]/85 flex items-center justify-center rounded-b-2xl"
           >
             <motion.div
               initial={{ scale: 0.85, opacity: 0 }}

--- a/client/src/module/student/learn/computer-networks/module-2/_components/Anim2C.tsx
+++ b/client/src/module/student/learn/computer-networks/module-2/_components/Anim2C.tsx
@@ -41,11 +41,11 @@ export default function Anim2C() {
   const serverLit = phase >= 7
 
   return (
-    <div className="bg-[#0F172A] p-5 min-h-[400px] flex flex-col gap-5">
+    <div className="bg-[#1C1917] p-5 min-h-[400px] flex flex-col gap-5">
 
       {/* ── URL bar + controls ── */}
       <div className="flex items-center gap-2">
-        <div className="flex-1 flex items-center gap-2 bg-[#1E293B] rounded-lg px-3 py-2 border border-[#334155]">
+        <div className="flex-1 flex items-center gap-2 bg-[#292524] rounded-lg px-3 py-2 border border-[#44403C]">
           <Lock size={11} className="text-emerald-400 shrink-0" />
           <span className="text-stone-300 text-xs font-mono">https://internhack.xyz/api/modules</span>
         </div>
@@ -60,7 +60,7 @@ export default function Anim2C() {
         ) : (
           <button
             onClick={reset}
-            className="flex items-center gap-1.5 px-3 py-2 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs transition-colors border border-[#334155] shrink-0"
+            className="flex items-center gap-1.5 px-3 py-2 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs transition-colors border border-[#44403C] shrink-0"
           >
             <RotateCcw size={11} /> Reset
           </button>
@@ -74,8 +74,8 @@ export default function Anim2C() {
         <div className="flex flex-col items-center gap-1.5 w-16 shrink-0 pt-1">
           <motion.div
             animate={{
-              borderColor: running ? "#7C3AED" : "#334155",
-              backgroundColor: running ? "#3B0764" : "#1E293B",
+              borderColor: running ? "#7C3AED" : "#44403C",
+              backgroundColor: running ? "#3B0764" : "#292524",
             }}
             transition={{ duration: 0.3 }}
             className="w-14 h-14 rounded-xl border-2 flex items-center justify-center"
@@ -180,8 +180,8 @@ export default function Anim2C() {
         <div className="flex flex-col items-center gap-1.5 w-16 shrink-0 pt-1">
           <motion.div
             animate={{
-              borderColor: serverLit ? "#10B981" : "#334155",
-              backgroundColor: serverLit ? "#064E3B" : "#1E293B",
+              borderColor: serverLit ? "#10B981" : "#44403C",
+              backgroundColor: serverLit ? "#064E3B" : "#292524",
             }}
             transition={{ duration: 0.3 }}
             className="w-14 h-14 rounded-xl border-2 flex items-center justify-center"

--- a/client/src/module/student/learn/computer-networks/module-3/_components/Anim3A.tsx
+++ b/client/src/module/student/learn/computer-networks/module-3/_components/Anim3A.tsx
@@ -58,7 +58,7 @@ export default function Anim3A() {
   const isDone        = phase === "done"
 
   return (
-    <div className="bg-[#0F172A] min-h-[400px] p-5 flex flex-col gap-4">
+    <div className="bg-[#1C1917] min-h-[400px] p-5 flex flex-col gap-4">
 
       {/* controls */}
       <div className="flex items-center gap-2 flex-wrap">
@@ -79,7 +79,7 @@ export default function Anim3A() {
         )}
         <button
           onClick={reset}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs transition-colors border border-[#334155]"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs transition-colors border border-[#44403C]"
         >
           <RotateCcw size={10} /> Reset
         </button>
@@ -107,13 +107,13 @@ export default function Anim3A() {
                 key={h.id}
                 x1={h.x + 20} y1={h.y + 16}
                 x2={SWITCH.x} y2={SWITCH.y}
-                stroke="#334155" strokeWidth="1.5"
+                stroke="#44403C" strokeWidth="1.5"
               />
             ))}
 
             {/* switch */}
-            <rect x={SWITCH.x - 22} y={SWITCH.y - 12} width={44} height={24} rx={4} fill="#1E293B" stroke="#475569" strokeWidth="1.5" />
-            <text x={SWITCH.x} y={SWITCH.y + 5} textAnchor="middle" fill="#94A3B8" fontSize="8" fontWeight="bold">SW</text>
+            <rect x={SWITCH.x - 22} y={SWITCH.y - 12} width={44} height={24} rx={4} fill="#292524" stroke="#57534E" strokeWidth="1.5" />
+            <text x={SWITCH.x} y={SWITCH.y + 5} textAnchor="middle" fill="#A8A29E" fontSize="8" fontWeight="bold">SW</text>
 
             {/* broadcast rays from switch to non-A hosts */}
             {showBroadcast && ["B","C","D"].map(id => {
@@ -162,7 +162,7 @@ export default function Anim3A() {
                 <motion.text
                   key={id}
                   x={h.x + 20} y={h.y - 6}
-                  textAnchor="middle" fill="#64748B" fontSize="7"
+                  textAnchor="middle" fill="#78716C" fontSize="7"
                   initial={{ opacity: 0 }} animate={{ opacity: 1 }}
                 >
                   not me
@@ -215,12 +215,12 @@ export default function Anim3A() {
                 <g key={h.id}>
                   <rect
                     x={h.x} y={h.y} width={40} height={32} rx={6}
-                    fill={isActive ? "#1E1B4B" : isSender ? "#3B0764" : "#1E293B"}
-                    stroke={isActive ? "#7C3AED" : isSender && showBroadcast ? "#F59E0B" : "#334155"}
+                    fill={isActive ? "#1A2E05" : isSender ? "#3B0764" : "#292524"}
+                    stroke={isActive ? "#7C3AED" : isSender && showBroadcast ? "#F59E0B" : "#44403C"}
                     strokeWidth="1.5"
                   />
-                  <text x={h.x + 20} y={h.y + 13} textAnchor="middle" fill={isNotMe ? "#475569" : "#E2E8F0"} fontSize="8" fontWeight="bold">{h.label}</text>
-                  <text x={h.x + 20} y={h.y + 24} textAnchor="middle" fill="#64748B" fontSize="6.5">{h.ip}</text>
+                  <text x={h.x + 20} y={h.y + 13} textAnchor="middle" fill={isNotMe ? "#57534E" : "#E7E5E4"} fontSize="8" fontWeight="bold">{h.label}</text>
+                  <text x={h.x + 20} y={h.y + 24} textAnchor="middle" fill="#78716C" fontSize="6.5">{h.ip}</text>
                 </g>
               )
             })}
@@ -229,7 +229,7 @@ export default function Anim3A() {
 
         {/* info / arp cache panel */}
         <div className="w-48 shrink-0 flex flex-col gap-3">
-          <div className="bg-[#1E293B] rounded-xl p-3 border border-[#334155]">
+          <div className="bg-[#292524] rounded-xl p-3 border border-[#44403C]">
             <p className="text-[9px] font-bold text-stone-400 uppercase tracking-wider mb-2">ARP Cache  Host A</p>
             <AnimatePresence>
               {arpCache ? (
@@ -258,7 +258,7 @@ export default function Anim3A() {
             </AnimatePresence>
           </div>
 
-          <div className="bg-[#1E293B] rounded-xl p-3 border border-[#334155] flex-1">
+          <div className="bg-[#292524] rounded-xl p-3 border border-[#44403C] flex-1">
             <p className="text-[9px] font-bold text-stone-400 uppercase tracking-wider mb-2">Legend</p>
             <div className="space-y-1.5">
               <div className="flex items-center gap-1.5">

--- a/client/src/module/student/learn/computer-networks/module-3/_components/Anim3B.tsx
+++ b/client/src/module/student/learn/computer-networks/module-3/_components/Anim3B.tsx
@@ -100,7 +100,7 @@ export default function Anim3B() {
     : table
 
   return (
-    <div className="bg-[#0F172A] min-h-[420px] p-5 flex flex-col gap-4">
+    <div className="bg-[#1C1917] min-h-[420px] p-5 flex flex-col gap-4">
 
       {/* controls */}
       <div className="flex items-center gap-2 flex-wrap">
@@ -113,7 +113,7 @@ export default function Anim3B() {
         </button>
         <button
           onClick={reset}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors"
         >
           <RotateCcw size={10} /> Reset
         </button>
@@ -139,16 +139,16 @@ export default function Anim3B() {
           <svg viewBox="0 0 360 220" className="w-full h-full" style={{ minHeight: 200 }}>
 
             {/* switch box */}
-            <rect x={SW.x-30} y={SW.y-18} width={60} height={36} rx={6} fill="#1E293B" stroke="#475569" strokeWidth="1.5" />
-            <text x={SW.x} y={SW.y-3}  textAnchor="middle" fill="#94A3B8" fontSize="8" fontWeight="bold">Switch</text>
-            <text x={SW.x} y={SW.y+10} textAnchor="middle" fill="#475569" fontSize="7">4-port</text>
+            <rect x={SW.x-30} y={SW.y-18} width={60} height={36} rx={6} fill="#292524" stroke="#57534E" strokeWidth="1.5" />
+            <text x={SW.x} y={SW.y-3}  textAnchor="middle" fill="#A8A29E" fontSize="8" fontWeight="bold">Switch</text>
+            <text x={SW.x} y={SW.y+10} textAnchor="middle" fill="#57534E" fontSize="7">4-port</text>
 
             {/* port connections */}
             {PORTS.map(p => (
               <line key={p.id}
                 x1={p.x + 30} y1={p.y + 18}
                 x2={SW.x + (p.x < 170 ? -30 : 30)} y2={SW.y}
-                stroke="#334155" strokeWidth="1.5"
+                stroke="#44403C" strokeWidth="1.5"
               />
             ))}
 
@@ -206,15 +206,15 @@ export default function Anim3B() {
                 <g key={p.id}>
                   <rect
                     x={p.x} y={p.y} width={60} height={36} rx={6}
-                    fill={isSrc ? "#3B0764" : isDest ? "#064E3B" : "#1E293B"}
-                    stroke={isSrc ? "#7C3AED" : isDest ? "#10B981" : isBlk ? "#334155" : isFlooded ? "#92400E" : "#334155"}
+                    fill={isSrc ? "#3B0764" : isDest ? "#064E3B" : "#292524"}
+                    stroke={isSrc ? "#7C3AED" : isDest ? "#10B981" : isBlk ? "#44403C" : isFlooded ? "#92400E" : "#44403C"}
                     strokeWidth={isSrc || isDest ? 2 : 1.5}
                     opacity={isBlk ? 0.5 : 1}
                   />
-                  <text x={p.x + 30} y={p.y + 14} textAnchor="middle" fill={isBlk ? "#475569" : "#E2E8F0"} fontSize="8" fontWeight="bold">{p.host}</text>
-                  <text x={p.x + 30} y={p.y + 26} textAnchor="middle" fill="#475569" fontSize="6">{p.mac.slice(0, 11)}…</text>
+                  <text x={p.x + 30} y={p.y + 14} textAnchor="middle" fill={isBlk ? "#57534E" : "#E7E5E4"} fontSize="8" fontWeight="bold">{p.host}</text>
+                  <text x={p.x + 30} y={p.y + 26} textAnchor="middle" fill="#57534E" fontSize="6">{p.mac.slice(0, 11)}…</text>
                   {isBlk && (
-                    <text x={p.x + 30} y={p.y - 4} textAnchor="middle" fill="#475569" fontSize="7">blocked</text>
+                    <text x={p.x + 30} y={p.y - 4} textAnchor="middle" fill="#57534E" fontSize="7">blocked</text>
                   )}
                 </g>
               )
@@ -241,7 +241,7 @@ export default function Anim3B() {
 
           {/* step description */}
           {step >= 0 && (
-            <div className="bg-[#1E293B] rounded-xl p-3 border border-[#334155]">
+            <div className="bg-[#292524] rounded-xl p-3 border border-[#44403C]">
               <p className="text-[9px] font-bold text-lime-400 uppercase tracking-wider mb-1">
                 Step {step + 1}  {SCENARIOS[step].label}
               </p>
@@ -250,13 +250,13 @@ export default function Anim3B() {
           )}
 
           {/* MAC table */}
-          <div className="bg-[#1E293B] rounded-xl p-3 border border-[#334155] flex-1">
+          <div className="bg-[#292524] rounded-xl p-3 border border-[#44403C] flex-1">
             <p className="text-[9px] font-bold text-stone-400 uppercase tracking-wider mb-2">MAC Address Table</p>
             {displayTable.length === 0 ? (
               <p className="text-[9px] text-stone-600 italic">empty</p>
             ) : (
               <div className="space-y-1.5">
-                <div className="grid grid-cols-3 text-[8px] text-stone-500 font-bold pb-1 border-b border-[#334155]">
+                <div className="grid grid-cols-3 text-[8px] text-stone-500 font-bold pb-1 border-b border-[#44403C]">
                   <span>MAC</span><span>Port</span><span>TTL</span>
                 </div>
                 <AnimatePresence>

--- a/client/src/module/student/learn/computer-networks/module-3/_components/Anim3C.tsx
+++ b/client/src/module/student/learn/computer-networks/module-3/_components/Anim3C.tsx
@@ -9,7 +9,7 @@ const FRAME_FIELDS = [
     name: "Preamble",
     bytes: "7B",
     hex: "AA AA AA AA AA AA AA",
-    color: "#475569",
+    color: "#57534E",
     desc: "Alternating 1s and 0s that synchronise the receiver's clock before the frame arrives.",
   },
   {
@@ -17,7 +17,7 @@ const FRAME_FIELDS = [
     name: "SFD",
     bytes: "1B",
     hex: "AB",
-    color: "#64748B",
+    color: "#78716C",
     desc: "Start Frame Delimiter  the byte 10101011 signals the end of the preamble and the start of the actual frame.",
   },
   {
@@ -104,7 +104,7 @@ export default function Anim3C() {
   const selectedField = FRAME_FIELDS.find(f => f.key === selected)
 
   return (
-    <div className="bg-[#0F172A] min-h-[420px] p-5 flex flex-col gap-4">
+    <div className="bg-[#1C1917] min-h-[420px] p-5 flex flex-col gap-4">
 
       {/* controls */}
       <div className="flex items-center gap-2 flex-wrap">
@@ -143,7 +143,7 @@ export default function Anim3C() {
         )}
         <button
           onClick={reset}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors"
         >
           <RotateCcw size={10} /> Reset
         </button>
@@ -153,7 +153,7 @@ export default function Anim3C() {
       {!exploded && (
         <div className="relative flex items-center gap-3 px-2">
           <div className="flex flex-col items-center gap-1">
-            <div className="w-10 h-10 rounded-xl bg-[#1E293B] border border-[#334155] flex items-center justify-center">
+            <div className="w-10 h-10 rounded-xl bg-[#292524] border border-[#44403C] flex items-center justify-center">
               <span className="text-[10px] text-stone-400 font-bold">NIC</span>
             </div>
             <span className="text-[8px] text-stone-500">Sender</span>
@@ -161,7 +161,7 @@ export default function Anim3C() {
 
           <div className="flex-1 relative h-6 flex items-center">
             {/* cable */}
-            <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-1 bg-[#334155] rounded-full" />
+            <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-1 bg-[#44403C] rounded-full" />
 
             {/* traveling packet */}
             {traveling && (
@@ -177,7 +177,7 @@ export default function Anim3C() {
             )}
 
             {!traveling && !arrived && (
-              <div className="absolute left-1 top-1/2 -translate-y-1/2 h-5 rounded flex items-center justify-center px-2 bg-[#1E293B] border border-[#334155]">
+              <div className="absolute left-1 top-1/2 -translate-y-1/2 h-5 rounded flex items-center justify-center px-2 bg-[#292524] border border-[#44403C]">
                 <span className="text-[9px] text-stone-500">Ready</span>
               </div>
             )}
@@ -195,7 +195,7 @@ export default function Anim3C() {
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className={`w-10 h-10 rounded-xl border flex items-center justify-center transition-colors ${arrived ? "bg-[#064E3B] border-emerald-700" : "bg-[#1E293B] border-[#334155]"}`}>
+            <div className={`w-10 h-10 rounded-xl border flex items-center justify-center transition-colors ${arrived ? "bg-[#064E3B] border-emerald-700" : "bg-[#292524] border-[#44403C]"}`}>
               <span className="text-[10px] text-stone-400 font-bold">NIC</span>
             </div>
             <span className="text-[8px] text-stone-500">Receiver</span>
@@ -214,7 +214,7 @@ export default function Anim3C() {
             <p className="text-[9px] text-stone-500 uppercase font-bold tracking-wider">Click any field to inspect</p>
 
             {/* field strip */}
-            <div className="flex rounded-xl overflow-hidden border border-[#334155]">
+            <div className="flex rounded-xl overflow-hidden border border-[#44403C]">
               {FRAME_FIELDS.map(f => (
                 <button
                   key={f.key}
@@ -226,7 +226,7 @@ export default function Anim3C() {
                       : f.key === "fcs" && corrupted
                         ? "#7F1D1D"
                         : f.color + "33",
-                    borderRight: "1px solid #0F172A",
+                    borderRight: "1px solid #1C1917",
                     outline: f.key === selected ? `2px solid ${f.color}` : "none",
                   }}
                 >
@@ -243,7 +243,7 @@ export default function Anim3C() {
 
             {/* detail panel */}
             <div className="flex gap-3 flex-1">
-              <div className="flex-1 bg-[#1E293B] rounded-xl p-4 border border-[#334155]">
+              <div className="flex-1 bg-[#292524] rounded-xl p-4 border border-[#44403C]">
                 {selectedField ? (
                   <motion.div
                     key={selectedField.key}
@@ -259,7 +259,7 @@ export default function Anim3C() {
                       <span className="font-display font-bold text-sm text-white">{selectedField.name}</span>
                       <span className="ml-auto text-[10px] text-stone-500 font-mono">{selectedField.bytes}</span>
                     </div>
-                    <div className="font-mono text-[10px] text-amber-300 bg-[#0F172A] px-3 py-2 rounded-lg break-all">
+                    <div className="font-mono text-[10px] text-amber-300 bg-[#1C1917] px-3 py-2 rounded-lg break-all">
                       {selectedField.key === "fcs" && corrupted ? "B4 D1 FF 00 (CORRUPTED)" : selectedField.hex}
                     </div>
                     <p className="text-xs text-stone-400 leading-relaxed flex-1">{selectedField.desc}</p>

--- a/client/src/module/student/learn/computer-networks/module-4/_components/Anim4A.tsx
+++ b/client/src/module/student/learn/computer-networks/module-4/_components/Anim4A.tsx
@@ -63,7 +63,7 @@ export default function Anim4A() {
   }
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-5 min-h-[420px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-5 min-h-[420px]">
 
       {/* presets */}
       <div className="flex flex-wrap gap-1.5">
@@ -71,7 +71,7 @@ export default function Anim4A() {
           <button
             key={i}
             onClick={() => applyPreset(i)}
-            className="px-2.5 py-1 rounded-lg bg-[#1E293B] hover:bg-[#334155] text-[9px] font-mono text-stone-400 border border-[#334155] transition-colors"
+            className="px-2.5 py-1 rounded-lg bg-[#292524] hover:bg-[#44403C] text-[9px] font-mono text-stone-400 border border-[#44403C] transition-colors"
           >
             {p.label}
           </button>
@@ -96,7 +96,7 @@ export default function Anim4A() {
                     animate={{
                       backgroundColor: b
                         ? isNetBit ? "#7C3AED" : "#2563EB"
-                        : "#1E293B",
+                        : "#292524",
                       borderColor: isNetBit ? "#5B21B6" : "#1D4ED8",
                     }}
                     transition={{ duration: 0.15 }}
@@ -154,7 +154,7 @@ export default function Anim4A() {
           { label: "Last Host",       value: ipStr(lastHost),  color: "#10B981" },
           { label: "Usable Hosts",    value: hostCount.toLocaleString(), color: "#2563EB" },
         ].map(({ label, value, color }) => (
-          <div key={label} className="bg-[#1E293B] rounded-xl p-2.5 border border-[#334155]">
+          <div key={label} className="bg-[#292524] rounded-xl p-2.5 border border-[#44403C]">
             <p className="text-[8px] text-stone-500 font-bold uppercase tracking-wider mb-1">{label}</p>
             <AnimatePresence mode="wait">
               <motion.p

--- a/client/src/module/student/learn/computer-networks/module-4/_components/Anim4B.tsx
+++ b/client/src/module/student/learn/computer-networks/module-4/_components/Anim4B.tsx
@@ -72,7 +72,7 @@ export default function Anim4B() {
   }
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-4 min-h-[420px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-4 min-h-[420px]">
 
       {/* controls */}
       <div className="flex flex-wrap gap-3 items-end">
@@ -81,7 +81,7 @@ export default function Anim4B() {
           <input
             value={input}
             onChange={e => handleInput(e.target.value)}
-            className="bg-[#1E293B] border border-[#334155] rounded-lg px-3 py-1.5 text-xs font-mono text-stone-200 outline-none focus:border-lime-500 w-44"
+            className="bg-[#292524] border border-[#44403C] rounded-lg px-3 py-1.5 text-xs font-mono text-stone-200 outline-none focus:border-lime-500 w-44"
           />
           {error && <span className="text-[9px] text-red-400">{error}</span>}
         </div>
@@ -109,7 +109,7 @@ export default function Anim4B() {
       {subnets.length > 0 ? (
         <div className="flex flex-col gap-2">
           <p className="text-[9px] text-stone-500 uppercase font-bold tracking-wider">Click a subnet to inspect</p>
-          <div className="flex h-14 rounded-xl overflow-hidden border border-[#334155] gap-px">
+          <div className="flex h-14 rounded-xl overflow-hidden border border-[#44403C] gap-px">
             {subnets.map((s, i) => (
               <motion.button
                 key={i}
@@ -144,7 +144,7 @@ export default function Anim4B() {
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0 }}
-            className="bg-[#1E293B] rounded-xl p-4 border"
+            className="bg-[#292524] rounded-xl p-4 border"
             style={{ borderColor: COLORS[selected % COLORS.length] + "55" }}
           >
             <div className="flex items-center gap-2 mb-3">
@@ -181,7 +181,7 @@ export default function Anim4B() {
 
       {/* summary */}
       {parsed && subnets.length > 0 && (
-        <div className="flex flex-wrap gap-3 text-[10px] text-stone-400 border-t border-[#334155] pt-3">
+        <div className="flex flex-wrap gap-3 text-[10px] text-stone-400 border-t border-[#44403C] pt-3">
           <span>Base: <span className="text-lime-300 font-mono">{input}</span></span>
           <span>Borrowed: <span className="text-amber-300">{borrow} bits</span></span>
           <span>New prefix: <span className="text-lime-300 font-mono">/{newPrefix}</span></span>

--- a/client/src/module/student/learn/computer-networks/module-4/_components/Anim4C.tsx
+++ b/client/src/module/student/learn/computer-networks/module-4/_components/Anim4C.tsx
@@ -127,7 +127,7 @@ export default function Anim4C() {
   function routerPos(id: string) { return ROUTERS.find(r => r.id === id)! }
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-4 min-h-[440px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-4 min-h-[440px]">
 
       {/* controls */}
       <div className="flex flex-wrap items-center gap-2">
@@ -136,7 +136,7 @@ export default function Anim4C() {
           <select
             value={dest}
             onChange={e => { setDest(e.target.value); reset() }}
-            className="bg-[#1E293B] border border-[#334155] rounded-lg px-2 py-1.5 text-xs font-mono text-stone-200 outline-none focus:border-lime-500"
+            className="bg-[#292524] border border-[#44403C] rounded-lg px-2 py-1.5 text-xs font-mono text-stone-200 outline-none focus:border-lime-500"
           >
             <option value="10.0.3.0/24">10.0.3.0/24 (H2 subnet)</option>
             <option value="10.0.4.0/24">10.0.4.0/24 (H3 subnet)</option>
@@ -151,26 +151,26 @@ export default function Anim4C() {
         </button>
         <button
           onClick={breakLink}
-          className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors self-end ${brokenLink ? "bg-red-700 hover:bg-red-600 text-white" : "bg-[#1E293B] hover:bg-[#334155] text-stone-400 border border-[#334155]"}`}
+          className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors self-end ${brokenLink ? "bg-red-700 hover:bg-red-600 text-white" : "bg-[#292524] hover:bg-[#44403C] text-stone-400 border border-[#44403C]"}`}
         >
           {brokenLink ? "Restore Link" : "Break R2–R4"}
         </button>
         <button
           onClick={reset}
-          className="px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors self-end"
+          className="px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors self-end"
         >
           <RotateCcw size={10} />
         </button>
         <button
           onClick={() => setShowAdd(s => !s)}
-          className="flex items-center gap-1 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors self-end"
+          className="flex items-center gap-1 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors self-end"
         >
           <Plus size={10} /> Static route
         </button>
       </div>
 
       {showAdd && (
-        <div className="flex items-center gap-2 bg-[#1E293B] p-3 rounded-xl border border-[#334155] text-[10px] text-stone-400">
+        <div className="flex items-center gap-2 bg-[#292524] p-3 rounded-xl border border-[#44403C] text-[10px] text-stone-400">
           <span>Injecting a static route would redirect traffic. In a real router: <code className="text-lime-300">ip route add 10.0.3.0/24 via 10.0.1.2</code></span>
           <button type="button" onClick={() => setShowAdd(false)} className="ml-auto text-stone-500 hover:text-stone-300"><X size={12} /></button>
         </div>
@@ -187,10 +187,10 @@ export default function Anim4C() {
               const r = routerPos(s.router)
               return (
                 <g key={s.host}>
-                  <line x1={s.hx + 16} y1={s.hy + 12} x2={r.x + 16} y2={r.y + 12} stroke="#334155" strokeWidth="1" strokeDasharray="4 2" />
-                  <rect x={s.hx} y={s.hy} width={32} height={24} rx={4} fill="#1E293B" stroke="#334155" strokeWidth="1" />
-                  <text x={s.hx + 16} y={s.hy + 10} textAnchor="middle" fill="#64748B" fontSize="6" fontWeight="bold">{s.host}</text>
-                  <text x={s.hx + 16} y={s.hy + 20} textAnchor="middle" fill="#475569" fontSize="5.5">{s.prefix.split("/")[0].split(".").slice(0, 3).join(".")}.x</text>
+                  <line x1={s.hx + 16} y1={s.hy + 12} x2={r.x + 16} y2={r.y + 12} stroke="#44403C" strokeWidth="1" strokeDasharray="4 2" />
+                  <rect x={s.hx} y={s.hy} width={32} height={24} rx={4} fill="#292524" stroke="#44403C" strokeWidth="1" />
+                  <text x={s.hx + 16} y={s.hy + 10} textAnchor="middle" fill="#78716C" fontSize="6" fontWeight="bold">{s.host}</text>
+                  <text x={s.hx + 16} y={s.hy + 20} textAnchor="middle" fill="#57534E" fontSize="5.5">{s.prefix.split("/")[0].split(".").slice(0, 3).join(".")}.x</text>
                 </g>
               )
             })}
@@ -209,7 +209,7 @@ export default function Anim4C() {
                 <g key={`${l.from}-${l.to}`}>
                   <line
                     x1={a.x + 16} y1={a.y + 12} x2={b.x + 16} y2={b.y + 12}
-                    stroke={isBroken ? "#EF4444" : isActive ? "#7C3AED" : "#334155"}
+                    stroke={isBroken ? "#EF4444" : isActive ? "#7C3AED" : "#44403C"}
                     strokeWidth={isActive ? 2.5 : 1.5}
                     strokeDasharray={isBroken ? "4 3" : undefined}
                   />
@@ -248,13 +248,13 @@ export default function Anim4C() {
                   <motion.rect
                     x={r.x} y={r.y} width={32} height={24} rx={6}
                     animate={{
-                      fill:        isActive ? r.color + "33" : inPath ? r.color + "15" : "#1E293B",
-                      stroke:      isActive ? r.color : inPath ? r.color + "88" : "#475569",
+                      fill:        isActive ? r.color + "33" : inPath ? r.color + "15" : "#292524",
+                      stroke:      isActive ? r.color : inPath ? r.color + "88" : "#57534E",
                       strokeWidth: isActive ? 2 : 1.5,
                     }}
                     transition={{ duration: 0.2 }}
                   />
-                  <text x={r.x + 16} y={r.y + 15} textAnchor="middle" fill={inPath ? "#E2E8F0" : "#94A3B8"} fontSize="9" fontWeight="bold">{r.label}</text>
+                  <text x={r.x + 16} y={r.y + 15} textAnchor="middle" fill={inPath ? "#E7E5E4" : "#A8A29E"} fontSize="9" fontWeight="bold">{r.label}</text>
                 </g>
               )
             })}
@@ -278,16 +278,16 @@ export default function Anim4C() {
           <p className="text-[9px] text-stone-500 font-bold uppercase tracking-wider">
             {activeRouter ? `${activeRouter} Routing Table` : "Routing Table"}
           </p>
-          <div className="bg-[#1E293B] rounded-xl border border-[#334155] overflow-hidden flex-1">
+          <div className="bg-[#292524] rounded-xl border border-[#44403C] overflow-hidden flex-1">
             {activeRouter ? (
               <div className="overflow-auto">
-                <div className="grid grid-cols-2 text-[7px] text-stone-500 font-bold px-2 py-1.5 border-b border-[#334155] bg-[#0F172A]">
+                <div className="grid grid-cols-2 text-[7px] text-stone-500 font-bold px-2 py-1.5 border-b border-[#44403C] bg-[#1C1917]">
                   <span>Destination</span><span>Next Hop</span>
                 </div>
                 {ROUTING_TABLES[activeRouter].map((row, i) => (
                   <div
                     key={i}
-                    className="grid grid-cols-2 text-[8px] px-2 py-1.5 border-b border-[#0F172A] transition-colors"
+                    className="grid grid-cols-2 text-[8px] px-2 py-1.5 border-b border-[#1C1917] transition-colors"
                     style={{
                       backgroundColor: i === activeRowIdx ? "#3B0764" : "transparent",
                     }}

--- a/client/src/module/student/learn/computer-networks/module-4/_components/Anim4D.tsx
+++ b/client/src/module/student/learn/computer-networks/module-4/_components/Anim4D.tsx
@@ -92,7 +92,7 @@ export default function Anim4D() {
   const selectedEntry = natTable.find(e => e.host === selected)
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-4 min-h-[420px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-4 min-h-[420px]">
 
       {/* controls */}
       <div className="flex items-center gap-2 flex-wrap">
@@ -110,7 +110,7 @@ export default function Anim4D() {
         ))}
         <button
           onClick={reset}
-          className="flex items-center gap-1 ml-auto px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors"
+          className="flex items-center gap-1 ml-auto px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors"
         >
           <RotateCcw size={10} /> Reset
         </button>
@@ -127,8 +127,8 @@ export default function Anim4D() {
               key={h.id}
               className="rounded-xl px-2.5 py-2 border text-center transition-all"
               style={{
-                backgroundColor: done.includes(h.id) ? h.color + "22" : "#1E293B",
-                borderColor: done.includes(h.id) ? h.color : "#334155",
+                backgroundColor: done.includes(h.id) ? h.color + "22" : "#292524",
+                borderColor: done.includes(h.id) ? h.color : "#44403C",
               }}
             >
               <p className="text-[9px] font-bold text-white">{h.label}</p>
@@ -142,7 +142,7 @@ export default function Anim4D() {
 
         {/* router / NAT box */}
         <div className="flex flex-col items-center justify-center gap-1.5 w-28 shrink-0">
-          <div className="w-full rounded-xl bg-[#1E293B] border-2 border-[#334155] p-2 text-center">
+          <div className="w-full rounded-xl bg-[#292524] border-2 border-[#44403C] p-2 text-center">
             <p className="text-[9px] font-bold text-stone-300">Router / NAT</p>
             <p className="text-[8px] font-mono text-lime-300">{PUBLIC_IP}</p>
           </div>
@@ -170,7 +170,7 @@ export default function Anim4D() {
         {/* internet side */}
         <div className="flex flex-col justify-center gap-2 flex-1">
           <p className="text-[8px] text-stone-500 font-bold uppercase tracking-wider text-center">Internet</p>
-          <div className="rounded-xl bg-[#1E293B] border border-[#334155] p-3 text-center">
+          <div className="rounded-xl bg-[#292524] border border-[#44403C] p-3 text-center">
             <p className="text-[9px] font-bold text-stone-300">Remote Server</p>
             <p className="text-[8px] font-mono text-amber-300">{SERVER_IP}</p>
             <p className="text-[7px] text-stone-500 mt-0.5">port 80</p>
@@ -179,7 +179,7 @@ export default function Anim4D() {
             <motion.div
               initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
-              className="rounded-xl bg-[#1E293B] border border-lime-500/30 p-2.5 text-[8px]"
+              className="rounded-xl bg-[#292524] border border-lime-500/30 p-2.5 text-[8px]"
             >
               <p className="font-bold text-lime-400 mb-1.5">Header rewrite (before/after)</p>
               <div className="flex flex-col gap-1">
@@ -200,15 +200,15 @@ export default function Anim4D() {
       </div>
 
       {/* NAT table */}
-      <div className="bg-[#1E293B] rounded-xl border border-[#334155] overflow-hidden">
-        <div className="px-3 py-2 border-b border-[#334155] bg-[#0F172A]">
+      <div className="bg-[#292524] rounded-xl border border-[#44403C] overflow-hidden">
+        <div className="px-3 py-2 border-b border-[#44403C] bg-[#1C1917]">
           <p className="text-[9px] font-bold text-stone-400 uppercase tracking-wider">NAT Translation Table</p>
         </div>
         {natTable.length === 0 ? (
           <p className="text-[9px] text-stone-600 italic px-3 py-2">empty  send a request to populate</p>
         ) : (
           <div className="overflow-auto">
-            <div className="grid grid-cols-4 text-[7px] text-stone-500 font-bold px-3 py-1.5 border-b border-[#0F172A]">
+            <div className="grid grid-cols-4 text-[7px] text-stone-500 font-bold px-3 py-1.5 border-b border-[#1C1917]">
               <span>Private IP:Port</span><span>Public IP:Port</span><span>Destination</span><span>State</span>
             </div>
             <AnimatePresence>
@@ -220,7 +220,7 @@ export default function Anim4D() {
                     onClick={() => setSelected(e.host === selected ? null : e.host)}
                     initial={{ opacity: 0, x: -8 }}
                     animate={{ opacity: 1, x: 0 }}
-                    className="grid grid-cols-4 text-[8px] px-3 py-1.5 border-b border-[#0F172A] w-full text-left transition-colors"
+                    className="grid grid-cols-4 text-[8px] px-3 py-1.5 border-b border-[#1C1917] w-full text-left transition-colors"
                     style={{ backgroundColor: e.host === selected ? host.color + "22" : "transparent" }}
                   >
                     <span className="font-mono text-rose-300">{e.privateIP}:{e.privatePort}</span>

--- a/client/src/module/student/learn/computer-networks/module-5/_components/Anim5A.tsx
+++ b/client/src/module/student/learn/computer-networks/module-5/_components/Anim5A.tsx
@@ -39,7 +39,7 @@ const STEPS_DROPPED: Step[] = [
 ]
 
 const STATE_COLORS: Record<State, string> = {
-  CLOSED:       "#475569",
+  CLOSED:       "#57534E",
   LISTEN:       "#2563EB",
   SYN_SENT:     "#F59E0B",
   SYN_RECEIVED: "#8B5CF6",
@@ -82,11 +82,11 @@ export default function Anim5A() {
   }
 
   return (
-    <div className="bg-[#0F172A] min-h-[440px] p-5 flex flex-col gap-4">
+    <div className="bg-[#1C1917] min-h-[440px] p-5 flex flex-col gap-4">
 
       {/* mode tabs + controls */}
       <div className="flex items-center gap-2 flex-wrap">
-        <div className="flex rounded-lg overflow-hidden border border-[#334155]">
+        <div className="flex rounded-lg overflow-hidden border border-[#44403C]">
           {(["normal", "dropped"] as const).map(m => (
             <button
               key={m}
@@ -94,7 +94,7 @@ export default function Anim5A() {
               className="px-3 py-1.5 text-xs font-semibold transition-colors"
               style={{
                 backgroundColor: mode === m ? "#A3E635" : "transparent",
-                color: mode === m ? "#1C1917" : "#64748B",
+                color: mode === m ? "#1C1917" : "#78716C",
               }}
             >
               {m === "normal" ? "Normal" : "Dropped SYN"}
@@ -110,7 +110,7 @@ export default function Anim5A() {
         </button>
         <button
           onClick={reset}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors"
         >
           <RotateCcw size={10} /> Reset
         </button>
@@ -127,14 +127,14 @@ export default function Anim5A() {
           {/* column headers */}
           <div className="flex justify-between px-8 mb-3">
             <div className="flex flex-col items-center gap-1">
-              <div className="w-12 h-12 rounded-xl bg-[#1E293B] border border-[#334155] flex items-center justify-center">
+              <div className="w-12 h-12 rounded-xl bg-[#292524] border border-[#44403C] flex items-center justify-center">
                 <span className="text-[10px] font-bold text-stone-300">CLI</span>
               </div>
               <span className="text-[9px] text-stone-500 font-bold uppercase tracking-wider">Client</span>
               <StatePill state={cur.clientState} />
             </div>
             <div className="flex flex-col items-center gap-1">
-              <div className="w-12 h-12 rounded-xl bg-[#1E293B] border border-[#334155] flex items-center justify-center">
+              <div className="w-12 h-12 rounded-xl bg-[#292524] border border-[#44403C] flex items-center justify-center">
                 <span className="text-[10px] font-bold text-stone-300">SRV</span>
               </div>
               <span className="text-[9px] text-stone-500 font-bold uppercase tracking-wider">Server</span>
@@ -216,7 +216,7 @@ export default function Anim5A() {
         </div>
 
         {/* info panel */}
-        <div className="w-48 shrink-0 bg-[#1E293B] rounded-xl border border-[#334155] p-4 flex flex-col gap-3">
+        <div className="w-48 shrink-0 bg-[#292524] rounded-xl border border-[#44403C] p-4 flex flex-col gap-3">
           <AnimatePresence mode="wait">
             <motion.div
               key={stepIdx}
@@ -234,7 +234,7 @@ export default function Anim5A() {
           </AnimatePresence>
 
           {/* step dots */}
-          <div className="flex flex-wrap gap-1 pt-2 border-t border-[#334155]">
+          <div className="flex flex-wrap gap-1 pt-2 border-t border-[#44403C]">
             {steps.map((_, i) => (
               <button
                 key={i}
@@ -244,7 +244,7 @@ export default function Anim5A() {
                   width: i === stepIdx ? 8 : 5,
                   height: i === stepIdx ? 8 : 5,
                   marginTop: i === stepIdx ? 0 : 1.5,
-                  backgroundColor: i === stepIdx ? "#A3E635" : "#334155",
+                  backgroundColor: i === stepIdx ? "#A3E635" : "#44403C",
                 }}
               />
             ))}

--- a/client/src/module/student/learn/computer-networks/module-5/_components/Anim5B.tsx
+++ b/client/src/module/student/learn/computer-networks/module-5/_components/Anim5B.tsx
@@ -51,14 +51,14 @@ export default function Anim5B() {
   })
 
   const SLOT_COLORS: Record<string, string> = {
-    "acked":       "#64748B",
+    "acked":       "#78716C",
     "sent-unacked":"#7C3AED",
     "can-send":    "#2563EB",
-    "cannot-send": "#1E293B",
+    "cannot-send": "#292524",
   }
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-5 min-h-[380px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-5 min-h-[380px]">
 
       {/* window size slider */}
       <div className="flex items-center gap-3">
@@ -91,13 +91,13 @@ export default function Anim5B() {
         {/* zone labels */}
         <div className="flex gap-4 flex-wrap">
           {[
-            { color: "#64748B", label: "Sent & ACK'd" },
+            { color: "#78716C", label: "Sent & ACK'd" },
             { color: "#7C3AED", label: "Sent, unACK'd" },
             { color: "#2563EB", label: "Window (can send)" },
-            { color: "#1E293B", label: "Beyond window" },
+            { color: "#292524", label: "Beyond window" },
           ].map(({ color, label }) => (
             <div key={label} className="flex items-center gap-1.5">
-              <div className="w-3 h-3 rounded-sm border border-[#334155]" style={{ backgroundColor: color }} />
+              <div className="w-3 h-3 rounded-sm border border-[#44403C]" style={{ backgroundColor: color }} />
               <span className="text-[9px] text-stone-400">{label}</span>
             </div>
           ))}
@@ -129,7 +129,7 @@ export default function Anim5B() {
         </button>
         <button
           onClick={reset}
-          className="flex items-center gap-1 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors"
+          className="flex items-center gap-1 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors"
         >
           <RotateCcw size={10} /> Reset
         </button>
@@ -182,7 +182,7 @@ export default function Anim5B() {
       </AnimatePresence>
 
       {/* stats */}
-      <div className="flex gap-4 text-[10px] text-stone-500 border-t border-[#334155] pt-3">
+      <div className="flex gap-4 text-[10px] text-stone-500 border-t border-[#44403C] pt-3">
         <span>ACK'd: <span className="text-stone-300 font-mono">{acked}</span></span>
         <span>In-flight: <span className="text-lime-300 font-mono">{sent}</span></span>
         <span>Window: <span className="text-blue-300 font-mono">{bufferFull ? 0 : windowSize}</span></span>

--- a/client/src/module/student/learn/computer-networks/module-5/_components/Anim5C.tsx
+++ b/client/src/module/student/learn/computer-networks/module-5/_components/Anim5C.tsx
@@ -124,7 +124,7 @@ export default function Anim5C() {
   }
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-4 min-h-[400px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-4 min-h-[400px]">
 
       {/* controls */}
       <div className="flex flex-wrap items-center gap-2">
@@ -136,8 +136,8 @@ export default function Anim5C() {
             className="px-3 py-1 rounded-lg text-[10px] font-bold border transition-all"
             style={{
               backgroundColor: algos.includes(a) ? ALGO_COLORS[a] + "22" : "transparent",
-              borderColor: algos.includes(a) ? ALGO_COLORS[a] : "#334155",
-              color: algos.includes(a) ? ALGO_COLORS[a] : "#64748B",
+              borderColor: algos.includes(a) ? ALGO_COLORS[a] : "#44403C",
+              color: algos.includes(a) ? ALGO_COLORS[a] : "#78716C",
             }}
           >
             TCP {a.charAt(0).toUpperCase() + a.slice(1)}
@@ -153,7 +153,7 @@ export default function Anim5C() {
         </button>
         <button
           onClick={reset}
-          className="flex items-center gap-1 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors"
+          className="flex items-center gap-1 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors"
         >
           <RotateCcw size={10} />
         </button>
@@ -165,22 +165,22 @@ export default function Anim5C() {
           {/* grid */}
           {[0, 8, 16, 24, 32].map(v => (
             <g key={v}>
-              <line x1={padL} y1={py(v)} x2={W - padR} y2={py(v)} stroke="#1E293B" strokeWidth="1" />
-              <text x={padL - 4} y={py(v) + 3} textAnchor="end" fill="#475569" fontSize="7">{v}</text>
+              <line x1={padL} y1={py(v)} x2={W - padR} y2={py(v)} stroke="#292524" strokeWidth="1" />
+              <text x={padL - 4} y={py(v) + 3} textAnchor="end" fill="#57534E" fontSize="7">{v}</text>
             </g>
           ))}
           {[0, 10, 20, 30, 40].map(v => (
             <g key={v}>
-              <line x1={px(v)} y1={padT} x2={px(v)} y2={H - padB} stroke="#1E293B" strokeWidth="1" />
-              <text x={px(v)} y={H - padB + 12} textAnchor="middle" fill="#475569" fontSize="7">{v}</text>
+              <line x1={px(v)} y1={padT} x2={px(v)} y2={H - padB} stroke="#292524" strokeWidth="1" />
+              <text x={px(v)} y={H - padB + 12} textAnchor="middle" fill="#57534E" fontSize="7">{v}</text>
             </g>
           ))}
 
           {/* axes */}
-          <line x1={padL} y1={padT} x2={padL} y2={H - padB} stroke="#334155" strokeWidth="1" />
-          <line x1={padL} y1={H - padB} x2={W - padR} y2={H - padB} stroke="#334155" strokeWidth="1" />
-          <text x={padL - 28} y={H / 2} textAnchor="middle" fill="#475569" fontSize="8" transform={`rotate(-90, ${padL - 28}, ${H / 2})`}>cwnd (MSS)</text>
-          <text x={W / 2} y={H - 2} textAnchor="middle" fill="#475569" fontSize="8">RTT</text>
+          <line x1={padL} y1={padT} x2={padL} y2={H - padB} stroke="#44403C" strokeWidth="1" />
+          <line x1={padL} y1={H - padB} x2={W - padR} y2={H - padB} stroke="#44403C" strokeWidth="1" />
+          <text x={padL - 28} y={H / 2} textAnchor="middle" fill="#57534E" fontSize="8" transform={`rotate(-90, ${padL - 28}, ${H / 2})`}>cwnd (MSS)</text>
+          <text x={W / 2} y={H - 2} textAnchor="middle" fill="#57534E" fontSize="8">RTT</text>
 
           {/* ssthresh reference line */}
           <line x1={padL} y1={py(SSTHRESH0)} x2={W - padR} y2={py(SSTHRESH0)} stroke="#F59E0B" strokeWidth="1" strokeDasharray="4 3" />
@@ -211,7 +211,7 @@ export default function Anim5C() {
                 key={`${a}-${i}`}
                 cx={px(p.rtt)} cy={py(p.cwnd)} r={4}
                 fill={p.event === "loss" ? "#EF4444" : "#F97316"}
-                stroke="#0F172A" strokeWidth="1.5"
+                stroke="#1C1917" strokeWidth="1.5"
               />
             ))
           )}
@@ -219,7 +219,7 @@ export default function Anim5C() {
 
         {/* legend */}
         <div className="w-40 shrink-0 flex flex-col gap-3">
-          <div className="bg-[#1E293B] rounded-xl p-3 border border-[#334155] space-y-2">
+          <div className="bg-[#292524] rounded-xl p-3 border border-[#44403C] space-y-2">
             <p className="text-[9px] font-bold text-stone-400 uppercase tracking-wider">Legend</p>
             {(["tahoe","reno","cubic"] as Algorithm[]).map(a => (
               <div key={a} className="flex items-center gap-1.5">
@@ -227,7 +227,7 @@ export default function Anim5C() {
                 <span className="text-[9px] text-stone-400">TCP {a.charAt(0).toUpperCase() + a.slice(1)}</span>
               </div>
             ))}
-            <div className="flex items-center gap-1.5 pt-1 border-t border-[#334155]">
+            <div className="flex items-center gap-1.5 pt-1 border-t border-[#44403C]">
               <Zap size={9} className="text-red-400" />
               <span className="text-[9px] text-stone-400">3-dup-ACK (RTT 12)</span>
             </div>
@@ -237,12 +237,12 @@ export default function Anim5C() {
             </div>
           </div>
 
-          <div className="bg-[#1E293B] rounded-xl p-3 border border-[#334155] text-[9px] text-stone-400 space-y-2">
+          <div className="bg-[#292524] rounded-xl p-3 border border-[#44403C] text-[9px] text-stone-400 space-y-2">
             <p className="font-bold text-stone-300">On 3-dup-ACK:</p>
             <p><span className="text-red-400">Tahoe:</span> cwnd→1, slow start</p>
             <p><span className="text-lime-400">Reno:</span> cwnd→ssthresh, fast recovery</p>
             <p><span className="text-emerald-400">CUBIC:</span> concave growth, less drastic cut</p>
-            <p className="border-t border-[#334155] pt-2 font-bold text-stone-300">On Timeout:</p>
+            <p className="border-t border-[#44403C] pt-2 font-bold text-stone-300">On Timeout:</p>
             <p>All: cwnd→1, ssthresh halved</p>
           </div>
         </div>

--- a/client/src/module/student/learn/computer-networks/module-5/_components/Anim5D.tsx
+++ b/client/src/module/student/learn/computer-networks/module-5/_components/Anim5D.tsx
@@ -21,7 +21,7 @@ function PktGrid({ packets, proto }: { packets: Packet[]; proto: "tcp" | "udp" }
       {Array.from({ length: TOTAL }, (_, i) => {
         const p = packets.find(x => x.id === i)
         const color = !p
-          ? "#1E293B"
+          ? "#292524"
           : p.state === "acked"
             ? "#10B981"
             : p.state === "lost"
@@ -34,7 +34,7 @@ function PktGrid({ packets, proto }: { packets: Packet[]; proto: "tcp" | "udp" }
             key={i}
             animate={{ backgroundColor: color }}
             transition={{ duration: 0.2 }}
-            className="w-7 h-7 rounded flex items-center justify-center border border-[#0F172A]"
+            className="w-7 h-7 rounded flex items-center justify-center border border-[#1C1917]"
             title={p?.state ?? "pending"}
           >
             <span className="text-[8px] text-white/60 font-mono">{i + 1}</span>
@@ -125,7 +125,7 @@ export default function Anim5D() {
   const udpDelivered = udpPkts.filter(p => p.state === "sent").length
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-5 min-h-[400px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-5 min-h-[400px]">
 
       {/* controls */}
       <div className="flex items-center gap-2">
@@ -138,7 +138,7 @@ export default function Anim5D() {
         </button>
         <button
           onClick={reset}
-          className="flex items-center gap-1 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors"
+          className="flex items-center gap-1 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors"
         >
           <RotateCcw size={10} /> Reset
         </button>
@@ -219,16 +219,16 @@ export default function Anim5D() {
       </div>
 
       {/* legend */}
-      <div className="flex flex-wrap gap-3 pt-3 border-t border-[#334155]">
+      <div className="flex flex-wrap gap-3 pt-3 border-t border-[#44403C]">
         {[
           { color: "#10B981", label: "Delivered" },
           { color: "#7C3AED", label: "In-flight (TCP)" },
           { color: "#F59E0B", label: "Retransmitting" },
           { color: "#EF4444", label: "Lost (UDP)" },
-          { color: "#1E293B", label: "Pending" },
+          { color: "#292524", label: "Pending" },
         ].map(({ color, label }) => (
           <div key={label} className="flex items-center gap-1.5">
-            <div className="w-3 h-3 rounded-sm border border-[#334155]" style={{ backgroundColor: color }} />
+            <div className="w-3 h-3 rounded-sm border border-[#44403C]" style={{ backgroundColor: color }} />
             <span className="text-[9px] text-stone-400">{label}</span>
           </div>
         ))}

--- a/client/src/module/student/learn/computer-networks/module-6/_components/Anim6A.tsx
+++ b/client/src/module/student/learn/computer-networks/module-6/_components/Anim6A.tsx
@@ -19,7 +19,7 @@ const PHASES: Phase[] = [
   { id: "req",  label: "HTTP GET Request",  detail: "GET /api/modules HTTP/1.1  |  Host: internhack.xyz  |  Accept: application/json  |  Authorization: Bearer …  Encrypted in TLS record.", color: "#2563EB", duration: 8,   icon: <Server size={10} /> },
   { id: "proc", label: "Server Processing", detail: "Server reads DB, builds JSON response. Network I/O + compute. Typical: 5–50 ms for a cached API response.", color: "#8B5CF6", duration: 18,  icon: <Server size={10} /> },
   { id: "res",  label: "HTTP 200 Response", detail: "HTTP/1.1 200 OK  |  Content-Type: application/json  |  Content-Length: 348  |  Body: {\"modules\":[…]}  Decrypted by TLS layer.", color: "#10B981", duration: 12,  icon: <Server size={10} /> },
-  { id: "keep", label: "Keep-Alive / Close",detail: "Connection: keep-alive header lets the TCP connection persist for the next request. Avoids paying TCP + TLS handshake cost again (~105 ms saved).", color: "#64748B", duration: 4,   icon: <Wifi size={10} /> },
+  { id: "keep", label: "Keep-Alive / Close",detail: "Connection: keep-alive header lets the TCP connection persist for the next request. Avoids paying TCP + TLS handshake cost again (~105 ms saved).", color: "#78716C", duration: 4,   icon: <Wifi size={10} /> },
 ]
 
 const TOTAL_VISIBLE_MS = PHASES.reduce((s, p) => s + p.duration, 0) // 147
@@ -70,7 +70,7 @@ export default function Anim6A() {
   const barTotal = TOTAL_VISIBLE_MS
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-5 min-h-[460px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-5 min-h-[460px]">
 
       {/* controls */}
       <div className="flex items-center gap-2 flex-wrap">
@@ -81,7 +81,7 @@ export default function Anim6A() {
         >
           <Play size={10} /> Trace Request
         </button>
-        <button type="button" onClick={reset} className="flex items-center gap-1 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors">
+        <button type="button" onClick={reset} className="flex items-center gap-1 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors">
           <RotateCcw size={10} /> Reset
         </button>
         <span className="text-[10px] text-stone-500 ml-2">Click any phase to expand details</span>
@@ -90,7 +90,7 @@ export default function Anim6A() {
       {/* browser + server */}
       <div className="flex justify-between items-start px-4">
         <div className="flex flex-col items-center gap-1">
-          <div className="w-14 h-10 rounded-lg bg-[#1E293B] border border-[#334155] flex items-center justify-center">
+          <div className="w-14 h-10 rounded-lg bg-[#292524] border border-[#44403C] flex items-center justify-center">
             <Globe size={16} className="text-blue-400" />
           </div>
           <span className="text-[9px] text-stone-500 font-bold uppercase tracking-wide">Browser</span>
@@ -100,7 +100,7 @@ export default function Anim6A() {
         {/* packet travel lane */}
         <div className="flex-1 mx-4 relative flex items-center h-12">
           <div className="absolute inset-0 flex items-center">
-            <div className="w-full h-px bg-[#1E293B] border-t border-dashed border-[#334155]" />
+            <div className="w-full h-px bg-[#292524] border-t border-dashed border-[#44403C]" />
           </div>
           <AnimatePresence>
             {packets.map(pk => (
@@ -120,7 +120,7 @@ export default function Anim6A() {
         </div>
 
         <div className="flex flex-col items-center gap-1">
-          <div className="w-14 h-10 rounded-lg bg-[#1E293B] border border-[#334155] flex items-center justify-center">
+          <div className="w-14 h-10 rounded-lg bg-[#292524] border border-[#44403C] flex items-center justify-center">
             <Server size={16} className="text-lime-400" />
           </div>
           <span className="text-[9px] text-stone-500 font-bold uppercase tracking-wide">Server</span>
@@ -145,14 +145,14 @@ export default function Anim6A() {
                 className="w-full flex items-center gap-2 px-3 py-2 rounded-lg border transition-all text-left"
                 style={{
                   backgroundColor: revealed ? ph.color + "11" : "transparent",
-                  borderColor: revealed ? ph.color + "44" : "#1E293B",
+                  borderColor: revealed ? ph.color + "44" : "#292524",
                 }}
               >
                 <span style={{ color: ph.color }}>{ph.icon}</span>
-                <span className="text-[10px] font-semibold flex-1" style={{ color: revealed ? ph.color : "#475569" }}>
+                <span className="text-[10px] font-semibold flex-1" style={{ color: revealed ? ph.color : "#57534E" }}>
                   {ph.label}
                 </span>
-                <span className="text-[9px] font-mono" style={{ color: revealed ? ph.color + "aa" : "#1E293B" }}>
+                <span className="text-[9px] font-mono" style={{ color: revealed ? ph.color + "aa" : "#292524" }}>
                   ~{ph.duration} ms
                 </span>
                 {revealed && (
@@ -187,7 +187,7 @@ export default function Anim6A() {
         <motion.div
           initial={{ opacity: 0, y: 4 }}
           animate={{ opacity: 1, y: 0 }}
-          className="flex flex-col gap-1.5 pt-3 border-t border-[#334155]"
+          className="flex flex-col gap-1.5 pt-3 border-t border-[#44403C]"
         >
           <span className="text-[9px] text-stone-500 uppercase tracking-wider font-bold">DevTools Waterfall</span>
           <div className="flex h-5 rounded overflow-hidden">

--- a/client/src/module/student/learn/computer-networks/module-6/_components/Anim6B.tsx
+++ b/client/src/module/student/learn/computer-networks/module-6/_components/Anim6B.tsx
@@ -89,15 +89,15 @@ export default function Anim6B() {
   }
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-4 min-h-[420px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-4 min-h-[420px]">
 
       {/* controls */}
       <div className="flex items-center gap-2 flex-wrap">
-        <div className="flex rounded-lg overflow-hidden border border-[#334155]">
+        <div className="flex rounded-lg overflow-hidden border border-[#44403C]">
           {(["first", "cached"] as const).map(m => (
             <button type="button" key={m} onClick={() => switchMode(m)}
               className="px-3 py-1.5 text-xs font-semibold transition-colors"
-              style={{ backgroundColor: mode === m ? "#7C3AED" : "transparent", color: mode === m ? "#fff" : "#64748B" }}
+              style={{ backgroundColor: mode === m ? "#7C3AED" : "transparent", color: mode === m ? "#fff" : "#78716C" }}
             >
               {m === "first" ? "First Lookup" : "Cache Hit"}
             </button>
@@ -108,7 +108,7 @@ export default function Anim6B() {
         >
           <Play size={10} /> Resolve
         </button>
-        <button type="button" onClick={reset} className="flex items-center gap-1 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors">
+        <button type="button" onClick={reset} className="flex items-center gap-1 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors">
           <RotateCcw size={10} />
         </button>
         <div className="ml-auto flex items-center gap-2">
@@ -158,7 +158,7 @@ export default function Anim6B() {
                   {a.label}
                 </text>
                 {/* hop number */}
-                <text x={mx - 12} y={my + 10} textAnchor="middle" fill="#475569" fontSize="7">
+                <text x={mx - 12} y={my + 10} textAnchor="middle" fill="#57534E" fontSize="7">
                   {i + 1}
                 </text>
               </g>
@@ -174,17 +174,17 @@ export default function Anim6B() {
               <g key={n.id}>
                 <motion.circle
                   cx={cx} cy={cy} r={18}
-                  fill={isActive ? n.color + "22" : "#1E293B"}
+                  fill={isActive ? n.color + "22" : "#292524"}
                   stroke={n.color}
                   strokeWidth={isActive ? "2" : "1"}
                   strokeOpacity={isActive ? 1 : 0.4}
                   animate={{ r: isActive ? 20 : 18 }}
                   transition={{ duration: 0.2 }}
                 />
-                <text x={cx} y={cy + 3} textAnchor="middle" fill={isActive ? n.color : "#475569"} fontSize="8" fontWeight="bold">
+                <text x={cx} y={cy + 3} textAnchor="middle" fill={isActive ? n.color : "#57534E"} fontSize="8" fontWeight="bold">
                   {n.id === "resolver" ? "Resolver" : n.id === "browser" ? "You" : n.id.toUpperCase()}
                 </text>
-                <text x={cx} y={cy + 28} textAnchor="middle" fill="#475569" fontSize="7">{n.label}</text>
+                <text x={cx} y={cy + 28} textAnchor="middle" fill="#57534E" fontSize="7">{n.label}</text>
                 <text x={cx} y={cy + 37} textAnchor="middle" fill={n.color + "88"} fontSize="6">{n.sublabel}</text>
               </g>
             )

--- a/client/src/module/student/learn/computer-networks/module-6/_components/Anim6C.tsx
+++ b/client/src/module/student/learn/computer-networks/module-6/_components/Anim6C.tsx
@@ -15,7 +15,7 @@ const PHASE_LABELS: Record<Phase, string> = {
 }
 
 const PHASE_COLORS: Record<Phase, string> = {
-  idle:     "#475569",
+  idle:     "#57534E",
   discover: "#F59E0B",
   offer:    "#7C3AED",
   request:  "#F59E0B",
@@ -84,7 +84,7 @@ export default function Anim6C() {
   const assigned = phase === "done"
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-5 min-h-[420px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-5 min-h-[420px]">
 
       {/* controls */}
       <div className="flex items-center gap-2">
@@ -96,7 +96,7 @@ export default function Anim6C() {
         >
           <Play size={10} /> Start DORA
         </button>
-        <button type="button" onClick={reset} className="flex items-center gap-1 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors">
+        <button type="button" onClick={reset} className="flex items-center gap-1 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors">
           <RotateCcw size={10} /> Reset
         </button>
       </div>
@@ -114,13 +114,13 @@ export default function Anim6C() {
                 className="w-5 h-5 rounded-full flex items-center justify-center text-[8px] font-bold border transition-all"
                 style={{
                   backgroundColor: (done || active) ? PHASE_COLORS[p] + "33" : "transparent",
-                  borderColor: (done || active) ? PHASE_COLORS[p] : "#334155",
-                  color: (done || active) ? PHASE_COLORS[p] : "#475569",
+                  borderColor: (done || active) ? PHASE_COLORS[p] : "#44403C",
+                  color: (done || active) ? PHASE_COLORS[p] : "#57534E",
                 }}
               >
                 {i + 1}
               </div>
-              {i < 3 && <div className="w-6 h-px" style={{ backgroundColor: done ? "#334155" : "#1E293B" }} />}
+              {i < 3 && <div className="w-6 h-px" style={{ backgroundColor: done ? "#44403C" : "#292524" }} />}
             </div>
           )
         })}
@@ -132,30 +132,30 @@ export default function Anim6C() {
         <svg viewBox="0 0 500 200" className="w-full" style={{ minHeight: 160 }}>
 
           {/* LAN bus */}
-          <line x1={50} y1={120} x2={450} y2={120} stroke="#1E293B" strokeWidth="3" />
+          <line x1={50} y1={120} x2={450} y2={120} stroke="#292524" strokeWidth="3" />
 
           {/* DHCP Server */}
-          <rect x={380} y={80} width={60} height={40} rx={6} fill="#1E293B" stroke="#7C3AED" strokeWidth="1.5" />
+          <rect x={380} y={80} width={60} height={40} rx={6} fill="#292524" stroke="#7C3AED" strokeWidth="1.5" />
           <text x={410} y={96} textAnchor="middle" fill="#7C3AED" fontSize="7" fontWeight="bold">DHCP</text>
           <text x={410} y={107} textAnchor="middle" fill="#7C3AED" fontSize="7">Server</text>
-          <text x={410} y={118} textAnchor="middle" fill="#475569" fontSize="6">.1</text>
+          <text x={410} y={118} textAnchor="middle" fill="#57534E" fontSize="6">.1</text>
           <line x1={410} y1={120} x2={410} y2={120} stroke="#7C3AED" strokeWidth="2" />
 
           {/* Assigned host 1 */}
-          <rect x={160} y={80} width={56} height={40} rx={6} fill="#1E293B" stroke="#10B981" strokeWidth="1.5" />
+          <rect x={160} y={80} width={56} height={40} rx={6} fill="#292524" stroke="#10B981" strokeWidth="1.5" />
           <text x={188} y={96} textAnchor="middle" fill="#10B981" fontSize="7" fontWeight="bold">Host A</text>
-          <text x={188} y={107} textAnchor="middle" fill="#475569" fontSize="6">.10</text>
-          <line x1={188} y1={120} x2={188} y2={120} stroke="#334155" strokeWidth="1.5" />
+          <text x={188} y={107} textAnchor="middle" fill="#57534E" fontSize="6">.10</text>
+          <line x1={188} y1={120} x2={188} y2={120} stroke="#44403C" strokeWidth="1.5" />
 
           {/* Assigned host 2 */}
-          <rect x={260} y={80} width={56} height={40} rx={6} fill="#1E293B" stroke="#10B981" strokeWidth="1.5" />
+          <rect x={260} y={80} width={56} height={40} rx={6} fill="#292524" stroke="#10B981" strokeWidth="1.5" />
           <text x={288} y={96} textAnchor="middle" fill="#10B981" fontSize="7" fontWeight="bold">Host B</text>
-          <text x={288} y={107} textAnchor="middle" fill="#475569" fontSize="6">.20</text>
+          <text x={288} y={107} textAnchor="middle" fill="#57534E" fontSize="6">.20</text>
 
           {/* New device */}
           <motion.rect
             x={60} y={80} width={60} height={40} rx={6}
-            fill="#1E293B"
+            fill="#292524"
             stroke={assigned ? "#10B981" : color}
             strokeWidth={assigned ? 2 : 1.5}
             strokeDasharray={assigned ? "0" : "4 2"}
@@ -163,10 +163,10 @@ export default function Anim6C() {
             transition={{ duration: 0.3 }}
           />
           <text x={90} y={94} textAnchor="middle" fill={color} fontSize="7" fontWeight="bold">New</text>
-          <text x={90} y={105} textAnchor="middle" fill={assigned ? "#10B981" : "#475569"} fontSize="6">
+          <text x={90} y={105} textAnchor="middle" fill={assigned ? "#10B981" : "#57534E"} fontSize="6">
             {assigned ? ".50" : "No IP"}
           </text>
-          <text x={90} y={116} textAnchor="middle" fill={assigned ? "#10B981" : "#334155"} fontSize="5">
+          <text x={90} y={116} textAnchor="middle" fill={assigned ? "#10B981" : "#44403C"} fontSize="5">
             {assigned ? "192.168.1.50" : "0.0.0.0"}
           </text>
 
@@ -228,7 +228,7 @@ export default function Anim6C() {
           </AnimatePresence>
 
           {/* labels below LAN */}
-          <text x={410} y={135} textAnchor="middle" fill="#475569" fontSize="6">:68 server</text>
+          <text x={410} y={135} textAnchor="middle" fill="#57534E" fontSize="6">:68 server</text>
         </svg>
       </div>
 
@@ -253,7 +253,7 @@ export default function Anim6C() {
             <span>Lease clock (24 h)</span>
             <span className="font-mono text-emerald-300">T1: renew at 12h · T2: expire at ~21h</span>
           </div>
-          <div className="w-full h-3 bg-[#1E293B] rounded-full overflow-hidden">
+          <div className="w-full h-3 bg-[#292524] rounded-full overflow-hidden">
             <motion.div
               className="h-full rounded-full"
               style={{

--- a/client/src/module/student/learn/computer-networks/module-6/_components/Anim6D.tsx
+++ b/client/src/module/student/learn/computer-networks/module-6/_components/Anim6D.tsx
@@ -25,7 +25,7 @@ export default function Anim6D() {
   const neededPostFields = ["title"]
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-5 min-h-[460px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-5 min-h-[460px]">
 
       {/* sliders */}
       <div className="grid grid-cols-2 gap-4">
@@ -50,7 +50,7 @@ export default function Anim6D() {
           </div>
 
           {/* Request 1 */}
-          <div className="bg-[#1E293B] rounded-xl border border-blue-800/40 p-3 text-[9px] font-mono">
+          <div className="bg-[#292524] rounded-xl border border-blue-800/40 p-3 text-[9px] font-mono">
             <div className="text-blue-400 mb-1">GET /users/42</div>
             <div className="text-stone-500 mb-2">→ returns all {ALL_USER_FIELDS.length} fields:</div>
             <div className="flex flex-wrap gap-1">
@@ -58,9 +58,9 @@ export default function Anim6D() {
                 <span key={f}
                   className="px-1 py-0.5 rounded text-[7px]"
                   style={{
-                    backgroundColor: neededUserFields.includes(f) ? "#1E40AF33" : "#1E293B",
-                    color: neededUserFields.includes(f) ? "#93C5FD" : "#334155",
-                    border: neededUserFields.includes(f) ? "1px solid #1E40AF55" : "1px solid #1E293B",
+                    backgroundColor: neededUserFields.includes(f) ? "#1E40AF33" : "#292524",
+                    color: neededUserFields.includes(f) ? "#93C5FD" : "#44403C",
+                    border: neededUserFields.includes(f) ? "1px solid #1E40AF55" : "1px solid #292524",
                   }}
                 >
                   {f}
@@ -73,7 +73,7 @@ export default function Anim6D() {
           </div>
 
           {/* Request 2 */}
-          <div className="bg-[#1E293B] rounded-xl border border-blue-800/40 p-3 text-[9px] font-mono">
+          <div className="bg-[#292524] rounded-xl border border-blue-800/40 p-3 text-[9px] font-mono">
             <div className="text-blue-400 mb-1">GET /users/42/posts</div>
             <div className="text-stone-500 mb-2">→ returns {numPosts} posts × {ALL_POST_FIELDS.length} fields:</div>
             <div className="flex flex-wrap gap-1">
@@ -81,9 +81,9 @@ export default function Anim6D() {
                 <span key={f}
                   className="px-1 py-0.5 rounded text-[7px]"
                   style={{
-                    backgroundColor: neededPostFields.includes(f) ? "#1E40AF33" : "#1E293B",
-                    color: neededPostFields.includes(f) ? "#93C5FD" : "#334155",
-                    border: neededPostFields.includes(f) ? "1px solid #1E40AF55" : "1px solid #1E293B",
+                    backgroundColor: neededPostFields.includes(f) ? "#1E40AF33" : "#292524",
+                    color: neededPostFields.includes(f) ? "#93C5FD" : "#44403C",
+                    border: neededPostFields.includes(f) ? "1px solid #1E40AF55" : "1px solid #292524",
                   }}
                 >
                   {f}
@@ -112,7 +112,7 @@ export default function Anim6D() {
           </div>
 
           {/* Single query */}
-          <div className="bg-[#1E293B] rounded-xl border border-lime-800/40 p-3 text-[9px] font-mono flex-1">
+          <div className="bg-[#292524] rounded-xl border border-lime-800/40 p-3 text-[9px] font-mono flex-1">
             <div className="text-lime-400 mb-1">POST /graphql</div>
             <pre className="text-stone-300 text-[8px] leading-relaxed whitespace-pre-wrap">{`query {
   user(id: 42) {
@@ -122,7 +122,7 @@ ${neededUserFields.map(f => `    ${f}`).join("\n")}
     }
   }
 }`}</pre>
-            <div className="mt-2 border-t border-[#334155] pt-2 text-stone-500">
+            <div className="mt-2 border-t border-[#44403C] pt-2 text-stone-500">
               Response: exactly <span className="text-lime-300">{numFields + numPosts}</span> fields
             </div>
           </div>
@@ -138,9 +138,9 @@ ${neededUserFields.map(f => `    ${f}`).join("\n")}
       </div>
 
       {/* savings */}
-      <div className="flex items-center gap-3 pt-2 border-t border-[#334155]">
+      <div className="flex items-center gap-3 pt-2 border-t border-[#44403C]">
         <span className="text-[10px] text-stone-500">GraphQL savings:</span>
-        <div className="flex-1 h-3 bg-[#1E293B] rounded-full overflow-hidden">
+        <div className="flex-1 h-3 bg-[#292524] rounded-full overflow-hidden">
           <motion.div
             className="h-full bg-emerald-500 rounded-full"
             animate={{ width: `${Math.max(0, savings)}%` }}

--- a/client/src/module/student/learn/computer-networks/module-6/_components/Anim6E.tsx
+++ b/client/src/module/student/learn/computer-networks/module-6/_components/Anim6E.tsx
@@ -84,7 +84,7 @@ export default function Anim6E() {
   const wsVisible   = wsMessages.slice(-8)
 
   return (
-    <div className="bg-[#0F172A] p-5 flex flex-col gap-4 min-h-[440px]">
+    <div className="bg-[#1C1917] p-5 flex flex-col gap-4 min-h-[440px]">
 
       {/* controls */}
       <div className="flex items-center gap-2 flex-wrap">
@@ -93,14 +93,14 @@ export default function Anim6E() {
         >
           <Play size={10} /> Simulate 30 s
         </button>
-        <button type="button" onClick={reset} className="flex items-center gap-1 px-3 py-1.5 bg-[#1E293B] hover:bg-[#334155] text-stone-400 rounded-lg text-xs border border-[#334155] transition-colors">
+        <button type="button" onClick={reset} className="flex items-center gap-1 px-3 py-1.5 bg-[#292524] hover:bg-[#44403C] text-stone-400 rounded-lg text-xs border border-[#44403C] transition-colors">
           <RotateCcw size={10} /> Reset
         </button>
         <span className="text-[10px] text-stone-500 ml-2">
           {running ? `t = ${elapsed} s / ${SIM_SECONDS} s` : done ? "Simulation complete" : "Ready"}
         </span>
         {(running || done) && (
-          <div className="ml-auto flex items-center gap-2 px-3 py-1 bg-[#1E293B] rounded-lg">
+          <div className="ml-auto flex items-center gap-2 px-3 py-1 bg-[#292524] rounded-lg">
             <span className="text-[9px] text-stone-400">Live counter:</span>
             <motion.span
               key={counter}
@@ -123,7 +123,7 @@ export default function Anim6E() {
             <span className="text-xs font-bold text-blue-300 font-display">HTTP Polling</span>
             <span className="text-[9px] text-stone-500">every {POLL_INTERVAL}s</span>
           </div>
-          <div className="flex-1 bg-[#0A0F1A] rounded-xl border border-[#1E293B] p-2 flex flex-col gap-0.5 overflow-hidden min-h-[160px]">
+          <div className="flex-1 bg-[#0C0A09] rounded-xl border border-[#292524] p-2 flex flex-col gap-0.5 overflow-hidden min-h-[160px]">
             <AnimatePresence initial={false}>
               {pollVisible.map(m => (
                 <motion.div
@@ -134,14 +134,14 @@ export default function Anim6E() {
                   className="flex items-center gap-1.5 py-0.5 px-1.5 rounded"
                   style={{
                     backgroundColor:
-                      m.type === "poll-req"   ? "#1E3A5F22" :
-                      m.type === "poll-empty" ? "#1E293B"    :
+                      m.type === "poll-req"   ? "#44403C22" :
+                      m.type === "poll-empty" ? "#292524"    :
                       "#1C3A2522",
                   }}
                 >
                   <span className="text-[7px] font-mono"
                     style={{
-                      color: m.type === "poll-req" ? "#60A5FA" : m.type === "poll-empty" ? "#475569" : "#34D399"
+                      color: m.type === "poll-req" ? "#60A5FA" : m.type === "poll-empty" ? "#57534E" : "#34D399"
                     }}>
                     {m.type === "poll-req"   ? "→ GET /updates" :
                      m.type === "poll-empty" ? "← 204 (nothing new)" :
@@ -164,7 +164,7 @@ export default function Anim6E() {
             <span className="text-xs font-bold text-lime-300 font-display">WebSocket</span>
             <span className="text-[9px] text-stone-500">push only</span>
           </div>
-          <div className="flex-1 bg-[#0A0F1A] rounded-xl border border-[#1E293B] p-2 flex flex-col gap-0.5 overflow-hidden min-h-[160px]">
+          <div className="flex-1 bg-[#0C0A09] rounded-xl border border-[#292524] p-2 flex flex-col gap-0.5 overflow-hidden min-h-[160px]">
             <AnimatePresence initial={false}>
               {wsVisible.map(m => (
                 <motion.div
@@ -198,7 +198,7 @@ export default function Anim6E() {
         <motion.div
           initial={{ opacity: 0, y: 4 }}
           animate={{ opacity: 1, y: 0 }}
-          className="flex flex-col gap-2 pt-3 border-t border-[#334155]"
+          className="flex flex-col gap-2 pt-3 border-t border-[#44403C]"
         >
           <div className="flex justify-between text-[9px] text-stone-400">
             <span>WebSocket used <span className="text-emerald-300 font-bold font-mono">{Math.round((1 - wsBytes / pollBytes) * 100)}% less data</span> than HTTP polling</span>

--- a/client/src/module/student/learn/dsa-foundations/lessons/L1_Arrays.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L1_Arrays.tsx
@@ -49,7 +49,7 @@ const CELL_COLORS: Record<CellState, { bg: string; border: string; text: string 
   compare:  { bg: "#fef9c3",        border: "#eab308",      text: "#713f12" },
   swap:     { bg: "#fce7f3",        border: "#ec4899",      text: "#831843" },
   done:     { bg: "#d1fae5",        border: "#10b981",      text: "#064e3b" },
-  visited:  { bg: "#f1f5f9",        border: "#94a3b8",      text: "#475569" },
+  visited:  { bg: "#f5f5f4",        border: "#a8a29e",      text: "#57534E" },
   match:    { bg: "#dcfce7",        border: "#22c55e",      text: "#14532d" },
   mismatch: { bg: "#fee2e2",        border: "#ef4444",      text: "#7f1d1d" },
   window:   { bg: "#ede9fe",        border: "#8b5cf6",      text: "#3b0764" },

--- a/client/src/module/student/learn/dsa-foundations/lessons/L1_Strings.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L1_Strings.tsx
@@ -50,7 +50,7 @@ const CELL_COLORS: Record<CellState, { bg: string; border: string; text: string 
   compare:  { bg: "#fef9c3",    border: "#eab308",      text: "#713f12" },
   swap:     { bg: "#fce7f3",    border: "#ec4899",      text: "#831843" },
   done:     { bg: "#d1fae5",    border: "#10b981",      text: "#064e3b" },
-  visited:  { bg: "#f1f5f9",    border: "#94a3b8",      text: "#475569" },
+  visited:  { bg: "#f5f5f4",    border: "#a8a29e",      text: "#57534E" },
   match:    { bg: "#dcfce7",    border: "#22c55e",      text: "#14532d" },
   mismatch: { bg: "#fee2e2",    border: "#ef4444",      text: "#7f1d1d" },
   window:   { bg: "#ede9fe",    border: "#8b5cf6",      text: "#3b0764" },

--- a/client/src/module/student/learn/dsa-foundations/lessons/L1_TwoPointerWindow.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L1_TwoPointerWindow.tsx
@@ -48,7 +48,7 @@ const BAR_COLORS: Record<CellState, { fill: string; text: string }> = {
   compare:  { fill: "#eab308",      text: "#ffffff" },
   swap:     { fill: "#ec4899",      text: "#ffffff" },
   done:     { fill: "#10b981",      text: "#ffffff" },
-  visited:  { fill: "#94a3b8",      text: "#ffffff" },
+  visited:  { fill: "#a8a29e",      text: "#ffffff" },
   match:    { fill: "#22c55e",      text: "#ffffff" },
   mismatch: { fill: "#ef4444",      text: "#ffffff" },
   window:   { fill: "#8b5cf6",      text: "#ffffff" },

--- a/client/src/module/student/learn/dsa-foundations/lessons/L2_Stacks.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L2_Stacks.tsx
@@ -201,7 +201,7 @@ function VisualizeTab() {
           {str.split("").map((ch, i) => {
             const isCur = i === (frame?.cursor ?? -1);
             const past = i < (frame?.cursor ?? -1);
-            const c = BR_COLOR[ch] ?? "#64748b";
+            const c = BR_COLOR[ch] ?? "#78716c";
             return (
               <div
                 key={i}

--- a/client/src/module/student/learn/dsa-foundations/lessons/L3_BPlusTree.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L3_BPlusTree.tsx
@@ -375,7 +375,7 @@ function BPTreeViz({ frame }: { frame: BPFrame }) {
     <svg viewBox={`0 0 ${W} ${height}`} style={{ width: "100%", height: "auto", maxHeight: height }}>
       <defs>
         <marker id="bp-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-          <path d="M0,0 L10,5 L0,10 z" fill="#94a3b8" />
+          <path d="M0,0 L10,5 L0,10 z" fill="#a8a29e" />
         </marker>
         <marker id="bp-leaf" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
           <path d="M0,0 L10,5 L0,10 z" fill="#8b5cf6" />
@@ -396,7 +396,7 @@ function BPTreeViz({ frame }: { frame: BPFrame }) {
               key={`${id}-${cid}`}
               x1={ax} y1={a.y + a.h}
               x2={b.x + b.w / 2} y2={b.y}
-              stroke="#94a3b8" strokeWidth={1.5}
+              stroke="#a8a29e" strokeWidth={1.5}
               markerEnd="url(#bp-arrow)"
             />
           );

--- a/client/src/module/student/learn/dsa-foundations/lessons/L3_RedBlack.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L3_RedBlack.tsx
@@ -286,7 +286,7 @@ function RBTreeViz({ frame }: { frame: RBFrame }) {
               cx={X}
               cy={Y}
               r={17}
-              fill={node.color === "R" ? "#dc2626" : "#1F2937"}
+              fill={node.color === "R" ? "#dc2626" : "#292524"}
               stroke={isActive ? THEME.accent : "#FFFFFF"}
               strokeWidth={isActive ? 4 : 2.5}
               style={{ transition: "fill 0.3s, stroke 0.2s" }}
@@ -390,7 +390,7 @@ function VisualizeTab() {
           RED
         </span>
         <span className="inline-flex items-center gap-1.5">
-          <span className="w-3 h-3 rounded-sm bg-[#1F2937] inline-block" />
+          <span className="w-3 h-3 rounded-sm bg-[#292524] inline-block" />
           BLACK
         </span>
         <span className="inline-flex items-center gap-1.5">

--- a/client/src/module/student/learn/dsa-foundations/lessons/L4_BFS.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L4_BFS.tsx
@@ -164,7 +164,7 @@ const NODE_STATE_COLOR: Record<NodeState, string> = {
   default: THEME.textMuted,
   frontier: "#06b6d4",
   active: "#3b82f6",
-  done: "#64748b",
+  done: "#78716c",
 };
 
 function GraphSVG({
@@ -312,7 +312,7 @@ function VisualizeTab() {
         {frame && <GraphSVG ids={ids} edges={edges} pos={pos} frame={frame} />}
         {frame && <QueueViz items={frame.queue} />}
         <div className="flex gap-2 flex-wrap text-xs text-stone-500">
-          {[["#3b82f6", "active"], ["#06b6d4", "frontier (in queue)"], ["#64748b", "visited (done)"], ["#fbbf24", "BFS tree edge"]].map(([c, l]) => (
+          {[["#3b82f6", "active"], ["#06b6d4", "frontier (in queue)"], ["#78716c", "visited (done)"], ["#fbbf24", "BFS tree edge"]].map(([c, l]) => (
             <span key={l} className="inline-flex items-center gap-1">
               <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ background: c }} />
               {l}

--- a/client/src/module/student/learn/dsa-foundations/lessons/L5_BinarySearch.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L5_BinarySearch.tsx
@@ -43,7 +43,7 @@ const STATE_COLORS: Record<CellState, string> = {
   compare: "#06b6d4",
   swap: "#f59e0b",
   sorted: "#a3e635",
-  active: "#818cf8",
+  active: "#a3e635",
   pivot: "#f97316",
   visited: "#d6d3d1",
   done: "#a3e635",

--- a/client/src/module/student/learn/dsa-foundations/lessons/L5_BubbleSelection.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L5_BubbleSelection.tsx
@@ -41,7 +41,7 @@ const STATE_COLORS: Record<CellState, string> = {
   compare: "#06b6d4",
   swap: "#f59e0b",
   sorted: "#a3e635",
-  active: "#818cf8",
+  active: "#a3e635",
   pivot: "#f97316",
   visited: "#d6d3d1",
   done: "#a3e635",

--- a/client/src/module/student/learn/dsa-foundations/lessons/L5_Insertion.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L5_Insertion.tsx
@@ -40,7 +40,7 @@ const STATE_COLORS: Record<CellState, string> = {
   compare: "#06b6d4",
   swap: "#f59e0b",
   sorted: "#a3e635",
-  active: "#818cf8",
+  active: "#a3e635",
   pivot: "#f97316",
   visited: "#d6d3d1",
   done: "#a3e635",

--- a/client/src/module/student/learn/dsa-foundations/lessons/L5_Merge.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L5_Merge.tsx
@@ -41,7 +41,7 @@ const STATE_COLORS: Record<CellState, string> = {
   compare: "#06b6d4",
   swap: "#f59e0b",
   sorted: "#a3e635",
-  active: "#818cf8",
+  active: "#a3e635",
   pivot: "#f97316",
   visited: "#d6d3d1",
   done: "#a3e635",

--- a/client/src/module/student/learn/dsa-foundations/lessons/L5_NonComparison.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L5_NonComparison.tsx
@@ -41,7 +41,7 @@ const STATE_COLORS: Record<CellState, string> = {
   compare: "#06b6d4",
   swap: "#f59e0b",
   sorted: "#a3e635",
-  active: "#818cf8",
+  active: "#a3e635",
   pivot: "#f97316",
   visited: "#d6d3d1",
   done: "#a3e635",

--- a/client/src/module/student/learn/dsa-foundations/lessons/L5_Quick.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L5_Quick.tsx
@@ -42,7 +42,7 @@ const STATE_COLORS: Record<CellState, string> = {
   compare: "#06b6d4",
   swap: "#f59e0b",
   sorted: "#a3e635",
-  active: "#818cf8",
+  active: "#a3e635",
   pivot: "#f97316",
   visited: "#d6d3d1",
   done: "#a3e635",

--- a/client/src/module/student/learn/dsa-foundations/lessons/L6_Backtracking.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L6_Backtracking.tsx
@@ -209,7 +209,7 @@ function QueensBoard({ frame, n }: { frame: QueensFrame; n: number }) {
             const queen = frame.board[r] === c;
             const isTrying = r === frame.row && c === frame.tryingCol;
             const isConflict = frame.conflict && frame.conflict.r === r && frame.conflict.c === c;
-            let bg = isLight ? "#f1f5f9" : "#cbd5e1";
+            let bg = isLight ? "#f5f5f4" : "#d6d3d1";
             if (isConflict) bg = "#fca5a5";
             if (isTrying && !queen) bg = "#fde68a";
             return (
@@ -330,22 +330,22 @@ function SudokuBoard({ frame, initial }: { frame: SudokuFrame; initial: number[]
     <div className="flex flex-col items-center gap-2">
       <div
         className="border-2 rounded overflow-hidden"
-        style={{ display: "grid", gridTemplateColumns: "repeat(9, 32px)", gridTemplateRows: "repeat(9, 32px)", borderColor: "#0f172a" }}
+        style={{ display: "grid", gridTemplateColumns: "repeat(9, 32px)", gridTemplateRows: "repeat(9, 32px)", borderColor: "#1c1917" }}
       >
         {frame.grid.map((row, r) => row.map((v, c) => {
           const isGiven = initial[r][c] !== 0;
           const isActive = frame.cell?.r === r && frame.cell?.c === c;
           const isConflict = isActive && frame.conflict;
           const shownVal = isActive && frame.tryingVal && !isGiven && v === 0 ? frame.tryingVal : v;
-          const borderRight = (c + 1) % 3 === 0 && c < 8 ? "2px solid #0f172a" : "1px solid #cbd5e1";
-          const borderBottom = (r + 1) % 3 === 0 && r < 8 ? "2px solid #0f172a" : "1px solid #cbd5e1";
+          const borderRight = (c + 1) % 3 === 0 && c < 8 ? "2px solid #1c1917" : "1px solid #d6d3d1";
+          const borderBottom = (r + 1) % 3 === 0 && r < 8 ? "2px solid #1c1917" : "1px solid #d6d3d1";
           return (
             <div key={`${r}-${c}`}
               className="flex items-center justify-center font-bold font-mono transition-colors"
               style={{
                 width: 32, height: 32, fontSize: "0.85rem",
-                color: isGiven ? "#0f172a" : isConflict ? "#991b1b" : "#1d4ed8",
-                background: isConflict ? "#fecaca" : isActive ? "#fde68a" : isGiven ? "#f1f5f9" : "#fff",
+                color: isGiven ? "#1c1917" : isConflict ? "#991b1b" : "#1d4ed8",
+                background: isConflict ? "#fecaca" : isActive ? "#fde68a" : isGiven ? "#f5f5f4" : "#fff",
                 borderRight, borderBottom,
               }}>
               {shownVal > 0 ? shownVal : ""}

--- a/client/src/module/student/learn/dsa-foundations/lessons/L6_DivideConquer.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L6_DivideConquer.tsx
@@ -198,7 +198,7 @@ function ClosestPairPlot({ points, frame }: { points: Point[]; frame: CPFrame })
         return (
           <g key={p.id}>
             <circle cx={sx(p.x)} cy={sy(p.y)} r={isBest ? 7 : 5}
-              fill={isBest ? "#ef4444" : inStrip ? "#8b5cf6" : "#0f172a"}
+              fill={isBest ? "#ef4444" : inStrip ? "#8b5cf6" : "#1c1917"}
               stroke="#fff" strokeWidth={2} style={{ transition: "all 0.3s" }} />
             <text x={sx(p.x) + 8} y={sy(p.y) - 8} fontSize="10" fill={THEME.textMuted} fontFamily={THEME.heading}>{p.id}</text>
           </g>

--- a/client/src/module/student/learn/dsa-foundations/lessons/L6_Greedy.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L6_Greedy.tsx
@@ -88,19 +88,19 @@ function ActivityTimeline({ frame }: { frame: ASFrame }) {
   const sx = (t: number) => PAD + (t / maxT) * (W - 2 * PAD);
   return (
     <svg viewBox={`0 0 ${W} ${rowH * frame.activities.length + 50}`} className="w-full h-auto rounded-md border border-stone-200 dark:border-white/10 bg-stone-50 dark:bg-stone-950">
-      <line x1={PAD} y1={20} x2={W - PAD} y2={20} stroke="#94a3b8" strokeWidth={1.5} />
+      <line x1={PAD} y1={20} x2={W - PAD} y2={20} stroke="#a8a29e" strokeWidth={1.5} />
       {Array.from({ length: Math.floor(maxT / 2) + 1 }).map((_, i) => {
         const t = i * 2;
         return (
           <g key={t}>
-            <line x1={sx(t)} y1={18} x2={sx(t)} y2={22} stroke="#94a3b8" />
-            <text x={sx(t)} y={14} fontSize="9" textAnchor="middle" fill="#64748b" fontFamily={THEME.heading}>{t}</text>
+            <line x1={sx(t)} y1={18} x2={sx(t)} y2={22} stroke="#a8a29e" />
+            <text x={sx(t)} y={14} fontSize="9" textAnchor="middle" fill="#78716c" fontFamily={THEME.heading}>{t}</text>
           </g>
         );
       })}
       {frame.activities.map((a, i) => {
         const st = frame.state[i];
-        const color = st === "picked" ? "#10b981" : st === "skipped" ? "#ef4444" : st === "checking" ? "#f59e0b" : "#cbd5e1";
+        const color = st === "picked" ? "#10b981" : st === "skipped" ? "#ef4444" : st === "checking" ? "#f59e0b" : "#d6d3d1";
         return (
           <g key={a.id}>
             <rect x={sx(a.start)} y={30 + i * rowH} width={Math.max(2, sx(a.end) - sx(a.start))} height={rowH - 8}

--- a/client/src/module/student/learn/dsa-foundations/lessons/L7_AdvancedDS.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L7_AdvancedDS.tsx
@@ -356,7 +356,7 @@ function RBTreeViz({ frame }: { frame: RBFrame }) {
         const X = 30 + x[id] * xScale, Y = 30 + y[id] * yScale;
         const children = [node.left, node.right].filter(Boolean) as string[];
         return children.map((cid) => (
-          <line key={`${id}-${cid}`} x1={X} y1={Y} x2={30 + x[cid] * xScale} y2={30 + y[cid] * yScale} stroke="#94a3b8" strokeWidth={1.8} />
+          <line key={`${id}-${cid}`} x1={X} y1={Y} x2={30 + x[cid] * xScale} y2={30 + y[cid] * yScale} stroke="#a8a29e" strokeWidth={1.8} />
         ));
       })}
       {ids.map((id) => {
@@ -365,7 +365,7 @@ function RBTreeViz({ frame }: { frame: RBFrame }) {
         const isActive = id === frame.activeId;
         return (
           <g key={id}>
-            <circle cx={X} cy={Y} r={16} fill={node.color === "R" ? "#ef4444" : "#1f2937"} stroke={isActive ? THEME.accent : "#fff"} strokeWidth={isActive ? 4 : 2.5} style={{ transition: "fill 0.3s, stroke 0.2s" }} />
+            <circle cx={X} cy={Y} r={16} fill={node.color === "R" ? "#ef4444" : "#292524"} stroke={isActive ? THEME.accent : "#fff"} strokeWidth={isActive ? 4 : 2.5} style={{ transition: "fill 0.3s, stroke 0.2s" }} />
             <text x={X} y={Y + 4} textAnchor="middle" fontSize={13} fontWeight={700} fill="#fff" fontFamily="ui-monospace, monospace">{node.key}</text>
           </g>
         );
@@ -401,7 +401,7 @@ function RBTreeVisualizer() {
       <div className="flex flex-col gap-3.5">
         <div className="flex gap-3.5 text-xs items-center">
           <span className="flex items-center gap-1.5"><span className="inline-block w-3 h-3 rounded-sm bg-red-500" />RED</span>
-          <span className="flex items-center gap-1.5"><span className="inline-block w-3 h-3 rounded-sm bg-gray-900" />BLACK</span>
+          <span className="flex items-center gap-1.5"><span className="inline-block w-3 h-3 rounded-sm bg-stone-900" />BLACK</span>
         </div>
         {frame && <RBTreeViz frame={frame} />}
         <Callout>{frame?.message ?? "Press play to step through."}</Callout>
@@ -692,7 +692,7 @@ function BloomViz({ frame }: { frame: BloomFrame }) {
               className="flex flex-col items-center justify-center font-mono font-extrabold rounded transition-all"
               style={{
                 width: cell, height: cell,
-                background: b ? (hl ? THEME.accent : "#64748b") : (hl ? "rgba(245,158,11,0.2)" : THEME.bg),
+                background: b ? (hl ? THEME.accent : "#78716c") : (hl ? "rgba(245,158,11,0.2)" : THEME.bg),
                 color: b ? "#fff" : THEME.textMuted,
                 border: hl ? "2px solid #f59e0b" : `1px solid ${THEME.border}`,
                 fontSize: "0.9rem",

--- a/client/src/module/student/learn/dsa-foundations/lessons/L7_DSU.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L7_DSU.tsx
@@ -255,7 +255,7 @@ function Forest({ frame }: { frame: Frame }) {
                       key={`e-${node.id}`}
                       x1={px(p2.x)} y1={py(p2.y)}
                       x2={px(node.x)} y2={py(node.y)}
-                      stroke="#94a3b8"
+                      stroke="#a8a29e"
                       strokeWidth={1.5}
                     />
                   );

--- a/client/src/module/student/learn/dsa-foundations/lessons/L7_RabinKarp.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L7_RabinKarp.tsx
@@ -215,7 +215,7 @@ function RKVisualization({ frame, text, pattern }: { frame: Frame; text: string;
       <div className="flex gap-4 flex-wrap justify-center">
         <HashBox label="Window hash" value={frame.windowHash} highlight={frame.highlightKey === "winHash"} color={THEME.accent} />
         <HashBox label="Pattern hash" value={frame.patternHash} highlight={frame.highlightKey === "patHash"} color="#8b5cf6" />
-        <HashBox label="Equal?" value={frame.windowHash === frame.patternHash ? "YES" : "no"} color={frame.windowHash === frame.patternHash ? THEME.success : "#64748b"} />
+        <HashBox label="Equal?" value={frame.windowHash === frame.patternHash ? "YES" : "no"} color={frame.windowHash === frame.patternHash ? THEME.success : "#78716c"} />
       </div>
       <div className="flex gap-2.5 text-xs">
         <span

--- a/client/src/module/student/learn/dsa-foundations/lessons/L8_DPStateDesign.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L8_DPStateDesign.tsx
@@ -276,7 +276,7 @@ function TSPVisualize() {
                                 key={i}
                                 className="py-0.5 px-1.5 text-center rounded transition-all"
                                 style={{
-                                  color: v === null ? "#cbd5e1" : isCell ? "#fff" : THEME.text,
+                                  color: v === null ? "#d6d3d1" : isCell ? "#fff" : THEME.text,
                                   background: isCell ? THEME.accent : "transparent",
                                   fontWeight: isCell ? 800 : 400,
                                 }}
@@ -448,7 +448,7 @@ function SpaceVisualize() {
                               width: 32, height: 32,
                               border: `1px solid ${THEME.border}`,
                               background: isHot ? THEME.accent : fromPrev ? `${THEME.accent}24` : THEME.bg,
-                              color: isHot ? "#fff" : v === null ? "#cbd5e1" : THEME.text,
+                              color: isHot ? "#fff" : v === null ? "#d6d3d1" : THEME.text,
                               fontWeight: isHot ? 800 : 500,
                             }}
                           >

--- a/client/src/module/student/learn/dsa-foundations/lessons/L8_GridToGraph.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L8_GridToGraph.tsx
@@ -170,7 +170,7 @@ function GridViz({
   function cellStyle(r: number, c: number): { bg: string; fg: string; border: string } {
     const kind = grid[r][c];
     const d = frame.dist[r][c];
-    if (kind === "wall") return { bg: "#334155", fg: "#fff", border: "#1e293b" };
+    if (kind === "wall") return { bg: "#44403C", fg: "#fff", border: "#292524" };
     if (kind === "source") return { bg: THEME.success, fg: "#fff", border: THEME.success };
     if (kind === "target") return { bg: THEME.danger, fg: "#fff", border: THEME.danger };
     if (pathSet.has(`${r},${c}`)) return { bg: "#fbbf24", fg: "#78350f", border: "#b45309" };
@@ -215,7 +215,7 @@ function GridViz({
       <div className="flex flex-wrap gap-3 justify-center">
         <LegendSwatch color={THEME.success} label="source" />
         <LegendSwatch color={THEME.danger} label="target" />
-        <LegendSwatch color="#334155" label="wall" />
+        <LegendSwatch color="#44403C" label="wall" />
         <LegendSwatch color="#06b6d4" label="frontier (queue)" />
         <LegendSwatch color="#3b82f6" label="current" />
         <LegendSwatch color="rgba(139,92,246,0.6)" label="visited (darker = closer)" />

--- a/client/src/module/student/learn/dsa-foundations/lessons/L8_MonotonicStack.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L8_MonotonicStack.tsx
@@ -37,7 +37,7 @@ type CellState = "default" | "active" | "compare" | "done" | "window" | "path";
 const STATE_COLOR: Record<CellState, { bg: string; fg: string; border: string }> = {
   default: { bg: THEME.bg, fg: THEME.textMuted, border: THEME.border },
   active:  { bg: THEME.accent, fg: "#fff", border: THEME.accentDark },
-  compare: { bg: "#c7d2fe", fg: "#3730a3", border: "#6366f1" },
+  compare: { bg: "#d9f99d", fg: "#3f6212", border: "#84cc16" },
   done:    { bg: "#dcfce7", fg: "#166534", border: "#16a34a" },
   window:  { bg: "#dbeafe", fg: "#1e40af", border: "#3b82f6" },
   path:    { bg: "#fef9c3", fg: "#713f12", border: "#ca8a04" },

--- a/client/src/module/student/learn/dsa-foundations/lessons/L8_PatternRecognition.tsx
+++ b/client/src/module/student/learn/dsa-foundations/lessons/L8_PatternRecognition.tsx
@@ -41,7 +41,7 @@ const PATTERNS: { id: Pattern; label: string; color: string; hint: string }[] = 
   { id: "greedy",         label: "Greedy",            color: "#fbbf24", hint: "local optimal choice proven to reach global optimum" },
   { id: "stack-queue",    label: "Stack / Queue",     color: "#ef4444", hint: "LIFO brackets / monotonic next-greater / BFS frontier" },
   { id: "hashing",        label: "Hashing",           color: "#ec4899", hint: "O(1) lookup, counting, de-duplication, 'seen' sets" },
-  { id: "divide-conquer", label: "Divide & Conquer",  color: "#64748b", hint: "split in halves, solve, combine (merge sort, majority element)" },
+  { id: "divide-conquer", label: "Divide & Conquer",  color: "#78716c", hint: "split in halves, solve, combine (merge sort, majority element)" },
 ];
 
 const PALETTE_IDS = new Set<Pattern>(PATTERNS.map((p) => p.id));


### PR DESCRIPTION
Closes #2812

## What changed

Migrated forbidden color tokens to the canonical **lime + stone** palette across the two scoped directories from the issue:

- `client/src/module/student/learn/computer-networks/**/_components/*.tsx`
- `client/src/module/student/learn/dsa-foundations/lessons/*.tsx`

The computer-networks animation components had no literal `slate-*`/`gray-*`/`indigo-*` Tailwind classes; the violations were the **hex codes** of those forbidden palettes used as chrome (canvas backgrounds, borders, grid dots, muted text, inactive-state fills). These were mapped shade-for-shade:

- `slate-*` hexes → `stone-*` hexes (e.g. `#0F172A` → `#1C1917`, `#334155` → `#44403C`, `#475569` → `#57534E`, `#94A3B8` → `#A8A29E`)
- `gray-*` hexes → `stone-*` hexes (`#1F2937` → `#292524`, `#9CA3AF` → `#A8A29E`)
- `indigo-*` accent hexes → `lime-*` hexes (`#818CF8` → `#A3E635`, `#6366F1` → `#84CC16`, `#3730A3` → `#3F6212`)
- Custom dark navy chrome (`#0A0F1A`, `#1E3A5F`) → stone equivalents
- One literal class migrated: `bg-gray-900` → `bg-stone-900` in `L7_AdvancedDS.tsx`

## Preserved (semantic teaching colors)

Colors that carry meaning were **kept untouched** per the issue's guidance: red/rose = lost packets/faults (`#EF4444`, `#F43F5E`), emerald = success/Data Link (`#10B981`, `#34D399`), blue = Network layer/server (`#2563EB`, `#3B82F6`), violet = Application layer (`#7C3AED`, `#8B5CF6`), amber/orange = warnings (`#F59E0B`, `#F97316`), plus existing lime/stone.

## Verification

- `tsc -b` passes
- `eslint` passes on both scoped directories
- No forbidden slate/gray/indigo hex or class tokens remain in the scoped files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Computer Networks visualizations with a warmer stone and brown color palette.
  * Refined DSA lesson visualizations with consistent stone-based colors and brighter lime highlights for active states.
  * Improved consistency across diagrams, controls, legends, indicators, and inactive states without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->