### PR TITLE
feat: add hiring insights section to company profile page

### DIFF
--- a/client/src/module/student/companies/CompanyDetailPage.tsx
+++ b/client/src/module/student/companies/CompanyDetailPage.tsx
@@ -21,7 +21,8 @@ import {
   Briefcase,
   ArrowUpRight,
   Download,
-} from "lucide-react"; 
+  TrendingUp,
+} from "lucide-react";
 import { LoadingScreen } from "../../../components/LoadingScreen";
 import api, { SERVER_URL } from "../../../lib/axios";
 import { useAuthStore } from "../../../lib/auth.store";
@@ -29,7 +30,10 @@ import { Navbar } from "../../../components/Navbar";
 import { Footer } from "../../../components/Footer";
 import { SEO } from "../../../components/SEO";
 import { canonicalUrl } from "../../../lib/seo.utils";
-import { organizationSchema, breadcrumbSchema } from "../../../lib/structured-data";
+import {
+  organizationSchema,
+  breadcrumbSchema,
+} from "../../../lib/structured-data";
 import type { Company, CompanyReview } from "../../../lib/types";
 import StarRating from "./StarRating";
 import ReviewCard from "./ReviewCard";
@@ -39,7 +43,6 @@ import InterviewExperienceSection from "./InterviewExperienceSection";
 import { GridBackground } from "../../../components/ui/GridBackground";
 import { Button } from "../../../components/ui/button";
 
