### PR TITLE
feat(admin): add page-size selection and jump-to-page to admin list pagination

### DIFF
--- a/client/src/components/ui/PaginationControls.tsx
+++ b/client/src/components/ui/PaginationControls.tsx
@@ -1,3 +1,4 @@
+import { useState, type FormEvent } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,8 +15,13 @@ interface PaginationControlsProps {
   onPageChange: (page: number) => void;
   maxVisiblePages?: number;
   showingInfo?: { total: number; limit: number };
+  pageSize?: number;
+  onPageSizeChange?: (size: number) => void;
+  pageSizeOptions?: number[];
   className?: string;
 }
+
+const DEFAULT_PAGE_SIZES = [10, 20, 50, 100];
 
 function getPageRange(
   current: number,
@@ -50,8 +56,13 @@ export function PaginationControls({
   onPageChange,
   maxVisiblePages = 5,
   showingInfo,
+  pageSize,
+  onPageSizeChange,
+  pageSizeOptions = DEFAULT_PAGE_SIZES,
   className,
 }: PaginationControlsProps) {
+  const [jumpInput, setJumpInput] = useState("");
+
   if (totalPages <= 1) return null;
 
   const pages = getPageRange(currentPage, totalPages, maxVisiblePages);
@@ -63,8 +74,21 @@ export function PaginationControls({
     ? Math.min(currentPage * showingInfo.limit, showingInfo.total)
     : 0;
 
+  const hasSizeSelect = typeof onPageSizeChange === "function" && typeof pageSize === "number";
+
+  const handleJumpSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const page = Number.parseInt(jumpInput, 10);
+    if (Number.isNaN(page) || page < 1 || page > totalPages) {
+      setJumpInput("");
+      return;
+    }
+    onPageChange(page);
+    setJumpInput("");
+  };
+
   return (
-    <div className={cn("flex flex-col items-center gap-2 mt-8", className)}>
+    <div className={cn("flex flex-col items-center gap-3 mt-8", className)}>
       <Pagination>
         <PaginationContent>
           <PaginationItem>
@@ -112,11 +136,50 @@ export function PaginationControls({
         </PaginationContent>
       </Pagination>
 
-      {showingInfo && (
-        <p className="text-xs text-muted-foreground">
-          Showing {showingStart}–{showingEnd} of {showingInfo.total}
-        </p>
-      )}
+      <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        {showingInfo && (
+          <span>
+            Showing {showingStart}–{showingEnd} of {showingInfo.total}
+          </span>
+        )}
+
+        {hasSizeSelect && (
+          <label className="flex items-center gap-1.5">
+            <span>Rows per page</span>
+            <select
+              value={pageSize}
+              onChange={(e) => onPageSizeChange(Number(e.target.value))}
+              className="h-7 rounded-md border border-input bg-background px-2 text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label="Rows per page"
+            >
+              {pageSizeOptions.map((size) => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <form onSubmit={handleJumpSubmit} className="flex items-center gap-1.5">
+          <span>Go to</span>
+          <input
+            type="number"
+            min={1}
+            max={totalPages}
+            value={jumpInput}
+            onChange={(e) => setJumpInput(e.target.value)}
+            className="h-7 w-12 rounded-md border border-input bg-background px-1 text-center text-xs text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Go to page"
+          />
+          <button
+            type="submit"
+            className="h-7 rounded-md border border-input bg-background px-2 text-xs text-foreground hover:bg-muted transition-colors"
+          >
+            Go
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/client/src/module/admin/AdminSubscribersPage.tsx
+++ b/client/src/module/admin/AdminSubscribersPage.tsx
@@ -18,7 +18,7 @@ export default function AdminSubscribersPage() {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
-  const limit = 50;
+  const [limit, setLimit] = useState(50);
 
   const fetchSubscribers = useCallback(() => {
     setLoading(true);
@@ -33,7 +33,7 @@ export default function AdminSubscribersPage() {
         toast.error("Failed to fetch subscribers");
       })
       .finally(() => setLoading(false));
-  }, [page]);
+  }, [page, limit]);
 
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { fetchSubscribers(); }, [fetchSubscribers]);
@@ -127,6 +127,12 @@ export default function AdminSubscribersPage() {
             currentPage={page}
             totalPages={totalPages}
             onPageChange={setPage}
+            showingInfo={{ total, limit }}
+            pageSize={limit}
+            onPageSizeChange={(size) => {
+              setLimit(size);
+              setPage(1);
+            }}
           />
         </>
       )}

--- a/client/src/module/admin/activity/ActivityLogsPage.tsx
+++ b/client/src/module/admin/activity/ActivityLogsPage.tsx
@@ -15,11 +15,12 @@ export default function ErrorLogsPage() {
   const [pathSearch, setPathSearch] = useState("");
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
+  const [limit, setLimit] = useState(20);
 
-  const fetchLogs = async (page = 1) => {
+  const fetchLogs = async (page = 1, size = limit) => {
     setLoading(true);
     try {
-      const params: Record<string, string | number> = { page, limit: 20 };
+      const params: Record<string, string | number> = { page, limit: size };
       if (statusGroup) params.statusGroup = statusGroup;
       if (method) params.method = method;
       if (pathSearch) params.path = pathSearch;
@@ -34,7 +35,7 @@ export default function ErrorLogsPage() {
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps, react-hooks/set-state-in-effect
-  useEffect(() => { fetchLogs(); }, [statusGroup, method]);
+  useEffect(() => { fetchLogs(); }, [statusGroup, method, limit]);
 
   useEffect(() => {
     const timeout = setTimeout(() => fetchLogs(), 400);
@@ -128,6 +129,8 @@ export default function ErrorLogsPage() {
           totalPages={pagination.totalPages}
           onPageChange={fetchLogs}
           showingInfo={{ total: pagination.total, limit: pagination.limit }}
+          pageSize={limit}
+          onPageSizeChange={(size) => setLimit(size)}
         />
       </div>
     </div>

--- a/client/src/module/admin/aptitude/AdminAptitudePage.tsx
+++ b/client/src/module/admin/aptitude/AdminAptitudePage.tsx
@@ -101,6 +101,7 @@ export default function AdminAptitudePage() {
   const [editingQ, setEditingQ] = useState<AptitudeQuestion | null>(null);
   const [qPage, setQPage] = useState(1);
   const [qTotal, setQTotal] = useState(0);
+  const [qLimit, setQLimit] = useState(20);
 
   const fetchCategories = useCallback(() => {
     setLoading(true);
@@ -118,11 +119,11 @@ export default function AdminAptitudePage() {
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { fetchCategories(); }, [fetchCategories]);
 
-  const fetchQuestions = useCallback((topicId: number, page: number = 1) => {
+  const fetchQuestions = useCallback((topicId: number, page: number = 1, size: number = qLimit) => {
     setQuestionsLoading(true);
     api
       .get("/admin/aptitude/questions", {
-        params: { topicId, page, limit: 20 },
+        params: { topicId, page, limit: size },
       })
       .then((res) => {
         setQuestions(res.data.questions);
@@ -131,7 +132,7 @@ export default function AdminAptitudePage() {
         setQuestionsLoading(false);
       })
       .catch(() => setQuestionsLoading(false));
-  }, []);
+  }, [qLimit]);
 
   // Category CRUD
   const handleSaveCategory = async () => {
@@ -568,8 +569,14 @@ export default function AdminAptitudePage() {
 
         <PaginationControls
           currentPage={qPage}
-          totalPages={Math.ceil(qTotal / 20)}
+          totalPages={Math.ceil(qTotal / qLimit)}
           onPageChange={(p) => fetchQuestions(selectedTopic.id, p)}
+          showingInfo={{ total: qTotal, limit: qLimit }}
+          pageSize={qLimit}
+          onPageSizeChange={(size) => {
+            setQLimit(size);
+            fetchQuestions(selectedTopic.id, 1, size);
+          }}
         />
       </div>
       </>

--- a/client/src/module/admin/companies/AdminCompaniesPage.tsx
+++ b/client/src/module/admin/companies/AdminCompaniesPage.tsx
@@ -13,11 +13,12 @@ export default function AdminCompaniesPage() {
   const [pagination, setPagination] = useState<Pagination | null>(null);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(20);
 
   const fetchCompanies = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await api.get("/admin/companies", { params: { page, limit: 20 } });
+      const res = await api.get("/admin/companies", { params: { page, limit } });
       setCompanies(res.data.companies);
       setPagination(res.data.pagination);
     } catch {
@@ -25,7 +26,7 @@ export default function AdminCompaniesPage() {
     } finally {
       setLoading(false);
     }
-  }, [page]);
+  }, [page, limit]);
 
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { fetchCompanies(); }, [fetchCompanies]);
@@ -127,6 +128,12 @@ export default function AdminCompaniesPage() {
           currentPage={page}
           totalPages={pagination.totalPages}
           onPageChange={setPage}
+          showingInfo={{ total: pagination.total, limit }}
+          pageSize={limit}
+          onPageSizeChange={(size) => {
+            setLimit(size);
+            setPage(1);
+          }}
         />
       )}
     </div>

--- a/client/src/module/admin/contributions/AdminContributionsPage.tsx
+++ b/client/src/module/admin/contributions/AdminContributionsPage.tsx
@@ -28,12 +28,13 @@ export default function AdminContributionsPage() {
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState("PENDING");
   const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(20);
   const [expandedId, setExpandedId] = useState<number | null>(null);
 
   const fetchContributions = async () => {
     setLoading(true);
     try {
-      const res = await api.get("/admin/contributions", { params: { status: statusFilter, page, limit: 20 } });
+      const res = await api.get("/admin/contributions", { params: { status: statusFilter, page, limit } });
       setContributions(res.data.contributions);
       setPagination(res.data.pagination);
     } catch {
@@ -46,7 +47,7 @@ export default function AdminContributionsPage() {
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setPage(1); }, [statusFilter]);
   // eslint-disable-next-line react-hooks/exhaustive-deps, react-hooks/set-state-in-effect
-  useEffect(() => { fetchContributions(); }, [statusFilter, page]);
+  useEffect(() => { fetchContributions(); }, [statusFilter, page, limit]);
 
   const handleStatus = async (id: number, status: "APPROVED" | "REJECTED") => {
     try {
@@ -147,6 +148,12 @@ export default function AdminContributionsPage() {
           currentPage={page}
           totalPages={pagination.totalPages}
           onPageChange={setPage}
+          showingInfo={{ total: pagination.total, limit }}
+          pageSize={limit}
+          onPageSizeChange={(size) => {
+            setLimit(size);
+            setPage(1);
+          }}
         />
       )}
     </div>

--- a/client/src/module/admin/external-jobs/AdminExternalJobsPage.tsx
+++ b/client/src/module/admin/external-jobs/AdminExternalJobsPage.tsx
@@ -28,6 +28,7 @@ const EMPTY_FORM = {
 export default function AdminExternalJobsPage() {
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(20);
   const [search, setSearch] = useState("");
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -65,9 +66,9 @@ export default function AdminExternalJobsPage() {
   }, []);
 
   const { data, isLoading } = useQuery({
-    queryKey: ["admin-external-jobs", page, search],
+    queryKey: ["admin-external-jobs", page, limit, search],
     queryFn: async () => {
-      const params = new URLSearchParams({ page: String(page), limit: "20" });
+      const params = new URLSearchParams({ page: String(page), limit: String(limit) });
       if (search) params.set("search", search);
       const res = await api.get(`/admin/external-jobs?${params}`);
       return res.data as { jobs: AdminJob[]; total: number; totalPages: number };
@@ -364,6 +365,12 @@ export default function AdminExternalJobsPage() {
           currentPage={page}
           totalPages={data.totalPages}
           onPageChange={setPage}
+          showingInfo={{ total: data.total, limit }}
+          pageSize={limit}
+          onPageSizeChange={(size) => {
+            setLimit(size);
+            setPage(1);
+          }}
         />
       )}
     </div>

--- a/client/src/module/admin/interviews/AdminInterviewsPage.tsx
+++ b/client/src/module/admin/interviews/AdminInterviewsPage.tsx
@@ -15,6 +15,7 @@ import { SEO } from "../../../components/SEO";
 import toast from "../../../components/ui/toast";
 import { queryKeys } from "../../../lib/query-keys";
 import api from "../../../lib/axios";
+import { PaginationControls } from "../../../components/ui/PaginationControls";
 import type { InterviewExperience, InterviewExperienceCompany, InterviewListResponse } from "../../../lib/types";
 import {
   deleteExperience,
@@ -32,6 +33,7 @@ export default function AdminInterviewsPage() {
   const qc = useQueryClient();
   const [status, setStatus] = useState<"PENDING" | "APPROVED" | "REJECTED">("PENDING");
   const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(20);
   const [search, setSearch] = useState("");
   const [preview, setPreview] = useState<InterviewExperience | null>(null);
   const [linkTarget, setLinkTarget] = useState<InterviewExperience | null>(null);
@@ -39,16 +41,16 @@ export default function AdminInterviewsPage() {
   const queryParams = useMemo(
     () => ({
       page,
-      limit: 20,
+      limit,
       status,
       search: search || undefined,
       sort: "recent" as const,
     }),
-    [page, status, search],
+    [page, limit, status, search],
   );
 
   const { data, isLoading } = useQuery<InterviewListResponse>({
-    queryKey: queryKeys.interviews.list({ admin: 1, status, page, search }),
+    queryKey: queryKeys.interviews.list({ admin: 1, status, page, limit, search }),
     queryFn: () => listExperiences(queryParams),
   });
 
@@ -276,27 +278,17 @@ export default function AdminInterviewsPage() {
         </div>
       </div>
 
-      {totalPages > 1 ? (
-        <div className="flex items-center justify-center gap-3 mb-10">
-          <button
-            disabled={page === 1}
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
-            className="px-3 py-1.5 rounded text-sm text-gray-300 bg-gray-800 disabled:opacity-40 hover:bg-gray-700 transition-colors"
-          >
-            Prev
-          </button>
-          <span className="text-sm text-gray-400">
-            {page} / {totalPages}
-          </span>
-          <button
-            disabled={page >= totalPages}
-            onClick={() => setPage((p) => p + 1)}
-            className="px-3 py-1.5 rounded text-sm text-gray-300 bg-gray-800 disabled:opacity-40 hover:bg-gray-700 transition-colors"
-          >
-            Next
-          </button>
-        </div>
-      ) : null}
+      <PaginationControls
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
+        showingInfo={{ total: data?.pagination.total ?? 0, limit }}
+        pageSize={limit}
+        onPageSizeChange={(size) => {
+          setLimit(size);
+          setPage(1);
+        }}
+      />
 
       {preview ? (
         <PreviewModal

--- a/client/src/module/admin/repo-requests/AdminRepoRequestsPage.tsx
+++ b/client/src/module/admin/repo-requests/AdminRepoRequestsPage.tsx
@@ -75,6 +75,7 @@ export default function AdminRepoRequestsPage() {
 const [domainFilter, setDomainFilter] = useState("");
 const [difficultyFilter, setDifficultyFilter] = useState("");
 const [page, setPage] = useState(1);
+const [limit, setLimit] = useState(20);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
 
   const fetchRequests = async () => {
@@ -86,7 +87,7 @@ const [page, setPage] = useState(1);
     domain: domainFilter,
     difficulty: difficultyFilter,
     page,
-    limit: 20,
+    limit,
   },
 });
       setRequests(res.data.requests);
@@ -105,7 +106,7 @@ const [page, setPage] = useState(1);
     // Selection is cleared when page or filters change because the list items change
     setSelectedIds([]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [statusFilter, domainFilter, difficultyFilter, page]);
+  }, [statusFilter, domainFilter, difficultyFilter, page, limit]);
 
   // Reset page to 1 when filters change
   const handleFilterChange = (setter: (v: string) => void, value: string) => {
@@ -270,6 +271,12 @@ const [page, setPage] = useState(1);
               currentPage={page}
               totalPages={pagination.totalPages}
               onPageChange={setPage}
+              showingInfo={{ total: pagination.total, limit }}
+              pageSize={limit}
+              onPageSizeChange={(size) => {
+                setLimit(size);
+                setPage(1);
+              }}
             />
           )}
         </div>

--- a/client/src/module/admin/reviews/AdminReviewsPage.tsx
+++ b/client/src/module/admin/reviews/AdminReviewsPage.tsx
@@ -14,11 +14,12 @@ export default function AdminReviewsPage() {
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState("PENDING");
   const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(20);
 
   const fetchReviews = async () => {
     setLoading(true);
     try {
-      const res = await api.get("/admin/reviews", { params: { status: statusFilter, page, limit: 20 } });
+      const res = await api.get("/admin/reviews", { params: { status: statusFilter, page, limit } });
       setReviews(res.data.reviews);
       setPagination(res.data.pagination);
     } catch {
@@ -31,7 +32,7 @@ export default function AdminReviewsPage() {
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setPage(1); }, [statusFilter]);
   // eslint-disable-next-line react-hooks/exhaustive-deps, react-hooks/set-state-in-effect
-  useEffect(() => { fetchReviews(); }, [statusFilter, page]);
+  useEffect(() => { fetchReviews(); }, [statusFilter, page, limit]);
 
   const handleStatus = async (id: number, status: "APPROVED" | "REJECTED") => {
     try {
@@ -126,6 +127,12 @@ export default function AdminReviewsPage() {
           currentPage={page}
           totalPages={pagination.totalPages}
           onPageChange={setPage}
+          showingInfo={{ total: pagination.total, limit }}
+          pageSize={limit}
+          onPageSizeChange={(size) => {
+            setLimit(size);
+            setPage(1);
+          }}
         />
       )}
     </div>

--- a/client/src/module/admin/signals/AdminSignalsPage.tsx
+++ b/client/src/module/admin/signals/AdminSignalsPage.tsx
@@ -14,6 +14,7 @@ import {
 import { SEO } from "../../../components/SEO";
 import toast from "../../../components/ui/toast";
 import { queryKeys } from "../../../lib/query-keys";
+import { PaginationControls } from "../../../components/ui/PaginationControls";
 import type { FundingSignal, FundingSignalListResponse } from "../../../lib/types";
 import {
   cleanupNoise,
@@ -114,6 +115,7 @@ function signalToForm(sig: FundingSignal): FormState {
 export default function AdminSignalsPage() {
   const qc = useQueryClient();
   const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(20);
   const [statusFilter, setStatusFilter] = useState<"ACTIVE" | "STALE" | "ARCHIVED" | "ALL">(
     "ACTIVE",
   );
@@ -126,12 +128,12 @@ export default function AdminSignalsPage() {
   const queryParams = useMemo(
     () => ({
       page,
-      limit: 20,
+      limit,
       status: statusFilter,
       source: sourceFilter || undefined,
       search: search || undefined,
     }),
-    [page, statusFilter, sourceFilter, search],
+    [page, limit, statusFilter, sourceFilter, search],
   );
 
   const { data, isLoading } = useQuery<FundingSignalListResponse>({
@@ -438,27 +440,17 @@ export default function AdminSignalsPage() {
       </div>
 
       {/* Pagination */}
-      {totalPages > 1 ? (
-        <div className="flex items-center justify-center gap-3 mb-10">
-          <button
-            disabled={page === 1}
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
-            className="px-3 py-1.5 rounded text-sm text-gray-300 bg-gray-800 disabled:opacity-40 hover:bg-gray-700 transition-colors"
-          >
-            Prev
-          </button>
-          <span className="text-sm text-gray-400">
-            {page} / {totalPages}
-          </span>
-          <button
-            disabled={page >= totalPages}
-            onClick={() => setPage((p) => p + 1)}
-            className="px-3 py-1.5 rounded text-sm text-gray-300 bg-gray-800 disabled:opacity-40 hover:bg-gray-700 transition-colors"
-          >
-            Next
-          </button>
-        </div>
-      ) : null}
+      <PaginationControls
+        currentPage={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
+        showingInfo={{ total: data?.pagination.total ?? 0, limit }}
+        pageSize={limit}
+        onPageSizeChange={(size) => {
+          setLimit(size);
+          setPage(1);
+        }}
+      />
 
       {/* Ingest logs */}
       <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">

--- a/client/src/module/admin/users/UsersListPage.tsx
+++ b/client/src/module/admin/users/UsersListPage.tsx
@@ -14,11 +14,12 @@ export default function UsersListPage() {
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState("");
   const [loading, setLoading] = useState(true);
+  const [limit, setLimit] = useState(20);
 
-  const fetchUsers = async (page = 1) => {
+  const fetchUsers = async (page = 1, size = limit) => {
     setLoading(true);
     try {
-      const params: Record<string, string | number> = { page, limit: 20 };
+      const params: Record<string, string | number> = { page, limit: size };
       if (search) params.search = search;
       if (roleFilter) params.role = roleFilter;
       const { data } = await api.get("/admin/users", { params });
@@ -32,7 +33,7 @@ export default function UsersListPage() {
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps, react-hooks/set-state-in-effect
-  useEffect(() => { fetchUsers(); }, [roleFilter]);
+  useEffect(() => { fetchUsers(); }, [roleFilter, limit]);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -168,6 +169,8 @@ export default function UsersListPage() {
           totalPages={pagination.totalPages}
           onPageChange={fetchUsers}
           showingInfo={{ total: pagination.total, limit: pagination.limit }}
+          pageSize={limit}
+          onPageSizeChange={(size) => setLimit(size)}
         />
       </div>
     </div>


### PR DESCRIPTION
Fixes #2848

## Summary
Adds a shared paginator with page-size selection, jump-to-page navigation, and result counts to admin list pages.

## Changes
- **`PaginationControls`** (shared component, backward compatible):
  - New optional props `pageSize`, `onPageSizeChange`, `pageSizeOptions` render a "Rows per page" selector.
  - Added a "Go to" jump-to-page input (bounds-clamped) alongside the existing prev/next + page-number nav.
  - Prev/next remain disabled at bounds; "Showing X–Y of Z" total count now renders in the same footer row.
- Wired page-size state (defaults preserved: 20, or 50 for subscribers) into 9 admin pages that already used the shared component:
  `UsersListPage`, `ActivityLogsPage`, `AdminCompaniesPage`, `AdminContributionsPage`, `AdminExternalJobsPage`, `AdminRepoRequestsPage`, `AdminReviewsPage`, `AdminSubscribersPage`, `AdminAptitudePage` (questions view).
- Replaced the ad-hoc Prev/Next inline paginators on `AdminInterviewsPage` and `AdminSignalsPage` with the shared component, so all admin list pages now have consistent controls, page-size selection, and total counts.

Changing page size resets to page 1 and refetches; all servers already accept a dynamic `limit` and return `total`/`totalPages`.

## Verification
- `tsc -b` passes.
- `eslint` passes on all modified files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rows-per-page selectors across administrative lists, including subscribers, users, companies, activity logs, interviews, reviews, signals, and other records.
  - Added page-number jump controls with validation.
  - Pagination now displays total results and adapts responsively.
  - Changing the page size refreshes results and returns to the first page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->