-
 const SIZE_LABELS: Record<string, string> = {
   STARTUP: "Startup (1-10)",
   SMALL: "Small (11-50)",
@@ -48,37 +51,38 @@ const SIZE_LABELS: Record<string, string> = {
   ENTERPRISE: "Enterprise (1000+)",
 };
 
-
-
-
-
 const getSocialIcon = (platform: string) => {
   const p = platform.toLowerCase();
-  const cls = "w-4 h-4 text-stone-400 group-hover:text-lime-500 transition-colors";
+  const cls =
+    "w-4 h-4 text-stone-400 group-hover:text-lime-500 transition-colors";
 
-  if (p.includes("github")) return (
-    <svg className={cls} fill="currentColor" viewBox="0 0 24 24">
-      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.38.6.1.82-.26.82-.58v-2.03c-3.34.72-4.04-1.6-4.04-1.6-.55-1.38-1.33-1.75-1.33-1.75-1.08-.74.08-.72.08-.72 1.2.08 1.83 1.23 1.83 1.23 1.07 1.83 2.8 1.3 3.48 1 .1-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.14-.3-.54-1.52.1-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 3-.4c1.02 0 2.04.13 3 .4 2.28-1.55 3.28-1.23 3.28-1.23.65 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.8 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58C20.56 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z"/>
-    </svg>
-  );
+  if (p.includes("github"))
+    return (
+      <svg className={cls} fill="currentColor" viewBox="0 0 24 24">
+        <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.38.6.1.82-.26.82-.58v-2.03c-3.34.72-4.04-1.6-4.04-1.6-.55-1.38-1.33-1.75-1.33-1.75-1.08-.74.08-.72.08-.72 1.2.08 1.83 1.23 1.83 1.23 1.07 1.83 2.8 1.3 3.48 1 .1-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.14-.3-.54-1.52.1-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 3-.4c1.02 0 2.04.13 3 .4 2.28-1.55 3.28-1.23 3.28-1.23.65 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.8 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58C20.56 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z" />
+      </svg>
+    );
 
-  if (p.includes("dribbble")) return (
-    <svg className={cls} fill="currentColor" viewBox="0 0 24 24">
-      <path d="M12 0C5.37 0 0 5.37 0 12s5.37 12 12 12 12-5.37 12-12S18.63 0 12 0zm7.97 5.54a10.17 10.17 0 0 1 2.3 6.35c-.33-.07-3.67-.75-7.02-.32-.08-.18-.15-.37-.23-.55-.22-.52-.46-1.04-.7-1.54 3.7-1.51 5.38-3.68 5.65-3.94zM12 1.8a10.17 10.17 0 0 1 6.84 2.64c-.24.23-1.73 2.27-5.3 3.6A45.6 45.6 0 0 0 9.6 2.13 10.23 10.23 0 0 1 12 1.8zm-2.38.37a43.7 43.7 0 0 1 3.9 5.76c-4.9 1.3-9.23 1.28-9.68 1.27A10.21 10.21 0 0 1 9.62 2.17zM1.8 12.02v-.26c.43.01 5.5.08 10.73-1.49.3.58.58 1.17.84 1.77l-.4.11c-5.4 1.75-8.27 6.52-8.52 6.96A10.18 10.18 0 0 1 1.8 12zm10.2 10.2a10.17 10.17 0 0 1-6.27-2.14c.2-.43 2.56-4.96 8.52-7.03l.07-.02a36.8 36.8 0 0 1 1.9 6.73 10.18 10.18 0 0 1-4.22 2.46zm5.94-1.64a38.5 38.5 0 0 0-1.77-6.28c2.9-.46 5.45.3 5.76.39a10.21 10.21 0 0 1-4 5.89z"/>
-    </svg>
-  );
+  if (p.includes("dribbble"))
+    return (
+      <svg className={cls} fill="currentColor" viewBox="0 0 24 24">
+        <path d="M12 0C5.37 0 0 5.37 0 12s5.37 12 12 12 12-5.37 12-12S18.63 0 12 0zm7.97 5.54a10.17 10.17 0 0 1 2.3 6.35c-.33-.07-3.67-.75-7.02-.32-.08-.18-.15-.37-.23-.55-.22-.52-.46-1.04-.7-1.54 3.7-1.51 5.38-3.68 5.65-3.94zM12 1.8a10.17 10.17 0 0 1 6.84 2.64c-.24.23-1.73 2.27-5.3 3.6A45.6 45.6 0 0 0 9.6 2.13 10.23 10.23 0 0 1 12 1.8zm-2.38.37a43.7 43.7 0 0 1 3.9 5.76c-4.9 1.3-9.23 1.28-9.68 1.27A10.21 10.21 0 0 1 9.62 2.17zM1.8 12.02v-.26c.43.01 5.5.08 10.73-1.49.3.58.58 1.17.84 1.77l-.4.11c-5.4 1.75-8.27 6.52-8.52 6.96A10.18 10.18 0 0 1 1.8 12zm10.2 10.2a10.17 10.17 0 0 1-6.27-2.14c.2-.43 2.56-4.96 8.52-7.03l.07-.02a36.8 36.8 0 0 1 1.9 6.73 10.18 10.18 0 0 1-4.22 2.46zm5.94-1.64a38.5 38.5 0 0 0-1.77-6.28c2.9-.46 5.45.3 5.76.39a10.21 10.21 0 0 1-4 5.89z" />
+      </svg>
+    );
 
-  if (p.includes("linkedin")) return (
-    <svg className={cls} fill="currentColor" viewBox="0 0 24 24">
-      <path d="M20.45 20.45h-3.56v-5.57c0-1.33-.03-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.35V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.07 2.07 0 1 1 0-4.14 2.07 2.07 0 0 1 0 4.14zM7.12 20.45H3.55V9h3.57v11.45zM22.23 0H1.77C.79 0 0 .77 0 1.72v20.56C0 23.23.79 24 1.77 24h20.46c.98 0 1.77-.77 1.77-1.72V1.72C24 .77 23.21 0 22.23 0z"/>
-    </svg>
-  );
+  if (p.includes("linkedin"))
+    return (
+      <svg className={cls} fill="currentColor" viewBox="0 0 24 24">
+        <path d="M20.45 20.45h-3.56v-5.57c0-1.33-.03-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.35V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.07 2.07 0 1 1 0-4.14 2.07 2.07 0 0 1 0 4.14zM7.12 20.45H3.55V9h3.57v11.45zM22.23 0H1.77C.79 0 0 .77 0 1.72v20.56C0 23.23.79 24 1.77 24h20.46c.98 0 1.77-.77 1.77-1.72V1.72C24 .77 23.21 0 22.23 0z" />
+      </svg>
+    );
 
-  if (p.includes("twitter") || p.includes("x")) return (
-    <svg className={cls} fill="currentColor" viewBox="0 0 24 24">
-      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.91-5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-    </svg>
-  );
+  if (p.includes("twitter") || p.includes("x"))
+    return (
+      <svg className={cls} fill="currentColor" viewBox="0 0 24 24">
+        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.91-5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+      </svg>
+    );
 
   return <Globe className={cls} />;
 };
@@ -105,13 +109,11 @@ export default function CompanyDetailPage() {
   const [isExporting, setIsExporting] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
-
-
-  const { 
-    data: company, 
+  const {
+    data: company,
     isLoading: companyLoading,
     isError: companyIsError,
-    error: companyError 
+    error: companyError,
   } = useQuery<Company>({
     queryKey: queryKeys.companies.detail(slug!),
     queryFn: () => api.get(`/companies/${slug}`).then((r) => r.data.company),
@@ -127,7 +129,8 @@ export default function CompanyDetailPage() {
     refetch: refetchReviews,
   } = useQuery<{ reviews: CompanyReview[] }>({
     queryKey: [...queryKeys.companies.reviews(slug!), sortBy],
-    queryFn: () => api.get(`/companies/${slug}/reviews?sort=${sortBy}`).then((r) => r.data),
+    queryFn: () =>
+      api.get(`/companies/${slug}/reviews?sort=${sortBy}`).then((r) => r.data),
     enabled: !!slug,
     placeholderData: keepPreviousData,
     staleTime: 5 * 60 * 1000,
@@ -144,14 +147,17 @@ export default function CompanyDetailPage() {
   const handleExportPdf = useReactToPrint({
     contentRef: contentRef as React.RefObject<HTMLDivElement>,
     documentTitle: `${company?.name || "Company"}_Profile`,
-    onBeforePrint: () => { setIsExporting(true); return Promise.resolve(); },
+    onBeforePrint: () => {
+      setIsExporting(true);
+      return Promise.resolve();
+    },
     onAfterPrint: () => setIsExporting(false),
     onPrintError: (errorType: "onBeforePrint" | "print", error: Error) => {
       console.error("Failed to generate PDF:", error);
       const err = error as { message?: string } | null;
       alert("Failed to generate PDF: " + (err?.message || String(errorType)));
       setIsExporting(false);
-    }
+    },
   });
 
   const backPath = isInsideLayout ? "/student/companies" : "/companies";
@@ -167,9 +173,23 @@ export default function CompanyDetailPage() {
 
   if (companyIsError || reviewsIsError) {
     const errorMsg = companyIsError
-      ? (companyError as { response?: { data?: { message?: string } }; message?: string })?.response?.data?.message || companyError?.message || "Failed to load company"
-      : (reviewsError as { response?: { data?: { message?: string } }; message?: string })?.response?.data?.message || reviewsError?.message || "Failed to load reviews";
-      
+      ? (
+          companyError as {
+            response?: { data?: { message?: string } };
+            message?: string;
+          }
+        )?.response?.data?.message ||
+        companyError?.message ||
+        "Failed to load company"
+      : (
+          reviewsError as {
+            response?: { data?: { message?: string } };
+            message?: string;
+          }
+        )?.response?.data?.message ||
+        reviewsError?.message ||
+        "Failed to load reviews";
+
     const errorContent = (
       <div className="max-w-6xl mx-auto px-6 pt-24 text-center">
         <Kicker>error / api</Kicker>
@@ -185,7 +205,7 @@ export default function CompanyDetailPage() {
         </Link>
       </div>
     );
-    
+
     if (isInsideLayout) return errorContent;
     return (
       <div className="min-h-screen bg-stone-50 dark:bg-stone-950">
@@ -228,10 +248,14 @@ export default function CompanyDetailPage() {
     <div className="min-h-screen bg-stone-50 dark:bg-stone-950 relative">
       <GridBackground />
 
-
-      <div className={`relative max-w-6xl mx-auto px-6 pb-16 ${isInsideLayout ? "" : "pt-24"}`}>
+      <div
+        className={`relative max-w-6xl mx-auto px-6 pb-16 ${isInsideLayout ? "" : "pt-24"}`}
+      >
         {/* Back link */}
-        <motion.div initial={{ opacity: 0, x: -10 }} animate={{ opacity: 1, x: 0 }}>
+        <motion.div
+          initial={{ opacity: 0, x: -10 }}
+          animate={{ opacity: 1, x: 0 }}
+        >
           <Link
             to={backPath}
             className="inline-flex items-center gap-1.5 text-xs font-mono uppercase tracking-widest text-stone-500 hover:text-stone-900 dark:hover:text-stone-50 mb-8 no-underline transition-colors mt-6"
@@ -240,7 +264,14 @@ export default function CompanyDetailPage() {
           </Link>
         </motion.div>
 
-        <motion.div ref={contentRef} id="company-profile-content" variants={stagger} initial="hidden" animate="show" className="space-y-10">
+        <motion.div
+          ref={contentRef}
+          id="company-profile-content"
+          variants={stagger}
+          initial="hidden"
+          animate="show"
+          className="space-y-10"
+        >
           {/* Header */}
           <motion.div variants={fadeUp}>
             <Kicker>company / profile</Kicker>
@@ -282,8 +313,8 @@ export default function CompanyDetailPage() {
                   </span>
                   {company.foundedYear && (
                     <span className="flex items-center gap-1.5">
-                      <Calendar className="w-3.5 h-3.5 text-stone-400" /> Founded{" "}
-                      {company.foundedYear}
+                      <Calendar className="w-3.5 h-3.5 text-stone-400" />{" "}
+                      Founded {company.foundedYear}
                     </span>
                   )}
                 </div>
@@ -291,12 +322,18 @@ export default function CompanyDetailPage() {
                 {/* Rating + CTA */}
                 <div className="mt-5 flex flex-col sm:flex-row sm:items-center gap-4">
                   <div className="flex items-center gap-2">
-                    <StarRating rating={Math.round(company.avgRating)} size="sm" />
+                    <StarRating
+                      rating={Math.round(company.avgRating)}
+                      size="sm"
+                    />
                     <span className="text-sm font-bold text-stone-900 dark:text-stone-50 tabular-nums">
-                      {company.avgRating > 0 ? company.avgRating.toFixed(1) : "—"}
+                      {company.avgRating > 0
+                        ? company.avgRating.toFixed(1)
+                        : "—"}
                     </span>
                     <span className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
-                      {company.reviewCount} review{company.reviewCount === 1 ? "" : "s"}
+                      {company.reviewCount} review
+                      {company.reviewCount === 1 ? "" : "s"}
                     </span>
                   </div>
 
@@ -381,7 +418,11 @@ export default function CompanyDetailPage() {
                     {company.photos.map((photo, i) => (
                       <img
                         key={i}
-                        src={photo.startsWith("http") ? photo : `${SERVER_URL}${photo}`}
+                        src={
+                          photo.startsWith("http")
+                            ? photo
+                            : `${SERVER_URL}${photo}`
+                        }
                         alt=""
                         className="w-full h-40 object-cover rounded-md border border-stone-200 dark:border-white/10"
                       />
@@ -395,7 +436,9 @@ export default function CompanyDetailPage() {
                 <InterviewExperienceSection
                   slug={slug ?? ""}
                   companyName={company.name}
-                  canContribute={Boolean(isAuthenticated && user?.role === "STUDENT")}
+                  canContribute={Boolean(
+                    isAuthenticated && user?.role === "STUDENT",
+                  )}
                   isInsideLayout={isInsideLayout}
                 />
               </motion.div>
@@ -510,7 +553,9 @@ export default function CompanyDetailPage() {
                       Rating
                     </dt>
                     <dd className="text-stone-900 dark:text-stone-50 text-right tabular-nums">
-                      {company.avgRating > 0 ? company.avgRating.toFixed(1) : "—"}
+                      {company.avgRating > 0
+                        ? company.avgRating.toFixed(1)
+                        : "—"}
                       <span className="text-stone-500 ml-1">/ 5</span>
                     </dd>
                   </div>
@@ -525,46 +570,101 @@ export default function CompanyDetailPage() {
                 </dl>
               </motion.div>
 
-            
-{/* Links */}
-{hasLinks && (
-  <motion.div
-    variants={fadeUp}
-    className="bg-white dark:bg-stone-900 rounded-md border border-stone-200 dark:border-white/10 p-6"
-  >
-    <Kicker>links</Kicker>
+              {/* Hiring Insights */}
+              <motion.div
+                variants={fadeUp}
+                className="bg-white dark:bg-stone-900 rounded-md border border-stone-200 dark:border-white/10 p-6"
+              >
+                <Kicker>hiring / insights</Kicker>
+                <dl className="mt-4 space-y-3 text-sm">
+                  <div className="flex items-start justify-between gap-3">
+                    <dt className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
+                      Status
+                    </dt>
+                    <dd className="text-stone-900 dark:text-stone-50 text-right flex items-center gap-1.5">
+                      <TrendingUp className="w-3.5 h-3.5 text-lime-500" />
+                      {company.hiringStatus
+                        ? "Actively hiring"
+                        : "Not specified"}
+                    </dd>
+                  </div>
+                  <div className="flex items-start justify-between gap-3">
+                    <dt className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
+                      Team size
+                    </dt>
+                    <dd className="text-stone-900 dark:text-stone-50 text-right">
+                      {SIZE_LABELS[company.size] ?? company.size}
+                    </dd>
+                  </div>
+                  {company.technologies.length > 0 && (
+                    <div className="flex items-start justify-between gap-3">
+                      <dt className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
+                        Tech stack
+                      </dt>
+                      <dd className="text-stone-900 dark:text-stone-50 text-right">
+                        {company.technologies.length} tool
+                        {company.technologies.length === 1 ? "" : "s"}
+                      </dd>
+                    </div>
+                  )}
+                  <div className="flex items-start justify-between gap-3">
+                    <dt className="text-[10px] font-mono uppercase tracking-widest text-stone-500">
+                      Community sentiment
+                    </dt>
+                    <dd className="text-stone-900 dark:text-stone-50 text-right">
+                      {company.avgRating >= 4
+                        ? "Highly rated"
+                        : company.avgRating >= 3
+                          ? "Mixed"
+                          : company.reviewCount > 0
+                            ? "Below average"
+                            : "No data yet"}
+                    </dd>
+                  </div>
+                </dl>
+                <p className="mt-4 text-[10px] font-mono uppercase tracking-widest text-stone-400">
+                  Live job listings coming soon
+                </p>
+              </motion.div>
 
-    <div className="mt-4 space-y-2">
-      {company.website && (
-        <a
-          href={company.website}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="group flex items-center gap-3 px-3 py-2.5 rounded-md border border-stone-200 dark:border-white/10 text-sm text-stone-700 dark:text-stone-300 hover:border-stone-400 dark:hover:border-white/30 no-underline transition-colors"
-        >
-          <Globe className="w-4 h-4 text-stone-400 group-hover:text-lime-500 transition-colors" />
-          <span className="flex-1">Website</span>
-          <ExternalLink className="w-3.5 h-3.5 text-stone-400" />
-        </a>
-      )}
+              {/* Links */}
+              {hasLinks && (
+                <motion.div
+                  variants={fadeUp}
+                  className="bg-white dark:bg-stone-900 rounded-md border border-stone-200 dark:border-white/10 p-6"
+                >
+                  <Kicker>links</Kicker>
 
-      {Object.entries(socialLinks).map(([platform, url]) => (
-        <a
-          key={platform}
-          href={url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="group flex items-center gap-3 px-3 py-2.5 rounded-md border border-stone-200 dark:border-white/10 text-sm text-stone-700 dark:text-stone-300 hover:border-stone-400 dark:hover:border-white/30 no-underline capitalize transition-colors"
-        >
-          {getSocialIcon(platform)}
-          <span className="flex-1">{platform}</span>
-          <ExternalLink className="w-3.5 h-3.5 text-stone-400" />
-        </a>
-      ))}
-    </div>
-  </motion.div>
-)}
+                  <div className="mt-4 space-y-2">
+                    {company.website && (
+                      <a
+                        href={company.website}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group flex items-center gap-3 px-3 py-2.5 rounded-md border border-stone-200 dark:border-white/10 text-sm text-stone-700 dark:text-stone-300 hover:border-stone-400 dark:hover:border-white/30 no-underline transition-colors"
+                      >
+                        <Globe className="w-4 h-4 text-stone-400 group-hover:text-lime-500 transition-colors" />
+                        <span className="flex-1">Website</span>
+                        <ExternalLink className="w-3.5 h-3.5 text-stone-400" />
+                      </a>
+                    )}
 
+                    {Object.entries(socialLinks).map(([platform, url]) => (
+                      <a
+                        key={platform}
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group flex items-center gap-3 px-3 py-2.5 rounded-md border border-stone-200 dark:border-white/10 text-sm text-stone-700 dark:text-stone-300 hover:border-stone-400 dark:hover:border-white/30 no-underline capitalize transition-colors"
+                      >
+                        {getSocialIcon(platform)}
+                        <span className="flex-1">{platform}</span>
+                        <ExternalLink className="w-3.5 h-3.5 text-stone-400" />
+                      </a>
+                    ))}
+                  </div>
+                </motion.div>
+              )}
 
               {/* Key People */}
               {company.contacts && company.contacts.length > 0 && (
@@ -592,7 +692,9 @@ export default function CompanyDetailPage() {
                             )}
                           </div>
                         </div>
-                        {(contact.email || contact.phone || contact.linkedinUrl) && (
+                        {(contact.email ||
+                          contact.phone ||
+                          contact.linkedinUrl) && (
                           <div className="mt-3 pl-12 space-y-1.5">
                             {contact.email && (
                               <a
@@ -600,12 +702,15 @@ export default function CompanyDetailPage() {
                                 className="flex items-center gap-1.5 text-xs text-stone-600 dark:text-stone-400 hover:text-lime-600 dark:hover:text-lime-400 no-underline transition-colors truncate"
                               >
                                 <Mail className="w-3 h-3 shrink-0" />
-                                <span className="truncate">{contact.email}</span>
+                                <span className="truncate">
+                                  {contact.email}
+                                </span>
                               </a>
                             )}
                             {contact.phone && (
                               <p className="flex items-center gap-1.5 text-xs text-stone-600 dark:text-stone-400">
-                                <Phone className="w-3 h-3 shrink-0" /> {contact.phone}
+                                <Phone className="w-3 h-3 shrink-0" />{" "}
+                                {contact.phone}
                               </p>
                             )}
                             {contact.linkedinUrl && (
@@ -635,7 +740,8 @@ export default function CompanyDetailPage() {
                 >
                   <Kicker>contribute</Kicker>
                   <p className="mt-3 text-xs text-stone-500 leading-relaxed">
-                    Help keep this profile accurate. Every edit and contact earns contributor points.
+                    Help keep this profile accurate. Every edit and contact
+                    earns contributor points.
                   </p>
                   <div className="mt-4 space-y-2">
                     <button
@@ -659,10 +765,18 @@ export default function CompanyDetailPage() {
 
       {/* Modals */}
       {showReviewForm && slug && (
-        <ReviewForm slug={slug} onClose={() => setShowReviewForm(false)} onSubmitted={refreshReviews} />
+        <ReviewForm
+          slug={slug}
+          onClose={() => setShowReviewForm(false)}
+          onSubmitted={refreshReviews}
+        />
       )}
       {showEditModal && slug && (
-        <SuggestEditModal slug={slug} company={company} onClose={() => setShowEditModal(false)} />
+        <SuggestEditModal
+          slug={slug}
+          company={company}
+          onClose={() => setShowEditModal(false)}
+        />
       )}
     </div>
   );
@@ -695,7 +809,10 @@ export default function CompanyDetailPage() {
           }),
           breadcrumbSchema([
             { name: "Companies", url: canonicalUrl("/companies") },
-            { name: company.name, url: canonicalUrl(`/companies/${company.slug}`) },
+            {
+              name: company.name,
+              url: canonicalUrl(`/companies/${company.slug}`),
+            },
           ]),
         ]}
       />


### PR DESCRIPTION
## Description
Adds a "Hiring Insights" section to the company profile page, surfacing hiring status, team size, tech stack size, and community sentiment (derived from existing review data) alongside the existing overview/industry/website/logo info.

Note: this repo's job listings module (backend routes, controller, and Prisma model) has been removed in a recent upstream sync, so "active openings" and "hiring history" from the original issue currently have no underlying data source. Flagging this here rather than fabricating placeholder data — happy to revisit once/if job listings return.

## Related Issue
Fixes #2793

## Type of Change
- [x] Feature

## Testing
- `npx tsc --noEmit` — no type errors
- Verified diff scoped to a single file (`CompanyDetailPage.tsx`), no unrelated changes
## Checklist
- [x] Code follows project guidelines
- [x] No new compile/type errors
- [ ] Tested manually (include steps above)
- [x] No `.env`, credentials, or `node_modules` committed
- [ ] Docs updated (if needed)
- [ ] Screenshot or video attached for every UI change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hiring insights to company profiles, including hiring status, team size, technology count, and community sentiment.
  * Added social links with icons for GitHub, Dribbble, LinkedIn, and Twitter/X.
  * Added a “Live job listings coming soon” notice.

* **Improvements**
  * Refined company detail page formatting and interaction handling without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->